### PR TITLE
fix(persona): the governor's [released] notice is pinned for one work turn, not recorded into the three-deep window

### DIFF
--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -147,7 +147,7 @@ pub(crate) const WM_FACULTY_ID: &str = "working-memory";
 #[derive(Debug)]
 /// A keyed working-memory fact with a lifetime in work turns.
 #[derive(Debug, Clone)]
-struct PinnedFact {
+struct TurnPinnedFact {
     key: String,
     text: String,
     turns_left: u8,
@@ -167,7 +167,7 @@ pub struct WorkingMemory {
     /// third act of a turn the rooting facts recorded at its start were gone
     /// (2026-09-07 11:46Z: four consecutive work turns with [investigation] and
     /// no [hands]/[env]). Cleared by key when the condition ends.
-    pinned: Mutex<Vec<PinnedFact>>,
+    pinned: Mutex<Vec<TurnPinnedFact>>,
     /// This mind's live served context window, in tokens — the source of every re-injection
     /// bound below. `0` = not yet known (cold boot / mid-relaunch), which means NO clipping:
     /// the deliberation guard still trims the assembled prompt to the real `n_ctx`, so an
@@ -695,7 +695,7 @@ impl WorkingMemory {
             slot.text = t.to_string();
             slot.turns_left = turns;
         } else {
-            p.push(PinnedFact { key: key.to_string(), text: t.to_string(), turns_left: turns });
+            p.push(TurnPinnedFact { key: key.to_string(), text: t.to_string(), turns_left: turns });
         }
     }
 

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -145,6 +145,14 @@ struct DispatchedAction {
 pub(crate) const WM_FACULTY_ID: &str = "working-memory";
 
 #[derive(Debug)]
+/// A keyed working-memory fact with a lifetime in work turns.
+#[derive(Debug, Clone)]
+struct PinnedFact {
+    key: String,
+    text: String,
+    turns_left: u8,
+}
+
 pub struct WorkingMemory {
     /// Process-unique construction ordinal. Purely diagnostic: lets any probe
     /// that renders from this instance say WHICH instance it is, so a duplicate
@@ -159,7 +167,7 @@ pub struct WorkingMemory {
     /// third act of a turn the rooting facts recorded at its start were gone
     /// (2026-09-07 11:46Z: four consecutive work turns with [investigation] and
     /// no [hands]/[env]). Cleared by key when the condition ends.
-    pinned: Mutex<Vec<(String, String)>>,
+    pinned: Mutex<Vec<PinnedFact>>,
     /// This mind's live served context window, in tokens — the source of every re-injection
     /// bound below. `0` = not yet known (cold boot / mid-relaunch), which means NO clipping:
     /// the deliberation guard still trims the assembled prompt to the real `n_ctx`, so an
@@ -667,26 +675,49 @@ impl WorkingMemory {
     /// (her hands' root, her checkout's environment) — `record_fact` is for
     /// one-off observations that may age out.
     pub fn pin_fact(&self, key: &str, text: &str) {
+        self.pin_fact_for_turns(key, text, 1);
+    }
+
+    /// Pin a keyed fact that outlives the turn it was made in: it survives
+    /// `turns` calls to [`end_of_work_turn`](Self::end_of_work_turn). A release
+    /// made during turn N must be read at the START of turn N+1 (the next pull
+    /// decision), so it is pinned with `turns = 2` — the releasing turn's end
+    /// takes one, the next turn's end takes the last (IntelMac's review of #3848:
+    /// pin and unpin in the same restore block is a no-op).
+    pub fn pin_fact_for_turns(&self, key: &str, text: &str, turns: u8) {
         let t = text.trim();
         if t.is_empty() {
             return;
         }
+        let turns = turns.max(1);
         let mut p = self.pinned.lock();
-        if let Some(slot) = p.iter_mut().find(|(k, _)| k == key) {
-            slot.1 = t.to_string();
+        if let Some(slot) = p.iter_mut().find(|f| f.key == key) {
+            slot.text = t.to_string();
+            slot.turns_left = turns;
         } else {
-            p.push((key.to_string(), t.to_string()));
+            p.push(PinnedFact { key: key.to_string(), text: t.to_string(), turns_left: turns });
         }
+    }
+
+    /// A work turn ended (her hands are home): every pin loses one turn; pins at
+    /// zero leave. Called once per work turn at the restore, so a 1-turn pin made
+    /// at rooting lives exactly that turn and a 2-turn pin reaches the next.
+    pub fn end_of_work_turn(&self) {
+        let mut p = self.pinned.lock();
+        for f in p.iter_mut() {
+            f.turns_left = f.turns_left.saturating_sub(1);
+        }
+        p.retain(|f| f.turns_left > 0);
     }
 
     /// The pinned facts in pin order — what the notices open with.
     pub fn pinned_facts(&self) -> Vec<String> {
-        self.pinned.lock().iter().map(|(_, t)| t.clone()).collect()
+        self.pinned.lock().iter().map(|f| f.text.clone()).collect()
     }
 
     /// Drop the pinned fact under `key` (the condition ended: hands restored).
     pub fn unpin_fact(&self, key: &str) {
-        self.pinned.lock().retain(|(k, _)| k != key);
+        self.pinned.lock().retain(|f| f.key != key);
     }
 
     pub fn record_fact(&self, fact: &str) {
@@ -2453,5 +2484,12 @@ mod tests {
         wm.unpin_fact("hands");
         wm.unpin_fact("env");
         assert!(wm.pinned_facts().is_empty());
+        // Turn lifetimes: a 1-turn pin dies at the first turn end, a 2-turn pin at the second.
+        wm.pin_fact("hands", "[hands] rooted at /c");
+        wm.pin_fact_for_turns("released", "[released] card x", 2);
+        wm.end_of_work_turn();
+        assert_eq!(wm.pinned_facts(), vec!["[released] card x".to_string()], "the release reaches the next turn");
+        wm.end_of_work_turn();
+        assert!(wm.pinned_facts().is_empty(), "and leaves after it");
     }
 }

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -144,7 +144,6 @@ struct DispatchedAction {
 /// capture tooling) matches on.
 pub(crate) const WM_FACULTY_ID: &str = "working-memory";
 
-#[derive(Debug)]
 /// A keyed working-memory fact with a lifetime in work turns.
 #[derive(Debug, Clone)]
 struct TurnPinnedFact {
@@ -153,6 +152,7 @@ struct TurnPinnedFact {
     turns_left: u8,
 }
 
+#[derive(Debug)]
 pub struct WorkingMemory {
     /// Process-unique construction ordinal. Purely diagnostic: lets any probe
     /// that renders from this instance say WHICH instance it is, so a duplicate

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -252,12 +252,12 @@ pub(crate) async fn ask_the_act_question(
                                         // gone by her third act; this one must reach her NEXT work
                                         // turn, where the pull decision is made. Unpinned at that
                                         // turn's restore (IntelMac's review of #3846).
-                                        body.working_memory.pin_fact("released", &format!(
+                                        body.working_memory.pin_fact_for_turns("released", &format!(
                                             "[released] The substrate released card {id8} after \
                                              {acts_without_write} acts of mine without a change to a \
                                              file — the investigation was long enough. A peer may take \
                                              it. Pull it again only with a file:line edit in hand."
-                                        ));
+                                        ), 2);
                                     }
                                 }
                                 Err(e) => crate::probe!(
@@ -436,12 +436,10 @@ pub(crate) async fn ask_the_act_question(
                         // Her hands are home again: the rooting facts no longer hold.
                         // The next work turn re-pins them at its own root.
                         if let Some(body) = cycle.acting() {
-                            body.working_memory.unpin_fact("hands");
-                            body.working_memory.unpin_fact("env");
-                            // A [released] notice lives for exactly one work turn after the
-                            // release: pinned during turn N, rendered at the start of turn N+1
-                            // (the next pull decision), dropped here at N+1's end.
-                            body.working_memory.unpin_fact("released");
+                            // One turn ended: 1-turn pins ([hands], [env]) leave now; the
+                            // governor's 2-turn [released] notice survives to the next work
+                            // turn's start — the pull decision — and leaves at its end.
+                            body.working_memory.end_of_work_turn();
                         }
                     }
                     let (work_step, _) =

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -248,7 +248,11 @@ pub(crate) async fn ask_the_act_question(
                                         "write-or-release at twice the gate: the substrate released the card"
                                     );
                                     if let Some(body) = cycle.acting() {
-                                        body.working_memory.record_fact(&format!(
+                                        // PINNED, like [hands]/[env] (#3845): a recorded fact is
+                                        // gone by her third act; this one must reach her NEXT work
+                                        // turn, where the pull decision is made. Unpinned at that
+                                        // turn's restore (IntelMac's review of #3846).
+                                        body.working_memory.pin_fact("released", &format!(
                                             "[released] The substrate released card {id8} after \
                                              {acts_without_write} acts of mine without a change to a \
                                              file — the investigation was long enough. A peer may take \
@@ -434,6 +438,10 @@ pub(crate) async fn ask_the_act_question(
                         if let Some(body) = cycle.acting() {
                             body.working_memory.unpin_fact("hands");
                             body.working_memory.unpin_fact("env");
+                            // A [released] notice lives for exactly one work turn after the
+                            // release: pinned during turn N, rendered at the start of turn N+1
+                            // (the next pull decision), dropped here at N+1's end.
+                            body.working_memory.unpin_fact("released");
                         }
                     }
                     let (work_step, _) =


### PR DESCRIPTION
## The governor's notice used the path #3845 retired

`record_fact` ages out of the three-deep working-memory window by the third act; the "[released] … pull it again only with a file:line edit in hand" notice from #3846 would never reach the next pull decision. Now `pin_fact("released", …)` at the release, `unpin_fact("released")` at the next work turn's restore — the notice lives for exactly the turn where it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
