### PR TITLE
fix(memory): the consciousness cache is keyed by a PAIR, so it can actually be invalidated

### DIFF
--- a/core/continuum-core/src/memory/cache.rs
+++ b/core/continuum-core/src/memory/cache.rs
@@ -6,15 +6,27 @@
 //! - Embedding vectors — cached until invalidated
 
 use parking_lot::Mutex;
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::time::{Duration, Instant};
 
 // ─── MemoryCache ───────────────────────────────────────────────────────────────
 
 /// Thread-safe TTL cache with automatic expiry.
 /// Clone bound on T because values are returned by clone (cache retains ownership).
-pub struct MemoryCache<T: Clone> {
-    entries: Mutex<HashMap<String, CacheEntry<T>>>,
+///
+/// The key is a TYPE, not a formatted string. It used to be `String`, and the
+/// consciousness cache built its keys as `format!("{persona}:{room}")` while every
+/// invalidation site passed the persona alone — so `entries.remove("<persona>")`
+/// never matched `"<persona>:<room>"` and the cache was NEVER invalidated, only
+/// TTL-expired. A persona could store a memory and keep reading a context that
+/// omitted it for the whole 30 s window. Nothing failed; the calls compiled and
+/// silently did nothing. With a key type, `invalidate(persona)` against a
+/// `ConsciousnessKey` map does not compile, and removing every entry for one
+/// persona has to say so ([`MemoryCache::invalidate_where`]).
+pub struct MemoryCache<K: Eq + Hash + Clone, T: Clone> {
+    entries: Mutex<HashMap<K, CacheEntry<T>>>,
     ttl: Duration,
 }
 
@@ -23,7 +35,7 @@ struct CacheEntry<T> {
     inserted_at: Instant,
 }
 
-impl<T: Clone> MemoryCache<T> {
+impl<K: Eq + Hash + Clone, T: Clone> MemoryCache<K, T> {
     pub fn new(ttl: Duration) -> Self {
         Self {
             entries: Mutex::new(HashMap::new()),
@@ -32,7 +44,11 @@ impl<T: Clone> MemoryCache<T> {
     }
 
     /// Get a cached value if it exists and hasn't expired.
-    pub fn get(&self, key: &str) -> Option<T> {
+    pub fn get<Q>(&self, key: &Q) -> Option<T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         let entries = self.entries.lock();
         entries.get(key).and_then(|entry| {
             if entry.inserted_at.elapsed() < self.ttl {
@@ -44,7 +60,7 @@ impl<T: Clone> MemoryCache<T> {
     }
 
     /// Store a value in the cache.
-    pub fn set(&self, key: String, value: T) {
+    pub fn set(&self, key: K, value: T) {
         let mut entries = self.entries.lock();
         entries.insert(
             key,
@@ -56,9 +72,24 @@ impl<T: Clone> MemoryCache<T> {
     }
 
     /// Remove a specific key.
-    pub fn invalidate(&self, key: &str) {
+    pub fn invalidate<Q>(&self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
         let mut entries = self.entries.lock();
         entries.remove(key);
+    }
+
+    /// Remove every entry whose key matches `pred`.
+    ///
+    /// The honest way to say "everything for this persona" when the key is a pair.
+    /// The old code said it by passing HALF a formatted key to `invalidate` and
+    /// removing nothing at all; a partial key is not a key, and this is the call
+    /// that partial intent actually requires.
+    pub fn invalidate_where(&self, pred: impl Fn(&K) -> bool) {
+        let mut entries = self.entries.lock();
+        entries.retain(|key, _| !pred(key));
     }
 
     /// Remove all entries.
@@ -117,6 +148,75 @@ mod tests {
 
         cache.invalidate("key1");
         assert_eq!(cache.get("key1"), None);
+    }
+
+    // what this catches: the packed-string key regression. The consciousness cache
+    // keyed entries as `format!("{persona}:{room}")` while all three invalidation
+    // sites passed the persona ALONE, so exact-match `remove` never hit anything and
+    // the cache was never invalidated — only TTL-expired. A persona could store a
+    // memory and keep reading a context without it for the rest of the 30 s window.
+    //
+    // Both halves are asserted because the bug needs both to be caught: removing one
+    // persona's entries must take EVERY room she has, and must leave other personas
+    // alone. A `retain` that got the predicate backwards passes the first and fails
+    // the second.
+    #[test]
+    fn invalidating_one_persona_takes_all_her_rooms_and_nobody_elses() {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        struct Key {
+            persona: &'static str,
+            room: &'static str,
+        }
+        let cache = MemoryCache::new(Duration::from_secs(60));
+        cache.set(
+            Key {
+                persona: "ada",
+                room: "general",
+            },
+            1,
+        );
+        cache.set(
+            Key {
+                persona: "ada",
+                room: "academy",
+            },
+            2,
+        );
+        cache.set(
+            Key {
+                persona: "grace",
+                room: "general",
+            },
+            3,
+        );
+
+        cache.invalidate_where(|k| k.persona == "ada");
+
+        assert_eq!(
+            cache.get(&Key {
+                persona: "ada",
+                room: "general"
+            }),
+            None,
+            "every room for the invalidated persona must go"
+        );
+        assert_eq!(
+            cache.get(&Key {
+                persona: "ada",
+                room: "academy"
+            }),
+            None,
+            "including the rooms the caller did not name — that is what the old \
+             half-a-key `invalidate` silently failed to do"
+        );
+        assert_eq!(
+            cache.get(&Key {
+                persona: "grace",
+                room: "general"
+            }),
+            Some(3),
+            "another persona's context is not hers to evict"
+        );
     }
 
     #[test]

--- a/core/continuum-core/src/memory/mod.rs
+++ b/core/continuum-core/src/memory/mod.rs
@@ -76,6 +76,25 @@ const MAX_EVENTS_PER_CORPUS: usize = 2000;
 /// Stale corpus TTL — evict if not accessed in 30 minutes.
 const CORPUS_STALE_TTL: Duration = Duration::from_secs(30 * 60);
 
+/// What the consciousness cache is keyed BY: a persona and a room, as two fields.
+///
+/// This was `format!("{persona}:{room}")`, and the packing hid a live defect for as
+/// long as it shipped. Every invalidation site called
+/// `invalidate(persona_id.as_str())` — half a key — so the exact-match `remove`
+/// never hit `"<persona>:<room>"` and the cache was never invalidated at all, only
+/// TTL-expired. A persona could store a memory and keep reading a consciousness
+/// context that omitted it for the rest of the 30 s window, three times over
+/// (corpus load, memory store, timeline store), with nothing failing anywhere.
+///
+/// As a struct that call site cannot be written: invalidating one persona's rooms
+/// has to say so via [`MemoryCache::invalidate_where`], and a lookup has to supply
+/// both halves. Never pack two things into a string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ConsciousnessKey {
+    persona: crate::identity::PersonaRef,
+    room: String,
+}
+
 /// Top-level manager for all persona memory operations.
 ///
 /// - Holds per-persona MemoryCorpus in a DashMap (zero cross-persona contention)
@@ -91,7 +110,7 @@ pub struct PersonaMemoryManager {
     corpus_access_times: DashMap<String, Instant>,
     embedding: Arc<dyn EmbeddingProvider>,
     recall_engine: MultiLayerRecall,
-    consciousness_cache: MemoryCache<ConsciousnessContextResponse>,
+    consciousness_cache: MemoryCache<ConsciousnessKey, ConsciousnessContextResponse>,
 }
 
 impl PersonaMemoryManager {
@@ -135,7 +154,8 @@ impl PersonaMemoryManager {
             .insert(persona_id.to_string(), Instant::now());
 
         // Invalidate consciousness cache (new data affects context)
-        self.consciousness_cache.invalidate(persona_id.as_str());
+        self.consciousness_cache
+            .invalidate_where(|k| &k.persona == persona_id);
 
         let load_time_ms = start.elapsed().as_secs_f64() * 1000.0;
 
@@ -363,7 +383,10 @@ impl PersonaMemoryManager {
         req: &ConsciousnessContextRequest,
     ) -> Result<ConsciousnessContextResponse, MemoryError> {
         // Check cache
-        let cache_key = format!("{}:{}", persona_id, req.room_id);
+        let cache_key = ConsciousnessKey {
+            persona: persona_id.clone(),
+            room: req.room_id.clone(),
+        };
         if let Some(cached) = self.consciousness_cache.get(&cache_key) {
             return Ok(cached);
         }
@@ -406,7 +429,8 @@ impl PersonaMemoryManager {
             }
         }
         drop(corpus); // Release write lock before invalidating cache
-        self.consciousness_cache.invalidate(persona_id.as_str());
+        self.consciousness_cache
+            .invalidate_where(|k| &k.persona == persona_id);
         Ok(())
     }
 
@@ -434,7 +458,8 @@ impl PersonaMemoryManager {
             }
         }
         drop(corpus); // Release write lock before invalidating cache
-        self.consciousness_cache.invalidate(persona_id.as_str());
+        self.consciousness_cache
+            .invalidate_where(|k| &k.persona == persona_id);
         Ok(())
     }
 


### PR DESCRIPTION
The cache was never invalidated. Not rarely — never.

Keys were built as `format!("{persona}:{room}")`, and all three invalidation
sites passed the persona ALONE:

    self.consciousness_cache.invalidate(persona_id.as_str());

`invalidate` is an exact-match `HashMap::remove`, so `remove("<persona>")`
could never match `"<persona>:<room>"`. All three calls compiled, ran, and
did nothing. The cache only ever aged out on its 30 s TTL — which means a
persona could store a memory and then read a consciousness context that
omitted it for the rest of that window, three times over (corpus load,
memory store, timeline-event store), each site commented "new data affects
context".

That call is impossible to write against a typed key, which is the fix:

  - `MemoryCache<T>` becomes `MemoryCache<K, T>`, keyed by a type.
    `get`/`invalidate` take `Borrow<Q>` so existing string-keyed use stays
    ergonomic and `HashMap`'s own lookup semantics carry over.
  - `ConsciousnessKey { persona: PersonaRef, room: String }` — `PersonaRef`
    already derived `Hash + Eq + Clone`.
  - `invalidate_where(pred)` is the honest way to say "everything for this
    persona" when the key is a pair. The old code said it by passing half a
    formatted key; a partial key is not a key.

The new test asserts BOTH halves — every room for the invalidated persona
goes, and nobody else's does — because a `retain` with the predicate
backwards passes the first and fails the second.

Proved by mutation rather than by reading: inverting `invalidate_where`'s
retain predicate fails the test on "every room for the invalidated persona
must go", and reverting restores 6 passed / 0 failed.

Per Joel, this session: "Never pack two or more things into a string just
use a struct." Found while checking his hypothesis that the citizen
message-plane deafness was uuid/string mixing. It was not that bug — that
one is `Polled::Quiet` declining to re-open a dead stream (card e592b633,
fixed in #3825) — but the class he named was real and this was sitting in
it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRQWzgSfo79JtnwZywHKrE