### PR TITLE
fix(inference): the remote lane says how each request ended — remote_lane.answered / remote_lane.failed

### DIFF
--- a/core/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/core/continuum-core/src/inference/airc_remote/adapter.rs
@@ -220,8 +220,31 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
         if let Some(peer) = &self.default_target_peer {
             envelope = envelope.with_target_peer(peer.clone());
         }
+        let started = std::time::Instant::now();
         let sent = self.transport.send_request(envelope).await;
         self.observe(&sent.as_ref().map(|_| ()));
+        // Every request ends in exactly one row. Before this the only remote
+        // rows were the breaker's — a turn that timed out, errored, or answered
+        // was invisible here, and 9 misses in 200 s could not be told from 3
+        // ten-minute waits (2026-09-07 01:59Z, the first read after #3818).
+        match &sent {
+            Ok(r) => crate::probe!(
+                class = "remote_lane.answered",
+                peer = %self.default_target_peer.as_deref().unwrap_or("-"),  // unwrap_or: probe label only — "-" = no pinned peer
+                served_by = %r.served_by,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                out_tokens = r.text_response.usage.output_tokens,
+                finish = ?r.text_response.finish_reason,
+                "remote inference answered"
+            ),
+            Err(e) => crate::probe!(
+                class = "remote_lane.failed",
+                peer = %self.default_target_peer.as_deref().unwrap_or("-"),  // unwrap_or: probe label only — "-" = no pinned peer
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                error = %e,
+                "remote inference failed"
+            ),
+        }
         let response = sent.map_err(|e| e.to_string())?;
         // First successful round-trip flips the health observation
         // bit so subsequent health_check calls can report Healthy.


### PR DESCRIPTION
## The instrument the last read was missing

First read on the M5 after #3818 (600 s deadline) landed: `remote_lane.cold` ×3 and `refused_cold` ×65 inside 200 s. Three trips = nine `Timeout` results — impossible as nine ten-minute waits — and nothing in any probe said what those requests returned or how long they took. The adapter's only rows were the breaker's; the deliberation layer swallows the adapter's error string.

## Change
`AircRemoteInferenceAdapter::generate_text` ends every request in exactly one row:
- `remote_lane.answered {peer, served_by, elapsed_ms, out_tokens, finish}`
- `remote_lane.failed {peer, elapsed_ms, error}`

So a deadline miss (`elapsed_ms` ≈ the deadline), a fast failure (stream ended, peer refused, no model), and a delivered answer are three different rows with the same join keys the breaker uses.

No behaviour change. Existing adapter tests cover the paths; the two `unwrap_or` sites are probe labels and carry same-line justifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
