### PR TITLE
docs(readme): keeping the core alive is a documented step, and the hint matches it

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,29 @@ continuum reboot          # after editing: rebuild, relaunch, VERIFY the running
 continuum ping            # is the core answering?
 ```
 
+**Keep the core alive across logout and reboot.** A core started from a shell is a CHILD of
+that shell: close the terminal, log out, or end an agent session and it dies with it (on
+Windows it inherits the session's job object, which kills it outright). `install-service.sh`
+registers it with the OS supervisor instead — LaunchAgent on macOS, systemd on Linux,
+Scheduled Task on Windows — so it survives a crash and comes back after a reboot, while
+still honouring an explicit `continuum stop`.
+
+```bash
+# macOS / Linux
+bash tools/scripts/install-service.sh install            # crash + reboot-then-login
+bash tools/scripts/install-service.sh install --system   # also survives LOGOUT (needs sudo)
+bash tools/scripts/install-service.sh status
+```
+
+```powershell
+# Windows — from an ADMINISTRATOR PowerShell. Creating a scheduled task needs
+# elevation (deleting one does not, which is a trap: tooling can tear the
+# supervisor down and then be unable to put it back).
+# Use Git Bash BY FULL PATH — a bare `bash` in PowerShell is the WSL shim and
+# fails with "execvpe(/bin/bash) failed".
+& "C:\Program Files\Git\bin\bash.exe" tools/scripts/install-service.sh install
+```
+
 Detailed dev environment + platform-specific gotchas: **[docs/SETUP.md](docs/SETUP.md)**.
 </details>
 

--- a/tools/scripts/install-service.sh
+++ b/tools/scripts/install-service.sh
@@ -291,7 +291,18 @@ win_install() {
     echo "  Creating a task requires an ELEVATED shell. Run this once, in an" >&2
     echo "  Administrator terminal, from this checkout:" >&2
     echo "" >&2
-    echo "    bash tools/scripts/install-service.sh install$([ "$SCOPE" = system ] && echo ' --system')" >&2
+    # Name GIT BASH BY FULL PATH, and give the PowerShell form. A bare `bash` in
+    # PowerShell resolves to C:\Windows\System32ash.exe — the WSL shim — which
+    # fails with "WSL ... execvpe(/bin/bash) failed: No such file or directory" and
+    # reads like the SCRIPT is broken. The operator this message exists for is, by
+    # definition, in an elevated PowerShell, which is exactly where the bare word is
+    # wrong. (Measured 2026-09-06: this hint sent Joel straight into that error.)
+    local _gb="$(win_path "$(command -v bash)")"
+    local _args="tools/scripts/install-service.sh install$([ "$SCOPE" = system ] && echo ' --system')"
+    echo "    & \"$_gb\" $_args" >&2
+    echo "" >&2
+    echo "  (from THIS directory. A bare \`bash\` in PowerShell is WSL, not Git Bash," >&2
+    echo "   and fails with 'execvpe(/bin/bash) failed' — use the full path above.)" >&2
     echo "" >&2
     echo "  Until then the core has NO supervisor: it will die with whatever shell" >&2
     echo "  started it (Windows job-object teardown) and will not return after a" >&2

--- a/tools/scripts/install-service.sh
+++ b/tools/scripts/install-service.sh
@@ -303,6 +303,7 @@ win_install() {
     echo "" >&2
     echo "  (from THIS directory. A bare \`bash\` in PowerShell is WSL, not Git Bash," >&2
     echo "   and fails with 'execvpe(/bin/bash) failed' — use the full path above.)" >&2
+    echo "  Canonical instructions: README.md § Getting Started -> Development." >&2
     echo "" >&2
     echo "  Until then the core has NO supervisor: it will die with whatever shell" >&2
     echo "  started it (Windows job-object teardown) and will not return after a" >&2


### PR DESCRIPTION
Two problems, one root: **there was no canonical instruction for supervising the core**, so the only place it existed was an error message — and that message was wrong for the shell its reader was standing in.

### The README never mentioned `install-service.sh`

§ Getting Started → Development taught `continuum start` and stopped. That's exactly where a developer learns the hard way that a core started from a shell is a *child* of that shell — close the terminal, log out, or end an agent session and it's gone. On Windows it inherits the session's job object and is killed outright.

Adds the step with both platform forms and what each actually survives (crash / reboot-then-login / logout).

### The elevation hint told the operator to run `bash …`

The operator that message exists for is, by definition, **in an elevated PowerShell** — the one place a bare `bash` resolves to the WSL shim:

```
WSL (10 - Relay) ERROR: CreateProcessCommon:800:
execvpe(/bin/bash) failed: No such file or directory
```

That reads like the *script* is broken, on a machine where the script is fine and elevation is the only real requirement. Measured 2026-09-06 — this hint sent the operator straight into that error, on the one instruction whose entire job is to be copy-pasteable by someone already being told something is wrong.

Now prints the PowerShell call form with Git Bash's **full path** (derived from `command -v bash`, never hardcoded), names the WSL trap so the next person recognises it rather than debugging it, and **cites the README as canonical** so the two can't drift.

### Also documented

The asymmetry that makes this dangerous rather than merely annoying: **creating** a scheduled task requires elevation, **deleting** one does not. Tooling can tear the supervisor down and then be unable to put it back — which is precisely what happened on this node tonight, costing it a real outage.

### The rule

An error message that hands over an instruction must be correct in the **shell its reader is standing in**, and it should point at documentation rather than become a second source of it. A recovery hint that itself fails costs more than no hint, because it moves suspicion onto the wrong component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc