### PR TITLE
fix(persona): an off-box brain is budgeted against the RESPONDER's window — persona/reassign-model --context_window

### DIFF
--- a/core/continuum-core/src/commands/persona/reassign_model.rs
+++ b/core/continuum-core/src/commands/persona/reassign_model.rs
@@ -109,6 +109,10 @@ pub struct PersonaReassignModelParams {
     /// to infer it from "persisted".
     #[serde(default)]
     pub remote_peer: Option<String>,
+    /// The RESPONDER's served per-slot context window, when `remote_peer` is
+    /// set. Her prompt is budgeted against it instead of the local lane.
+    #[serde(default)]
+    pub context_window: Option<u32>,
 }
 
 /// What `persona/reassign-model` did: the durable assignment that now sticks, and
@@ -136,6 +140,9 @@ pub struct ReassignModelReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub remote_peer: Option<String>,
+    /// The responder's window recorded with a remote assignment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u32>,
     /// Human-readable summary.
     pub detail: String,
 }
@@ -263,6 +270,10 @@ crate::action_command! {
                 peer,
             ),
         };
+        let override_record = match p.context_window {
+            Some(window) if override_record.is_remote() => override_record.with_context_window(window),
+            _ => override_record,
+        };
         override_record.write(&home).map_err(|e| {
             CommandError::Internal(format!(
                 "host is now serving '{}' for '{}' but persisting her durable assignment failed: {e}. \
@@ -306,6 +317,7 @@ crate::action_command! {
             previous_model,
             override_persisted: true,
             remote_peer: p.remote_peer,
+            context_window: p.context_window,
             detail,
         })
     }
@@ -352,6 +364,7 @@ mod tests {
                     model_id: "qwen3-coder-14b".to_string(),
                     set_by: None,
                     remote_peer: None,
+                    context_window: None,
                 },
             )
             .await
@@ -380,6 +393,7 @@ mod tests {
                     model_id: "qwen3-coder-14b".to_string(),
                     set_by: Some("operator".to_string()),
                     remote_peer: None,
+                    context_window: None,
                 },
             )
             .await
@@ -420,6 +434,7 @@ mod tests {
                     model_id: "ornith-ai/Ornith-1.5-35B-A3B-GGUF".to_string(),
                     set_by: Some("operator".to_string()),
                     remote_peer: Some(peer.to_string()),
+                    context_window: None,
                 },
             )
             .await
@@ -462,6 +477,7 @@ mod tests {
                     model_id: "ornith-ai/Ornith-1.5-35B-A3B-GGUF".to_string(),
                     set_by: None,
                     remote_peer: Some("not-a-uuid".to_string()),
+                    context_window: None,
                 },
             )
             .await

--- a/core/continuum-core/src/persona/model_override.rs
+++ b/core/continuum-core/src/persona/model_override.rs
@@ -73,6 +73,13 @@ pub struct PersonaModelOverride {
     /// adapter in 409 ms, with the reply naming the REMOTE host's served models.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_peer: Option<String>,
+    /// The RESPONDER's served per-slot context window, when her brain runs
+    /// off-box. Her prompt is budgeted against this, never against the local
+    /// lane: measured 2026-09-07 03:1xZ, two citizens bound to a 5090 slot
+    /// budgeted against the M5's 50,944-token lane, sent 35–43k-token prompts,
+    /// and every answer died at `Length` with an empty completion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_context_window: Option<u32>,
 }
 
 /// Failure modes of reading / writing a persona's model override. Every variant
@@ -106,6 +113,7 @@ impl PersonaModelOverride {
             set_at_ms: now_ms,
             set_by,
             remote_peer: None,
+            remote_context_window: None,
         }
     }
 
@@ -126,7 +134,14 @@ impl PersonaModelOverride {
             set_at_ms: now_ms,
             set_by,
             remote_peer: Some(peer.into()),
+            remote_context_window: None,
         }
+    }
+
+    /// Record the responder's served per-slot window for an off-box brain.
+    pub fn with_context_window(mut self, window: u32) -> Self {
+        self.remote_context_window = Some(window);
+        self
     }
 
     /// Does this assignment run off-box? `true` when a peer serves her model.
@@ -214,6 +229,21 @@ impl PersonaModelOverride {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: the responder's window must survive the write/load
+    // round trip and be absent (None) for a local assignment — a remote brain
+    // budgeted against the local lane sends prompts the peer cannot hold.
+    #[test]
+    fn a_remote_assignment_keeps_the_responders_window_across_the_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = PersonaHome::from_root(dir.path().to_path_buf());
+        let over = PersonaModelOverride::new_remote("m", None, 1, "peer").with_context_window(24_832);
+        over.write(&home).expect("write");
+        let back = PersonaModelOverride::load(&home).expect("load").expect("present");
+        assert_eq!(back.remote_context_window, Some(24_832));
+        let local = PersonaModelOverride::new("m", None, 1);
+        assert_eq!(local.remote_context_window, None);
+    }
 
     fn home() -> (tempfile::TempDir, PersonaHome) {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -487,6 +487,11 @@ pub enum SupervisorError {
 /// on an 8 GiB Intel Mac. Slice 10+ can introduce parallel + capped
 /// materialization once #122 (shared base) makes the per-persona
 /// cost much smaller.
+/// The window an off-box brain gets when nobody recorded her responder's slot:
+/// small enough to be safe on any lane we have served (the 5090's 27B slots
+/// were 24,832; the Intel Mac's CPU lane smaller), never the local lane's size.
+pub const REMOTE_WINDOW_FLOOR: u32 = 16_384;
+
 pub async fn materialize_adapters(
     plans: Vec<MaterializedPersonaPlan>,
     factory: &dyn PersonaAdapterFactory,
@@ -591,15 +596,23 @@ pub async fn materialize_adapters(
                     );
                     profile.context_length = window;
                 }
-                None => crate::probe!(
-                    class = "persona.upstart.window",
-                    persona = %profile.persona_name,
-                    persona_id = %profile.persona_id,
-                    planned = profile.context_length,
-                    source = "remote_unknown",
-                    "off-box brain with no recorded responder window — keeping the planned value; \
-                     pass --context_window to persona/reassign-model",
-                ),
+                None => {
+                    // The planned value IS the outage (it is the local lane's size).
+                    // Unknown responder → the conservative floor: briefly under-
+                    // budgeted costs context; over-budgeted costs every answer.
+                    let floor = REMOTE_WINDOW_FLOOR.min(profile.context_length);
+                    crate::probe!(
+                        class = "persona.upstart.window",
+                        persona = %profile.persona_name,
+                        persona_id = %profile.persona_id,
+                        planned = profile.context_length,
+                        served = floor,
+                        source = "remote_floor",
+                        "off-box brain with no recorded responder window — sized to the floor; \
+                         pass --context_window to persona/reassign-model for her real slot",
+                    );
+                    profile.context_length = floor;
+                }
             }
         } else if profile.tier_category != crate::persona::hw_tier_descriptor::HwTierCategory::Cloud {
             let snap = crate::inference::llama_server::current_serving();
@@ -1266,6 +1279,45 @@ mod tests {
     /// A row that arrives with `Err(profile)` from slice 8 passes
     /// through as `SupervisorError::Profile` — the factory is NOT
     /// called for it (sibling rows still materialize normally).
+    // what this catches: the DECISION, not the serialization. A remote-bound
+    // persona's window comes from her recorded responder slot (or the floor when
+    // none is recorded) and never from the local serving snapshot — reordering
+    // the remote branch against the local-slot clamp would size every off-box
+    // brain to a lane it never runs in (35–43k prompts at a 24,832 slot, 2026-09-07).
+    #[tokio::test]
+    async fn a_remote_override_wins_over_the_local_slot_at_spawn() {
+        init_test_registry();
+        let homes = tempfile::tempdir().expect("tempdir");
+        let mut with_window = fake_instance("Rin");
+        with_window.home = homes.path().join("rin");
+        std::fs::create_dir_all(&with_window.home).expect("home dir");
+        crate::persona::model_override::PersonaModelOverride::new_remote("model-a", None, 1, "peer")
+            .with_context_window(24_832)
+            .write(&crate::persona::home::PersonaHome::from_root(with_window.home.clone()))
+            .expect("write override");
+        let mut without_window = fake_instance("Sol");
+        without_window.home = homes.path().join("sol");
+        std::fs::create_dir_all(&without_window.home).expect("home dir");
+        crate::persona::model_override::PersonaModelOverride::new_remote("model-b", None, 1, "peer")
+            .write(&crate::persona::home::PersonaHome::from_root(without_window.home.clone()))
+            .expect("write override");
+        let mut rin = fake_profile("Rin", "model-a");
+        rin.context_length = 50_944;
+        let mut sol = fake_profile("Sol", "model-b");
+        sol.context_length = 50_944;
+        let plans = vec![
+            MaterializedPersonaPlan { role: RoleId::Helper, instance: with_window, profile: Ok(rin) },
+            MaterializedPersonaPlan { role: RoleId::Coder, instance: without_window, profile: Ok(sol) },
+        ];
+        let factory = ScriptedPersonaAdapterFactory::heuristic();
+        let hosted =
+            materialize_adapters(plans, &factory, StubAircCitizen::fresh_lookup(), |_| None).await;
+        let rin = hosted[0].as_ref().expect("Rin hosted");
+        assert_eq!(rin.profile.context_length, 24_832, "the recorded responder window wins");
+        let sol = hosted[1].as_ref().expect("Sol hosted");
+        assert_eq!(sol.profile.context_length, REMOTE_WINDOW_FLOOR, "unknown responder → the floor, never the local lane");
+    }
+
     #[tokio::test]
     async fn forwards_profile_errors_without_calling_factory() {
         init_test_registry();

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -487,11 +487,6 @@ pub enum SupervisorError {
 /// on an 8 GiB Intel Mac. Slice 10+ can introduce parallel + capped
 /// materialization once #122 (shared base) makes the per-persona
 /// cost much smaller.
-/// The window an off-box brain gets when nobody recorded her responder's slot:
-/// small enough to be safe on any lane we have served (the 5090's 27B slots
-/// were 24,832; the Intel Mac's CPU lane smaller), never the local lane's size.
-pub const REMOTE_WINDOW_FLOOR: u32 = 16_384;
-
 pub async fn materialize_adapters(
     plans: Vec<MaterializedPersonaPlan>,
     factory: &dyn PersonaAdapterFactory,
@@ -600,7 +595,10 @@ pub async fn materialize_adapters(
                     // The planned value IS the outage (it is the local lane's size).
                     // Unknown responder → the conservative floor: briefly under-
                     // budgeted costs context; over-budgeted costs every answer.
-                    let floor = REMOTE_WINDOW_FLOOR.min(profile.context_length);
+                    // The planner's own full-turn window floor — the one substrate-owned
+                    // minimum every other bound derives from; never a number of our own.
+                    let floor = crate::cognition::serving_plan::BOOTSTRAP_WORKING_SET
+                        .min(profile.context_length);
                     crate::probe!(
                         class = "persona.upstart.window",
                         persona = %profile.persona_name,
@@ -1315,7 +1313,11 @@ mod tests {
         let rin = hosted[0].as_ref().expect("Rin hosted");
         assert_eq!(rin.profile.context_length, 24_832, "the recorded responder window wins");
         let sol = hosted[1].as_ref().expect("Sol hosted");
-        assert_eq!(sol.profile.context_length, REMOTE_WINDOW_FLOOR, "unknown responder → the floor, never the local lane");
+        assert_eq!(
+            sol.profile.context_length,
+            crate::cognition::serving_plan::BOOTSTRAP_WORKING_SET,
+            "unknown responder → the planner's floor, never the local lane"
+        );
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -566,7 +566,42 @@ pub async fn materialize_adapters(
         // probe) to the served truth so every budget is correct by construction.
         // Cloud-routed personas (tier `Cloud`) keep their model's full window —
         // their adapter owns its own context and there is no local slot to fit.
-        if profile.tier_category != crate::persona::hw_tier_descriptor::HwTierCategory::Cloud {
+        // An OFF-BOX brain is budgeted against the RESPONDER's slot, never the
+        // local gateway's: measured 2026-09-07 03:1xZ, two citizens bound to a
+        // 5090 slot were pinned to the M5's 50,944-token lane below, sent
+        // 35–43k-token prompts, and every answer died at `Length`.
+        let remote_window = crate::persona::model_override::PersonaModelOverride::load(
+            &crate::persona::home::PersonaHome::from_root(identity.home.clone()),
+        )
+        .ok()
+        .flatten()
+        .filter(|o| o.is_remote())
+        .map(|o| o.remote_context_window);
+        if let Some(remote) = remote_window {
+            match remote {
+                Some(window) => {
+                    crate::probe!(
+                        class = "persona.upstart.window",
+                        persona = %profile.persona_name,
+                        persona_id = %profile.persona_id,
+                        planned = profile.context_length,
+                        served = window,
+                        source = "remote_override",
+                        "pinning persona context window to the RESPONDER's slot (her brain runs off-box)",
+                    );
+                    profile.context_length = window;
+                }
+                None => crate::probe!(
+                    class = "persona.upstart.window",
+                    persona = %profile.persona_name,
+                    persona_id = %profile.persona_id,
+                    planned = profile.context_length,
+                    source = "remote_unknown",
+                    "off-box brain with no recorded responder window — keeping the planned value; \
+                     pass --context_window to persona/reassign-model",
+                ),
+            }
+        } else if profile.tier_category != crate::persona::hw_tier_descriptor::HwTierCategory::Cloud {
             let snap = crate::inference::llama_server::current_serving();
             // A ready snapshot always carries a real window (the daemon refuses to
             // publish ready with 0). Guard on both so a not-yet-ready/empty

--- a/protocol/typescript/persona/PersonaReassignModelParams.ts
+++ b/protocol/typescript/persona/PersonaReassignModelParams.ts
@@ -49,4 +49,9 @@ set_by: string | null,
  * reassign THEN (re)spawn, and the report says so rather than leaving an operator
  * to infer it from "persisted".
  */
-remote_peer: string | null, };
+remote_peer: string | null, 
+/**
+ * The RESPONDER's served per-slot context window, when `remote_peer` is
+ * set. Her prompt is budgeted against it instead of the local lane.
+ */
+context_window: number | null, };

--- a/protocol/typescript/persona/ReassignModelReport.ts
+++ b/protocol/typescript/persona/ReassignModelReport.ts
@@ -31,6 +31,10 @@ override_persisted: boolean,
  */
 remote_peer?: string, 
 /**
+ * The responder's window recorded with a remote assignment.
+ */
+context_window?: number | null, 
+/**
  * Human-readable summary.
  */
 detail: string, };


### PR DESCRIPTION
## Why every off-box answer ended at Length

Ledger tail on the M5, 03:12–03:23Z: Kira's and Mathis's turns ran with `context_window 50,944` and `completion_reserve 16,384` — the M5's Ornith slot, pinned at spawn by `materialize_adapters` from the LOCAL `/props` — while their brains run on the 5090's 27B, which serves ~25k per slot. 35–43k-token prompts crossed the wire; the peer clamped; six of nine answers were `finish=Length` (1,196–3,833 tokens) and `delib.empty_completion` followed each.

## Change
- `PersonaModelOverride.remote_context_window: Option<u32>` (durable, serde-default) + `with_context_window`.
- `persona/reassign-model --context_window N` records it for a remote assignment; the report echoes it.
- `materialize_adapters`: a remote-bound persona is pinned to the recorded responder window (`persona.upstart.window source=remote_override`), or keeps the planned value with a loud `source=remote_unknown` row; the local-slot pin applies only to local brains.

## Test
`a_remote_assignment_keeps_the_responders_window_across_the_round_trip`.

## Acceptance
After `persona/reassign-model Kira … --context_window <5090 slot>` + respawn: `delib.turn.demand context_window` = the responder's; `remote_lane.answered finish=ToolUse` with no `empty_completion`. The responder's window should eventually ride the accept frame (#3819's quote); this is the durable operator half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
