### PR TITLE
fix(inference): the remote inference deadline fits a turn (600 s), not a command (30 s) — the 5090 completed every turn and the M5 dropped every answer

### DIFF
--- a/core/continuum-core/src/inference/airc_remote/transport.rs
+++ b/core/continuum-core/src/inference/airc_remote/transport.rs
@@ -28,6 +28,16 @@ use continuum_airc_protocol::{
 };
 use uuid::Uuid;
 
+/// How long a remote INFERENCE request may take, end to end. This is a
+/// turn, not a command: a citizen's prompt is 15k–25k tokens of prefill plus
+/// a decode of up to ~3k tokens on a lane she shares with the peer's own
+/// citizens — minutes, not seconds. Measured 2026-09-07 01:2xZ: every reply
+/// from the 5090 arrived 35 s or more after the request, past the 30 s
+/// `DEFAULT_COMMAND_DEADLINE` this transport used to inherit, so the peer did
+/// the work and the requester dropped the answer, 21 times in an hour, then
+/// read the peer as cold. Sized like the local generation ceiling.
+pub const REMOTE_INFERENCE_DEADLINE: Duration = Duration::from_secs(600);
+
 use crate::ai::adapter::AIProviderAdapter;
 use crate::routing::airc_transport::AircTransport;
 
@@ -188,7 +198,7 @@ impl AircLiveTransport {
         Arc::new(Self {
             airc,
             default_target_peer: PeerId(default_target_peer),
-            deadline: DEFAULT_COMMAND_DEADLINE,
+            deadline: REMOTE_INFERENCE_DEADLINE,
         })
     }
 
@@ -389,6 +399,16 @@ impl AircInferenceTransport for AircLiveTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: a revert to the COMMAND deadline. A command answers
+    // in milliseconds; an inference answers in minutes. With 30 s here the
+    // peer completes every turn and the requester drops every answer, which
+    // reads exactly like a dead peer (2026-09-07: 21 wasted completions).
+    #[test]
+    fn the_inference_deadline_is_sized_for_a_turn_not_a_command() {
+        assert!(REMOTE_INFERENCE_DEADLINE >= Duration::from_secs(300));
+        assert!(REMOTE_INFERENCE_DEADLINE > DEFAULT_COMMAND_DEADLINE * 5);
+    }
     use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
     use crate::ai::types::{
         ChatMessage, FinishReason, MessageContent, TextGenerationRequest, TextGenerationResponse,


### PR DESCRIPTION
## Wall #4 (after #3814): the answer arrived and the requester had already given up

In the M5's event store, Sahar's (5090) replies to Kira's and Mathis's `ai/generate` requests are present — `reply_to` 80f28992, correlation ids matching, `continuum.command.response.v1`, successes at 01:23:59 / 01:26:51 / 01:28:46 — each **35 s or more after its request**. `AircLiveTransport::new` inherited `DEFAULT_COMMAND_DEADLINE` (30 s). So the 5090 did the prefill and the decode, the M5 dropped the answer at 30 s, the breaker counted a miss, and after three the peer read cold. BigMama's node counted 21 completions in the hour; none reached a citizen.

The operator seat answered "PONG from the 5090" in 1.6 s only because a 45-token reply on an idle lane fits inside 30 s.

## Fix
`REMOTE_INFERENCE_DEADLINE = 600 s` (a turn: 15k–25k prefill + up to ~3k decode on a shared lane, sized like the local generation ceiling), used by the transport's constructor; both production sites (`RemoteLaneAdapterFactory`, the CLI `aircPeer` interceptor) inherit it. `with_deadline` stays for tests. The breaker's three-miss rule now means three genuinely dead ten-minute waits, not three slow answers.

## Test
`the_inference_deadline_is_sized_for_a_turn_not_a_command` — pins the deadline above the command deadline.

## Acceptance
After the M5 deploys: `delib.generate.cache` rows for Kira and Mathis with the remote adapter; `remote_lane.cold` stops; their thoughts land in the run room from the 5090's 27B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
