### PR TITLE
fix(routing): the command probe carries WORK SIZE, not just duration

### DIFF
--- a/core/continuum-core/src/routing/command_handler.rs
+++ b/core/continuum-core/src/routing/command_handler.rs
@@ -547,9 +547,23 @@ impl ConsumerAdapter for CommandRequestHandler {
         // path-agnostic (it dispatches ANY command), so it must not special-case
         // `ai/generate`'s payload shape to reach a `usage` field. Bytes are a coarse
         // proxy that stays correct for every path, including ones not written yet.
-        let params_bytes = serde_json::to_vec(&parsed.request.params)
-            .map(|v| v.len() as u64)
-            .unwrap_or(0); // unwrap_or: the params ALREADY deserialized to get here, so re-serialization failing is not a real branch; 0 reads as "unmeasured", never as "empty request"
+        //
+        // COST GATE. The probe system's contract is a Noop default at ZERO hot-path
+        // cost, and this handler is the front door for EVERY cross-grid command, not
+        // just generations. Measuring by re-serializing is not free — the params are
+        // the largest thing in the request (a 10k-token prompt gets re-encoded purely
+        // to be measured, then dropped). `tracing::enabled!` is the same question the
+        // probe itself asks, so with no sink listening this costs a level check and
+        // nothing else. Raised in review of #3816 by the IntelMac: "we added a probe
+        // and the accept path got slower" is a bad way to learn this.
+        let measure = tracing::enabled!(tracing::Level::INFO);
+        let params_bytes = if measure {
+            serde_json::to_vec(&parsed.request.params)
+                .map(|v| v.len() as u64)
+                .unwrap_or(0) // unwrap_or: the params ALREADY deserialized to get here, so re-serialization failing is not a real branch; 0 reads as "unmeasured", never as "empty request"
+        } else {
+            0
+        };
         let response = self.process_request(&parsed).await;
         // Carry the refusal TEXT, not just the fact of refusal. `outcome=error`
         // with elapsed_ms=0 says a gate declined before any work happened but not
@@ -565,7 +579,11 @@ impl ConsumerAdapter for CommandRequestHandler {
             AircCommandResponse::Ok { result } => (
                 "ok",
                 String::new(),
-                serde_json::to_vec(result).map(|v| v.len() as u64).unwrap_or(0), // unwrap_or: the value came FROM serde and is about to be sent; 0 means unmeasured
+                if measure {
+                    serde_json::to_vec(result).map(|v| v.len() as u64).unwrap_or(0) // unwrap_or: the value came FROM serde and is about to be sent; 0 means unmeasured
+                } else {
+                    0
+                },
             ),
         };
         crate::probe!(

--- a/core/continuum-core/src/routing/command_handler.rs
+++ b/core/continuum-core/src/routing/command_handler.rs
@@ -534,17 +534,39 @@ impl ConsumerAdapter for CommandRequestHandler {
             "peer command request ACCEPTED — this node answers it"
         );
         let started = std::time::Instant::now();
+        // WORK SIZE, or elapsed_ms is uninterpretable. Measured 2026-09-06: nine
+        // successful cross-grid generations split cleanly bimodal — two at ~32s, six
+        // at 135-292s, nothing between — and the probe could not say whether the slow
+        // mode did MORE WORK or was merely slower, because it recorded duration and
+        // not size. I checked contention (concurrent local inferences per run) and it
+        // was REFUTED: the two fastest runs carried the HIGHEST concurrent load. With
+        // no size field there was no next hypothesis to test. A stopwatch with no
+        // odometer measures something, but it cannot explain anything.
+        //
+        // Serialized byte counts rather than tokens on purpose: this handler is
+        // path-agnostic (it dispatches ANY command), so it must not special-case
+        // `ai/generate`'s payload shape to reach a `usage` field. Bytes are a coarse
+        // proxy that stays correct for every path, including ones not written yet.
+        let params_bytes = serde_json::to_vec(&parsed.request.params)
+            .map(|v| v.len() as u64)
+            .unwrap_or(0); // unwrap_or: the params ALREADY deserialized to get here, so re-serialization failing is not a real branch; 0 reads as "unmeasured", never as "empty request"
         let response = self.process_request(&parsed).await;
         // Carry the refusal TEXT, not just the fact of refusal. `outcome=error`
         // with elapsed_ms=0 says a gate declined before any work happened but not
         // WHICH gate — and the message is the whole diagnosis (kind/env refusal vs
         // the AuthPolicy verdict vs an unknown path). Truncated: a gate string is
         // a sentence, and an unbounded field in a hot probe is a log-flood risk.
-        let (outcome, detail) = match &response {
-            AircCommandResponse::Error { message } => {
-                ("error", message.chars().take(400).collect::<String>())
-            }
-            _ => ("ok", String::new()),
+        let (outcome, detail, result_bytes) = match &response {
+            AircCommandResponse::Error { message } => (
+                "error",
+                message.chars().take(400).collect::<String>(),
+                0u64,
+            ),
+            AircCommandResponse::Ok { result } => (
+                "ok",
+                String::new(),
+                serde_json::to_vec(result).map(|v| v.len() as u64).unwrap_or(0), // unwrap_or: the value came FROM serde and is about to be sent; 0 means unmeasured
+            ),
         };
         crate::probe!(
             class = "airc.command.completed",
@@ -554,6 +576,8 @@ impl ConsumerAdapter for CommandRequestHandler {
             correlation = %parsed.correlation_id,
             outcome = %outcome,
             detail = %detail,
+            params_bytes = params_bytes,
+            result_bytes = result_bytes,
             elapsed_ms = started.elapsed().as_millis() as u64,
             "peer command request answered"
         );


### PR DESCRIPTION
`airc.command.completed` (added earlier tonight in #3813) recorded `elapsed_ms` and nothing about how much work produced it. **Duration without size is uninterpretable**, and it dead-ended a real investigation a few hours later.

## What happened

Nine successful cross-grid `ai/generate` runs on the 5090 split cleanly bimodal:

```
242,669 / 292,239 / 134,897 / 190,750 / 189,817 / 175,971 / 140,632 ms   (slow mode)
 31,964 /  31,609 ms                                                      (fast mode)
```

Two clean modes, a 5.5× gap, nothing in between. The obvious hypothesis was queue contention, so I tested it — counting concurrent local `inference.prefill.complete` rows inside each run's own execution window:

```
finished   elapsed_ms   concurrent local inferences during the run
00:22:26     189,817    n=1   (0.3/min)
00:08:58     242,669    n=3   (0.7/min)
00:13:50     292,239    n=4   (0.8/min)
00:25:54      31,964    n=1   (1.9/min)   <-- FASTEST
00:26:25      31,609    n=1   (1.9/min)   <-- FASTEST
```

**Refuted.** The two fastest runs carried the *highest* concurrent load; the slowest ran at 0.3–0.8/min. The opposite of the prediction.

With contention dead, the next hypothesis is work size — and the probe could not answer it. There was no field. The investigation stopped at "unknown" rather than at an answer, and I had to retract a causal story I'd already given a collaborator.

## The change

Adds `params_bytes` (request params, serialized) and `result_bytes` (Ok payload, serialized) to `airc.command.completed`.

**Bytes rather than tokens, deliberately.** This handler is path-agnostic — it dispatches *any* command — so it must not special-case `ai/generate`'s payload shape to reach a `usage` field. Bytes are a coarse proxy that stays correct for every path, including ones not written yet. A per-path token count is worth having, but it belongs to that path's own probe, not to the generic dispatcher.

Both `unwrap_or(0)`s are justified inline: re-serializing a value that already came *from* serde is not a real failure branch, and `0` reads as "unmeasured" rather than "empty request".

## Why it's worth a PR on its own

The generalisable form: **a timing probe without a size field can detect that something is slow but can never say why.** It supports exactly one hypothesis — "it's slow" — and dies at the first follow-up question. This is the same shape as the accept-path blindness #3813 fixed, one level up: there I instrumented *that* something happened; here I'd failed to instrument *how much*.

What this makes answerable in one query rather than a night: **is the slow mode doing more work, or the same work slower?**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc