### PR TITLE
feat(persona): the write-or-release gate releases — at twice the gate the substrate hands the card back with a receipt

### DIFF
--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -224,6 +224,48 @@ pub(crate) async fn ask_the_act_question(
                             "the work turn is gated: edit now or release the card"
                         );
                     }
+                    // THE GOVERNOR. At twice the gate the substrate takes the second exit
+                    // for her: the card goes back on the deck with a receipt, a peer (or
+                    // she, with a plan) can take it, and her lane stops paying for
+                    // orientation. Review cards are not released (they carry no write).
+                    if crate::persona::work_burst::governor_releases(acts_without_write) {
+                        for c in &held {
+                            if crate::commands::benchmark::parse_review_title(&c.title).is_some() {
+                                continue;
+                            }
+                            let Some(claim_id) = c.claim_id.clone() else { continue };
+                            let id8: String = c.card_id.as_uuid().to_string().chars().take(8).collect();
+                            let reason = format!(
+                                "released by the substrate: {acts_without_write} acts without a write"
+                            );
+                            match citizen.release_card(c.card_id, claim_id, &reason).await {
+                                Ok(()) => {
+                                    crate::probe!(
+                                        class = "persona.work.released_by_governor",
+                                        persona = %ctx.identity.agent_name,
+                                        card = %id8,
+                                        acts_without_write,
+                                        "write-or-release at twice the gate: the substrate released the card"
+                                    );
+                                    if let Some(body) = cycle.acting() {
+                                        body.working_memory.record_fact(&format!(
+                                            "[released] The substrate released card {id8} after \
+                                             {acts_without_write} acts of mine without a change to a \
+                                             file — the investigation was long enough. A peer may take \
+                                             it. Pull it again only with a file:line edit in hand."
+                                        ));
+                                    }
+                                }
+                                Err(e) => crate::probe!(
+                                    class = "persona.work.governor_release_failed",
+                                    persona = %ctx.identity.agent_name,
+                                    card = %id8,
+                                    error = %e,
+                                    "the governor could not release the card — she keeps it this turn"
+                                ),
+                            }
+                        }
+                    }
                     let burst_text = crate::persona::work_burst::held_work_burst_gated(&held, &last_state, acts_without_write, &progress);
                     // The producer's CONTEXT half, kept before the burst is
                     // moved into the driver — one construction, so the

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -207,6 +207,18 @@ pub trait AircCitizen:
         Err("this citizen has no work-board write capability".to_string())
     }
 
+    /// Hand a held card back — the substrate's half of "write or release" (the
+    /// governor in `act_question`). Rides `work/release` as this citizen, the same
+    /// verb her own tool call would use. Default: no capability.
+    async fn release_card(
+        &self,
+        _card_id: airc_lib::WorkCardId,
+        _claim_id: airc_lib::ClaimId,
+        _reason: &str,
+    ) -> Result<(), String> {
+        Err("this citizen has no work-board write capability".to_string())
+    }
+
     /// The rooms this citizen is RESIDENT in (her durable subscription set). This is
     /// the pull-eligibility source: a card is content of the room it was posted in,
     /// and a resident may pull it — never a dispatch-time team or assignee list.

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1404,6 +1404,31 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
         .await
     }
 
+    async fn release_card(
+        &self,
+        card_id: airc_lib::WorkCardId,
+        claim_id: airc_lib::ClaimId,
+        reason: &str,
+    ) -> Result<(), String> {
+        // ONE release path, same as the claim: `work/release` as this citizen.
+        let Some(executor) = self.executor.as_ref() else {
+            return Err("no command executor installed on this runtime yet".to_string());
+        };
+        let caller = crate::routing::CallerIdentity::airc(crate::identity::PeerId::from_uuid(
+            self.persona_id,
+        ));
+        let params = serde_json::json!({
+            "card_id": card_id.as_uuid().to_string(),
+            "claim_id": claim_id.to_string(),
+            "reason": reason,
+        });
+        executor
+            .execute_with_caller("work/release", params, Some(caller))
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
     async fn claim_card(&self, card_id: airc_lib::WorkCardId) -> Result<bool, String> {
         // ONE claim path. The pull rides `work/claim` as this citizen — the same
         // verb her tool call would use — so the on-claim staging and the room's

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -12,6 +12,16 @@ use uuid::Uuid;
 /// followed from it).
 // context-budget-exempt: an act count, not a window or token budget
 pub(crate) const WRITE_OR_RELEASE_AFTER_ACTS: usize = 6;
+/// The substrate's own exit from "write or release": at twice the gate, the card
+/// is released FOR her, with a receipt. Measured 2026-09-07 11:30–12:20Z on
+/// 66ab948fc: the gate fired eight times across five holders, 78 acts, 0 writes,
+/// 0 releases — the sentence was read and not acted on. A governor acts.
+pub(crate) const GOVERNOR_RELEASE_AFTER_ACTS: usize = 2 * WRITE_OR_RELEASE_AFTER_ACTS;
+
+/// Whether the substrate releases the card this turn. Pure.
+pub(crate) fn governor_releases(acts_without_write: usize) -> bool {
+    acts_without_write >= GOVERNOR_RELEASE_AFTER_ACTS
+}
 
 /// Her acts since her last file change, counted from her own ⚙ receipts in the
 /// room (oldest → newest). A `code/edit` / `git_apply` / `edit_file` receipt resets
@@ -393,5 +403,20 @@ pub(crate) fn work_board_anchor(deliveries: &[crate::persona::rag_budget::RagDel
              Restating prior messages adds nothing; acting on a card would.",
             facts.join("; ")
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // what this catches: the governor firing under the gate (a nag becoming a release
+    // at six acts) or never (the sentence read and ignored forever). It releases at
+    // exactly twice the gate.
+    #[test]
+    fn the_governor_releases_at_twice_the_gate_and_not_before() {
+        assert!(!governor_releases(WRITE_OR_RELEASE_AFTER_ACTS));
+        assert!(!governor_releases(GOVERNOR_RELEASE_AFTER_ACTS - 1));
+        assert!(governor_releases(GOVERNOR_RELEASE_AFTER_ACTS));
+        assert!(governor_releases(GOVERNOR_RELEASE_AFTER_ACTS + 30));
     }
 }


### PR DESCRIPTION
## The gate fired eight times and nothing moved

11:30–12:20Z on 66ab948fc: 78 acts (49 runs), 0 writes, 0 releases, `persona.work.write_or_release_gate` ×8. The gate is a sentence in the burst; the holders read it and kept orienting.

## Change
At twice the gate (`GOVERNOR_RELEASE_AFTER_ACTS = 12` acts without a write) the substrate takes the second exit for her: `AircCitizen::release_card` (rides `work/release` as the citizen, mirroring `claim_card`), probe `persona.work.released_by_governor {persona, card, acts_without_write}`, and a working-memory fact naming the condition for the next pull. Review cards are skipped. Failure is a named probe and she keeps the card that turn.

## Acceptance
`persona.work.released_by_governor` rows appear; releases per hour > 0; cards held 12+ write-less acts stop existing; writes per hour rise or the deck turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
