### PR TITLE
feat(persona): a work turn names the instance's prepared environment — or its absence — beside her hands

### DIFF
--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -302,6 +302,15 @@ pub(crate) async fn ask_the_act_question(
                                              (there is no `swe/` directory from here).",
                                             ws.display()
                                         ));
+                                        // THE ENVIRONMENT, as a fact. Live 2026-09-07: a
+                                        // holder ran `pip install --no-build-isolation -e .`
+                                        // twelve times in one checkout (21 acts, 0 edits) —
+                                        // the grader's prepared env for her instance sat
+                                        // beside it, unnamed. Absence is named too, so
+                                        // she never guesses an interpreter.
+                                        body.working_memory.record_fact(
+                                            &crate::persona::instance_env_fact::instance_env_fact(&ws),
+                                        );
                                     }
                                     crate::probe!(
                                         class = "persona.work.hands_rooted",

--- a/core/continuum-core/src/persona/instance_env_fact.rs
+++ b/core/continuum-core/src/persona/instance_env_fact.rs
@@ -1,0 +1,72 @@
+//! The environment a held checkout runs in, as a working-memory fact.
+//!
+//! The grading path prepares one environment per SWE instance
+//! (`swe_bench::ensure_env` → `<swe cache>/envs/<instance>`), with the repo's
+//! era-pinned dependencies installed. A holder's work turn never named it, so
+//! she reached for whatever interpreter she could guess and re-installed the
+//! repo into it — measured 2026-09-07: twelve `pip install -e .` runs in one
+//! checkout, 21 acts, 0 edits. One fact per turn closes that: the interpreter
+//! when the env exists, and the honest absence when it does not.
+
+use std::path::{Path, PathBuf};
+
+/// The prepared environment's interpreter for the instance a checkout belongs
+/// to, if the grader has built one. The checkout's directory name IS the
+/// instance id (`…/swe/<instance>`), the same key `ensure_env` uses.
+pub fn instance_python(checkout: &Path) -> Option<PathBuf> {
+    let instance = checkout.file_name()?.to_str()?;
+    let env_dir = crate::cognition::swe_bench::swe_cache_dir()
+        .join("envs")
+        .join(instance);
+    env_python_in(&env_dir)
+}
+
+fn env_python_in(env_dir: &Path) -> Option<PathBuf> {
+    let unix = env_dir.join("bin").join("python");
+    if unix.is_file() {
+        return Some(unix);
+    }
+    let windows = env_dir.join("Scripts").join("python.exe");
+    windows.is_file().then_some(windows)
+}
+
+/// The fact line for her working memory. Never a guess: an env that exists is
+/// named by path; one that does not is said to be missing, with the one
+/// command that prepares it, so the turn does not open with an install.
+pub fn instance_env_fact(checkout: &Path) -> String {
+    match instance_python(checkout) {
+        Some(py) => format!(
+            "[env] This checkout's dependencies are installed in a prepared environment: \
+             run Python and tests with `{}` (e.g. `{} -m pytest <path>`). Do not pip-install \
+             the repo or its dependencies — they are already there.",
+            py.display(),
+            py.display()
+        ),
+        None => "[env] No prepared environment exists for this checkout yet — the grader \
+                 builds one at verdict time. Do not spend acts installing the repo; read and \
+                 edit the code, and run only what needs no installed dependencies."
+            .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// what this catches: the fact guessing an interpreter. A present env names
+    /// its python by path; an absent one is said to be absent and forbids the
+    /// install spiral — never a stand-in path.
+    #[test]
+    fn the_env_fact_names_the_interpreter_or_the_absence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let env = tmp.path().join("envs").join("django__django-1");
+        std::fs::create_dir_all(env.join("bin")).expect("mkdir");
+        std::fs::write(env.join("bin").join("python"), b"#!/bin/sh\n").expect("py");
+        let py = env_python_in(&env).expect("present env names its python");
+        assert!(py.ends_with("bin/python"));
+        assert!(env_python_in(&tmp.path().join("envs").join("absent")).is_none());
+        let absent = instance_env_fact(&tmp.path().join("swe").join("absent"));
+        assert!(absent.contains("No prepared environment"));
+        assert!(!absent.contains("swe-venv"), "never a guessed interpreter");
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -103,6 +103,7 @@ pub mod service_loop;
 pub mod presence_glyph;
 pub mod wake_backlog;
 pub mod work_burst;
+pub mod instance_env_fact;
 pub mod work_focus;
 pub mod work_pull;
 pub mod staged_workspace;


### PR DESCRIPTION
## The install spiral

Glass box 09:4xZ today: Atlas, 21 acts on one card, 12 of them `pip install --no-build-isolation -e .` (570 s each), 0 edits. The grader's prepared environment for her instance exists on this host (`swe_cache_dir()/envs/<instance>`, `ensure_env`), but nothing in her turn named it, so she guessed `/Users/joel/swe-venv/bin/python` and rebuilt the repo into it — every turn.

## Change
Beside the `[hands]` fact, a work turn records an `[env]` fact from `persona/instance_env_fact.rs`: the env's interpreter by path with "do not pip-install" when it exists; when it does not, the honest absence plus "read and edit; do not spend acts installing". The checkout's dir name is the instance id (same key as `ensure_env`). Windows `Scripts/python.exe` handled. Test covers present, absent, and never-a-guess.

## Not in this PR
Preparing the env at claim staging (the recipe's on_claim step) — a bigger change on the claim edge; this fact makes the existing env usable and stops the spiral where none exists.

## Acceptance
`cognition/trace` of a holder's work turn shows the `[env]` fact; `persona.act.observed` verbs for holders stop repeating `code/run(pip install …)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
