### PR TITLE
feat(inference): the responder stamps its served window on every answer and the requester's override learns it

### DIFF
--- a/core/continuum-core/src/ai/types.rs
+++ b/core/continuum-core/src/ai/types.rs
@@ -509,6 +509,13 @@ pub struct RoutingInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub model_requested: Option<String>,
+    /// The context window the SERVING node's lane was serving when it answered,
+    /// in tokens. Stamped by the responder so a requester on another node learns
+    /// the window it is really budgeting against (card 1ab60567: the 5090 moved
+    /// from 24,832 to 26,112 under two off-box citizens and nothing said so).
+    /// Absent when the answer did not come from a local served lane.
+    #[ts(optional)]
+    pub served_context_window: Option<u32>,
 }
 
 /// Provider health status

--- a/core/continuum-core/src/commands/ai/generate.rs
+++ b/core/continuum-core/src/commands/ai/generate.rs
@@ -194,8 +194,17 @@ crate::action_command! {
                 .unwrap_or_default(),
             model_mapped: None,
             model_requested: prior_routing.and_then(|r| r.model_requested),
+            served_context_window: if is_local { served_window_now() } else { None },
         });
 
         Ok(AiGenerateResult::from(response))
     }
+}
+
+
+/// The window the local lane serves right now, or None when no lane is ready —
+/// never a stand-in number (a requester would budget against it).
+fn served_window_now() -> Option<u32> {
+    let s = crate::inference::llama_server::current_serving();
+    (s.ready && s.served_context_window > 0).then_some(s.served_context_window)
 }

--- a/core/continuum-core/src/inference/airc_remote/adapter.rs
+++ b/core/continuum-core/src/inference/airc_remote/adapter.rs
@@ -53,6 +53,10 @@ pub struct AircRemoteInferenceAdapter {
     /// wire without one is refused there (measured 2026-09-06, BigMama's
     /// `detail` field: "No provider or model specified").
     default_model: Option<String>,
+    /// Told the served window every time the peer stamps one on an answer.
+    /// The persona's lane factory hangs her override's writer here so the
+    /// window she budgets against follows the responder's (card 1ab60567).
+    window_sink: Option<Arc<dyn Fn(u32) + Send + Sync>>,
     /// Flipped to true the first time a `generate_text` round-trip
     /// succeeds. `health_check` returns `Unknown` while this is
     /// false (no observation yet) and `Healthy` once it's true.
@@ -90,6 +94,7 @@ impl AircRemoteInferenceAdapter {
             transport,
             default_target_peer: None,
             default_model: None,
+            window_sink: None,
             has_observed_success: AtomicBool::new(false),
             consecutive_deadlines: AtomicU32::new(0),
             cold_until_ms: AtomicU64::new(0),
@@ -140,6 +145,12 @@ impl AircRemoteInferenceAdapter {
     /// unset. The peer refuses a request that names none.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.default_model = Some(model.into());
+        self
+    }
+
+    /// Learn the responder's served window from every answer (see `window_sink`).
+    pub fn with_window_sink(mut self, sink: Arc<dyn Fn(u32) + Send + Sync>) -> Self {
+        self.window_sink = Some(sink);
         self
     }
 }
@@ -251,6 +262,7 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 out_tokens = r.text_response.usage.output_tokens,
                 finish = ?r.text_response.finish_reason,
+                served_window = ?r.text_response.routing.as_ref().and_then(|x| x.served_context_window),
                 "remote inference answered"
             ),
             Err(e) => crate::probe!(
@@ -262,6 +274,16 @@ impl AIProviderAdapter for AircRemoteInferenceAdapter {
             ),
         }
         let response = sent.map_err(|e| e.to_string())?;
+        if let (Some(sink), Some(window)) = (
+            self.window_sink.as_ref(),
+            response
+                .text_response
+                .routing
+                .as_ref()
+                .and_then(|x| x.served_context_window),
+        ) {
+            sink(window);
+        }
         // First successful round-trip flips the health observation
         // bit so subsequent health_check calls can report Healthy.
         // Relaxed is fine: a stale Unknown -> Healthy transition is
@@ -721,5 +743,50 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("successful round-trip"),);
+    }
+
+    // what this catches: the responder's served window dying at the requester.
+    // The peer stamps routing.served_context_window on its answer; the sink the
+    // lane factory installs must see exactly that number (card 1ab60567).
+    #[tokio::test]
+    async fn the_served_window_on_an_answer_reaches_the_sink() {
+        let transport = StubInferenceTransport::new(|req: &RemoteInferenceRequest| {
+            Ok(RemoteInferenceResponse {
+                correlation_id: req.correlation_id,
+                served_by: "peer".to_string(),
+                text_response: crate::ai::types::TextGenerationResponse {
+                    text: "ok".to_string(),
+                    finish_reason: FinishReason::Stop,
+                    model: "qwen3.8-27b".to_string(),
+                    provider: HEURISTIC_PROVIDER_ID.to_string(),
+                    usage: Default::default(),
+                    response_time_ms: 0,
+                    request_id: "stub".to_string(),
+                    content: None,
+                    tool_calls: None,
+                    reasoning: None,
+                    routing: Some(crate::ai::types::RoutingInfo {
+                        provider: "llama".to_string(),
+                        is_local: true,
+                        routing_reason: "adapter_selected".to_string(),
+                        adapters_applied: vec![],
+                        model_mapped: None,
+                        model_requested: None,
+                        served_context_window: Some(26_112),
+                    }),
+                    error: None,
+                    timing: None,
+                },
+            })
+        });
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let sink_seen = Arc::clone(&seen);
+        let adapter = AircRemoteInferenceAdapter::new(transport)
+            .with_model("qwen3.8-27b")
+            .with_window_sink(Arc::new(move |w| {
+                *sink_seen.lock().unwrap() = Some(w);  // unwrap_or: test mutex — a poisoned lock is a failed test
+            }));
+        adapter.generate_text(req("hi")).await.unwrap();
+        assert_eq!(*seen.lock().unwrap(), Some(26_112));
     }
 }

--- a/core/continuum-core/src/modules/ai_provider.rs
+++ b/core/continuum-core/src/modules/ai_provider.rs
@@ -1259,6 +1259,7 @@ pub async fn generate_text(
             .routing
             .as_ref()
             .and_then(|r| r.model_requested.clone()),
+        served_context_window: None,
     });
 
     Ok(response)

--- a/core/continuum-core/src/persona/remote_lane_factory.rs
+++ b/core/continuum-core/src/persona/remote_lane_factory.rs
@@ -190,9 +190,39 @@ impl PersonaAdapterFactory for RemoteLaneAdapterFactory {
         })?;
 
         let transport = AircLiveTransport::new(Arc::clone(airc), peer);
+        // The responder stamps the window its lane serves on every answer; when it
+        // differs from what her override recorded, the record follows the wire so
+        // her next re-host budgets against the real window (card 1ab60567). The
+        // running adapter is not resized mid-flight — the spawn pin owns that.
+        let learned_home = home.clone();
+        let learned_over = over.clone();
+        let learned_name = profile.persona_name.clone();
+        let window_sink: Arc<dyn Fn(u32) + Send + Sync> = Arc::new(move |window: u32| {
+            if learned_over.remote_context_window == Some(window) {
+                return;
+            }
+            let updated = learned_over.clone().with_context_window(window);
+            match updated.write(&learned_home) {
+                Ok(()) => crate::probe!(
+                    class = "remote_lane.window_learned",
+                    persona = %learned_name,
+                    window = window,
+                    was = ?learned_over.remote_context_window,
+                    "the responder serves a different window than her override recorded — record updated; takes effect at her next re-host"
+                ),
+                Err(e) => crate::probe!(
+                    class = "remote_lane.window_learn_failed",
+                    persona = %learned_name,
+                    window = window,
+                    error = %e,
+                    "could not record the responder's served window"
+                ),
+            }
+        });
         let adapter = AircRemoteInferenceAdapter::new(transport)
             .with_target_peer(peer.to_string())
-            .with_model(over.model_id.clone());
+            .with_model(over.model_id.clone())
+            .with_window_sink(window_sink);
 
         crate::probe!(
             class = "persona.adapter.remote_lane",

--- a/protocol/typescript/ai/RoutingInfo.ts
+++ b/protocol/typescript/ai/RoutingInfo.ts
@@ -3,4 +3,12 @@
 /**
  * Routing observability info
  */
-export type RoutingInfo = { provider: string, isLocal: boolean, routingReason: string, adaptersApplied: Array<string>, modelMapped?: string, modelRequested?: string, };
+export type RoutingInfo = { provider: string, isLocal: boolean, routingReason: string, adaptersApplied: Array<string>, modelMapped?: string, modelRequested?: string, 
+/**
+ * The context window the SERVING node's lane was serving when it answered,
+ * in tokens. Stamped by the responder so a requester on another node learns
+ * the window it is really budgeting against (card 1ab60567: the 5090 moved
+ * from 24,832 to 26,112 under two off-box citizens and nothing said so).
+ * Absent when the answer did not come from a local served lane.
+ */
+servedContextWindow?: number, };


### PR DESCRIPTION
## The requester budgets against a window the responder no longer serves

Card 1ab60567. Kira + Mathis are bound to the 5090's 27B with `remote_context_window: 24832` recorded at reassign time; the 5090 re-planned to 26,112 lanes-wide and the M5 had no way to learn it. Any responder re-plan (smaller or larger) leaves the requester's budget wrong until an operator notices.

## Change
- `RoutingInfo.served_context_window: Option<u32>` (ts-rs; bindings regenerated): stamped by `ai/generate` from the live served lane, None when no local lane answered.
- `AircRemoteInferenceAdapter::with_window_sink`: every answer's stamp reaches the sink; `remote_lane.answered` rows carry `served_window`.
- `RemoteLaneAdapterFactory` installs the sink: differs from the override's record → rewrite the record (`remote_lane.window_learned`), so her next re-host budgets against the real window. No mid-flight resize (the spawn pin owns the window).

## Acceptance
On the M5 with the 5090 on this PR: first off-box answer → `remote_lane.answered served_window=26112`, `remote_lane.window_learned persona=Kira window=26112 was=Some(24832)`, `model_override.json` updated. Until the 5090 deploys, `served_window=None` (honest absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
