### PR TITLE
fix(airc): the daemon socket re-resolves when the daemon moves — 1,216 silent capacity-publish failures, node invisible to the grid

### DIFF
--- a/core/continuum-core/src/airc/daemon_transport.rs
+++ b/core/continuum-core/src/airc/daemon_transport.rs
@@ -54,25 +54,74 @@ use crate::airc::realtime_wire::{
     body_for_envelope, envelope_from_event, frame_kind_for_delivery, headers_for_envelope,
 };
 
+/// Why a daemon RPC failed, in the ONE distinction callers act on:
+/// could we reach the daemon at all?
+///
+/// This exists because the answer must survive our boundary as a TYPE.
+/// `airc_ipc::ClientError` already says it precisely (`NotConnected`),
+/// and we used to discard that by stringifying at the trait edge — which
+/// left the recovery path in `ReresolvingDaemonClient` matching a
+/// SUBSTRING of a message produced by a separately versioned binary.
+/// airc ships on its own cadence; a reword there would silently disable
+/// the re-resolve and re-open #3849 with every test in both repos still
+/// green ([[strong-typing-across-boundaries]]: match the variant, never
+/// substring a stringified enum). Classification now happens here, where
+/// the typed error still exists.
+#[derive(Debug)]
+pub enum DaemonCallError {
+    /// The daemon could not be reached at the socket path we hold —
+    /// it is not running, or it moved. The one condition that justifies
+    /// re-resolving the socket.
+    Unreachable(String),
+    /// Any other failure. The daemon IS answering, so re-resolving would
+    /// only hide a real fault.
+    Other(String),
+}
+
+impl std::fmt::Display for DaemonCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable(message) | Self::Other(message) => f.write_str(message),
+        }
+    }
+}
+
+impl From<airc_ipc::ClientError> for DaemonCallError {
+    fn from(error: airc_ipc::ClientError) -> Self {
+        let message = error.to_string();
+        match error {
+            // "Couldn't connect to the socket — daemon not running."
+            airc_ipc::ClientError::NotConnected(_) => Self::Unreachable(message),
+            _ => Self::Other(message),
+        }
+    }
+}
+
 #[async_trait]
 pub trait AircDaemonClient: Send + Sync {
-    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String>;
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, DaemonCallError>;
 
-    async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String>;
+    async fn inbox(
+        &self,
+        request: InboxRequest,
+    ) -> Result<airc_ipc::InboxResponse, DaemonCallError>;
 }
 
 #[async_trait]
 impl AircDaemonClient for DaemonClient {
-    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, DaemonCallError> {
         DaemonClient::publish(self, request)
             .await
-            .map_err(|error| error.to_string())
+            .map_err(DaemonCallError::from)
     }
 
-    async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String> {
+    async fn inbox(
+        &self,
+        request: InboxRequest,
+    ) -> Result<airc_ipc::InboxResponse, DaemonCallError> {
         DaemonClient::inbox(self, request)
             .await
-            .map_err(|error| error.to_string())
+            .map_err(DaemonCallError::from)
     }
 }
 
@@ -146,7 +195,8 @@ impl AircEventTransport for DaemonAircEventTransport {
                 payload,
                 headers: headers_for_envelope(&envelope),
             })
-            .await?;
+            .await
+            .map_err(|error| error.to_string())?;
 
         Ok(AircRealtimePublishResult {
             ok: true,
@@ -190,7 +240,8 @@ impl AircEventTransport for DaemonAircEventTransport {
                 // persona/airc_source.rs (#297).
                 kinds: None,
             })
-            .await?;
+            .await
+            .map_err(|error| error.to_string())?;
 
         // IpcCursor → TranscriptCursor via the airc#1096 From impl.
         let newest = response.newest.map(|cursor| {
@@ -274,7 +325,10 @@ mod tests {
 
     #[async_trait]
     impl AircDaemonClient for FakeDaemonClient {
-        async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+        async fn publish(
+            &self,
+            request: PublishRequest,
+        ) -> Result<PublishResponse, DaemonCallError> {
             self.publishes.lock().push(request);
             Ok(PublishResponse {
                 event_id: EventId::from_u128(0xfeed),
@@ -285,7 +339,10 @@ mod tests {
             })
         }
 
-        async fn inbox(&self, request: InboxRequest) -> Result<airc_ipc::InboxResponse, String> {
+        async fn inbox(
+            &self,
+            request: InboxRequest,
+        ) -> Result<airc_ipc::InboxResponse, DaemonCallError> {
             self.inbox_requests.lock().push(request);
             Ok(airc_ipc::InboxResponse {
                 envelopes: Vec::new(), // empty: we test cursor/request shape, not decode

--- a/core/continuum-core/src/airc/mod.rs
+++ b/core/continuum-core/src/airc/mod.rs
@@ -9,6 +9,7 @@ pub mod client;
 pub mod daemon_endpoint;
 pub mod daemon_transport;
 pub mod discovery;
+pub mod reresolving_client;
 pub mod discovery_aggregate;
 pub mod discovery_state;
 pub mod event_transport;
@@ -30,6 +31,7 @@ pub use client::{AircQueueClient, CliAircQueueClient};
 #[allow(deprecated)]
 pub use daemon_endpoint::default_socket_path_in;
 pub use daemon_transport::{AircDaemonClient, DaemonAircEventTransport};
+pub use reresolving_client::{DaemonSocketResolver, ReresolvingDaemonClient};
 pub use discovery::{
     discover_airc_socket, discover_default_channel, discover_default_room_name, discover_peer_id,
     DiscoveryError,

--- a/core/continuum-core/src/airc/reresolving_client.rs
+++ b/core/continuum-core/src/airc/reresolving_client.rs
@@ -1,0 +1,286 @@
+//! A daemon client that re-resolves the airc socket when the daemon moves.
+//!
+//! ### The defect this closes (#3849)
+//!
+//! The daemon socket was resolved exactly ONCE, at boot, by
+//! [`crate::airc::discover_airc_socket`]. `DaemonClient` holds only a
+//! path and dials FRESH on every call, so there is no stale connection
+//! to blame — but if the daemon was not reachable at that single boot
+//! moment, the core kept a path that never worked again for the whole
+//! process lifetime.
+//!
+//! Measured on BigMama 2026-09-07: the airc daemon died overnight, the
+//! core booted without it, and `grid-capacity` offer publishing then
+//! failed 1,216 CONSECUTIVE times over seven hours — including the five
+//! hours the daemon was back up and its pipe verifiably accepted
+//! connections. The node was not idle, it was UNADVERTISED: no capacity
+//! offer reaches the grid, so no work is routed to it, while every
+//! health surface reads fine. Restarting the core with the daemon live
+//! took the failure rate to zero.
+//!
+//! ### Why this is not a fallback ([[no-fallbacks-ever]])
+//!
+//! `modules::airc::from_discovery` refuses to build a daemon transport
+//! against state discovery has declared not-Healthy, precisely so the
+//! substrate never "looks healthy" against a stale socket. This wrapper
+//! does NOT reintroduce that: it never guesses a path and never
+//! substitutes a degraded stand-in. On an unreachable error it re-asks
+//! the SAME authoritative source discovery used (`airc ipc-endpoint`)
+//! and retries once. If that re-ask fails, the original error is
+//! returned with the re-resolution failure appended — loud, not masked.
+//! Errors that are not reachability failures are returned untouched and
+//! never trigger a re-resolve.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use airc_ipc::{DaemonClient, InboxRequest, InboxResponse, PublishRequest, PublishResponse};
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::airc::daemon_transport::AircDaemonClient;
+
+/// Resolves the airc daemon's current socket path.
+///
+/// Exists so the retry path is testable without shelling out to
+/// `airc ipc-endpoint`.
+#[async_trait]
+pub trait DaemonSocketResolver: Send + Sync {
+    async fn resolve(&self) -> Result<PathBuf, String>;
+}
+
+/// Production resolver — asks airc itself, the same authoritative
+/// source boot discovery uses. Never derives a path locally.
+pub struct DiscoverySocketResolver;
+
+#[async_trait]
+impl DaemonSocketResolver for DiscoverySocketResolver {
+    async fn resolve(&self) -> Result<PathBuf, String> {
+        crate::airc::discover_airc_socket()
+            .await
+            .map_err(|error| error.to_string())
+    }
+}
+
+/// Builds a client for a freshly resolved socket path.
+pub type DaemonClientFactory = fn(PathBuf) -> Arc<dyn AircDaemonClient>;
+
+/// The production factory: a real `airc_ipc::DaemonClient`.
+pub fn live_daemon_client(socket: PathBuf) -> Arc<dyn AircDaemonClient> {
+    Arc::new(DaemonClient::new(socket))
+}
+
+/// Wraps a daemon client so a reachability failure re-resolves the
+/// socket and retries once, instead of failing forever.
+pub struct ReresolvingDaemonClient {
+    current: RwLock<Arc<dyn AircDaemonClient>>,
+    resolver: Arc<dyn DaemonSocketResolver>,
+    factory: DaemonClientFactory,
+}
+
+impl ReresolvingDaemonClient {
+    pub fn new(
+        socket: PathBuf,
+        resolver: Arc<dyn DaemonSocketResolver>,
+        factory: DaemonClientFactory,
+    ) -> Self {
+        Self {
+            current: RwLock::new(factory(socket)),
+            resolver,
+            factory,
+        }
+    }
+
+    /// The wiring used at boot: a real daemon client that re-resolves
+    /// through `airc ipc-endpoint`.
+    pub fn against_live_daemon(socket: PathBuf) -> Self {
+        Self::new(socket, Arc::new(DiscoverySocketResolver), live_daemon_client)
+    }
+
+    /// A reachability failure is the ONE condition that justifies
+    /// re-resolving: the daemon we were told about is not answering at
+    /// that path. Every other error (a rejected publish, a protocol
+    /// error) means the daemon IS there and re-resolving would only
+    /// hide a real fault.
+    fn is_unreachable(error: &str) -> bool {
+        error.contains("not reachable")
+    }
+
+    async fn snapshot(&self) -> Arc<dyn AircDaemonClient> {
+        self.current.read().await.clone()
+    }
+
+    async fn reresolve(&self, original: &str) -> Result<Arc<dyn AircDaemonClient>, String> {
+        let socket = self
+            .resolver
+            .resolve()
+            .await
+            .map_err(|error| format!("{original}; re-resolving the daemon socket failed: {error}"))?;
+        let fresh = (self.factory)(socket);
+        *self.current.write().await = fresh.clone();
+        Ok(fresh)
+    }
+}
+
+#[async_trait]
+impl AircDaemonClient for ReresolvingDaemonClient {
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+        match self.snapshot().await.publish(request.clone()).await {
+            Err(error) if Self::is_unreachable(&error) => {
+                self.reresolve(&error).await?.publish(request).await
+            }
+            outcome => outcome,
+        }
+    }
+
+    async fn inbox(&self, request: InboxRequest) -> Result<InboxResponse, String> {
+        match self.snapshot().await.inbox(request.clone()).await {
+            Err(error) if Self::is_unreachable(&error) => {
+                self.reresolve(&error).await?.inbox(request).await
+            }
+            outcome => outcome,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const UNREACHABLE: &str =
+        "daemon not reachable: The system cannot find the file specified. (os error 2)";
+    /// The re-resolved client answers with a sentinel rather than a real
+    /// `InboxResponse`: what these tests assert is WHICH client served
+    /// the call, and a sentinel proves that without fabricating a wire
+    /// response whose shape is airc's to define, not ours.
+    const SECOND_CLIENT: &str = "reached the re-resolved client";
+
+    struct Canned(&'static str);
+
+    #[async_trait]
+    impl AircDaemonClient for Canned {
+        async fn publish(&self, _: PublishRequest) -> Result<PublishResponse, String> {
+            Err(self.0.to_string())
+        }
+        async fn inbox(&self, _: InboxRequest) -> Result<InboxResponse, String> {
+            Err(self.0.to_string())
+        }
+    }
+
+    /// Maps a resolved path to a client, so a test can say "after
+    /// re-resolution the daemon is at a different path" without a
+    /// stateful factory (the factory is a plain `fn`).
+    fn factory(path: PathBuf) -> Arc<dyn AircDaemonClient> {
+        if path.ends_with("moved.sock") {
+            Arc::new(Canned(SECOND_CLIENT))
+        } else if path.ends_with("rejects.sock") {
+            Arc::new(Canned("publish rejected: not a member of that channel"))
+        } else {
+            Arc::new(Canned(UNREACHABLE))
+        }
+    }
+
+    struct Resolver {
+        calls: AtomicUsize,
+        answer: Result<&'static str, &'static str>,
+    }
+
+    impl Resolver {
+        fn ok() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                answer: Ok("moved.sock"),
+            })
+        }
+        fn failing() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                answer: Err("`airc ipc-endpoint` did not exit within 2s"),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl DaemonSocketResolver for Resolver {
+        async fn resolve(&self) -> Result<PathBuf, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.answer
+                .map(PathBuf::from)
+                .map_err(|error| error.to_string())
+        }
+    }
+
+    fn request() -> InboxRequest {
+        InboxRequest {
+            since: None,
+            channel: None,
+            limit: None,
+            kinds: None,
+        }
+    }
+
+    // what this catches: regression for #3849 — the boot-resolved socket
+    // was kept for the process lifetime, so a daemon restart meant every
+    // subsequent call failed FOREVER (1,216 consecutive capacity-publish
+    // failures over 7h while the daemon was up and connectable). An
+    // unreachable error must re-resolve and retry against the new path.
+    #[tokio::test]
+    async fn an_unreachable_daemon_re_resolves_and_retries_once() {
+        let resolver = Resolver::ok();
+        let client =
+            ReresolvingDaemonClient::new("dead.sock".into(), resolver.clone(), factory);
+
+        let outcome = client.inbox(request()).await;
+
+        assert_eq!(outcome.unwrap_err(), SECOND_CLIENT, "retry must use the re-resolved client");
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 1, "exactly one re-resolve");
+    }
+
+    // what this catches: re-resolving on ANY error would mask real faults
+    // (a rejected publish means the daemon IS answering). Only
+    // reachability failures may re-resolve.
+    #[tokio::test]
+    async fn a_non_reachability_error_never_re_resolves() {
+        let resolver = Resolver::ok();
+        let client =
+            ReresolvingDaemonClient::new("rejects.sock".into(), resolver.clone(), factory);
+
+        let outcome = client.inbox(request()).await;
+
+        assert!(outcome.unwrap_err().contains("not a member"), "original error surfaces");
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 0, "no re-resolve attempted");
+    }
+
+    // what this catches: [[no-fallbacks-ever]] — when re-resolution
+    // itself fails the caller must see BOTH the original reachability
+    // failure and why the re-ask failed, never a masked success or a
+    // lone generic error.
+    #[tokio::test]
+    async fn a_failed_re_resolution_reports_both_causes() {
+        let resolver = Resolver::failing();
+        let client =
+            ReresolvingDaemonClient::new("dead.sock".into(), resolver.clone(), factory);
+
+        let error = client.inbox(request()).await.unwrap_err();
+
+        assert!(error.contains("not reachable"), "original cause kept: {error}");
+        assert!(error.contains("ipc-endpoint"), "re-resolution cause kept: {error}");
+    }
+
+    // what this catches: the second call must use the client cached by
+    // the first re-resolution rather than re-resolving every time — the
+    // retry is a repair, not a per-call discovery shell-out.
+    #[tokio::test]
+    async fn a_repaired_client_is_reused_by_later_calls() {
+        let resolver = Resolver::ok();
+        let client =
+            ReresolvingDaemonClient::new("dead.sock".into(), resolver.clone(), factory);
+
+        let _ = client.inbox(request()).await;
+        let second = client.inbox(request()).await;
+
+        assert_eq!(second.unwrap_err(), SECOND_CLIENT);
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 1, "no second re-resolve");
+    }
+}

--- a/core/continuum-core/src/airc/reresolving_client.rs
+++ b/core/continuum-core/src/airc/reresolving_client.rs
@@ -30,6 +30,14 @@
 //! returned with the re-resolution failure appended — loud, not masked.
 //! Errors that are not reachability failures are returned untouched and
 //! never trigger a re-resolve.
+//!
+//! Reachability is decided by MATCHING [`DaemonCallError::Unreachable`],
+//! a variant classified where `airc_ipc::ClientError` is still typed —
+//! never by substring-matching a message. airc ships on its own cadence,
+//! so a reworded string would otherwise silently disable this recovery
+//! and re-open #3849 with every test in both repos still green
+//! ([[strong-typing-across-boundaries]]). Reviewed by IntelMac on #3850,
+//! who caught exactly that door being left open.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -38,7 +46,7 @@ use airc_ipc::{DaemonClient, InboxRequest, InboxResponse, PublishRequest, Publis
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
-use crate::airc::daemon_transport::AircDaemonClient;
+use crate::airc::daemon_transport::{AircDaemonClient, DaemonCallError};
 
 /// Resolves the airc daemon's current socket path.
 ///
@@ -97,25 +105,19 @@ impl ReresolvingDaemonClient {
         Self::new(socket, Arc::new(DiscoverySocketResolver), live_daemon_client)
     }
 
-    /// A reachability failure is the ONE condition that justifies
-    /// re-resolving: the daemon we were told about is not answering at
-    /// that path. Every other error (a rejected publish, a protocol
-    /// error) means the daemon IS there and re-resolving would only
-    /// hide a real fault.
-    fn is_unreachable(error: &str) -> bool {
-        error.contains("not reachable")
-    }
-
     async fn snapshot(&self) -> Arc<dyn AircDaemonClient> {
         self.current.read().await.clone()
     }
 
-    async fn reresolve(&self, original: &str) -> Result<Arc<dyn AircDaemonClient>, String> {
-        let socket = self
-            .resolver
-            .resolve()
-            .await
-            .map_err(|error| format!("{original}; re-resolving the daemon socket failed: {error}"))?;
+    async fn reresolve(
+        &self,
+        original: &str,
+    ) -> Result<Arc<dyn AircDaemonClient>, DaemonCallError> {
+        let socket = self.resolver.resolve().await.map_err(|error| {
+            DaemonCallError::Other(format!(
+                "{original}; re-resolving the daemon socket failed: {error}"
+            ))
+        })?;
         let fresh = (self.factory)(socket);
         *self.current.write().await = fresh.clone();
         Ok(fresh)
@@ -124,19 +126,22 @@ impl ReresolvingDaemonClient {
 
 #[async_trait]
 impl AircDaemonClient for ReresolvingDaemonClient {
-    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, String> {
+    async fn publish(&self, request: PublishRequest) -> Result<PublishResponse, DaemonCallError> {
         match self.snapshot().await.publish(request.clone()).await {
-            Err(error) if Self::is_unreachable(&error) => {
-                self.reresolve(&error).await?.publish(request).await
+            Err(DaemonCallError::Unreachable(cause)) => {
+                self.reresolve(&cause).await?.publish(request).await
             }
             outcome => outcome,
         }
     }
 
-    async fn inbox(&self, request: InboxRequest) -> Result<InboxResponse, String> {
+    async fn inbox(
+        &self,
+        request: InboxRequest,
+    ) -> Result<InboxResponse, DaemonCallError> {
         match self.snapshot().await.inbox(request.clone()).await {
-            Err(error) if Self::is_unreachable(&error) => {
-                self.reresolve(&error).await?.inbox(request).await
+            Err(DaemonCallError::Unreachable(cause)) => {
+                self.reresolve(&cause).await?.inbox(request).await
             }
             outcome => outcome,
         }
@@ -156,15 +161,28 @@ mod tests {
     /// response whose shape is airc's to define, not ours.
     const SECOND_CLIENT: &str = "reached the re-resolved client";
 
-    struct Canned(&'static str);
+    struct Canned {
+        unreachable: bool,
+        message: &'static str,
+    }
+
+    impl Canned {
+        fn error(&self) -> DaemonCallError {
+            if self.unreachable {
+                DaemonCallError::Unreachable(self.message.to_string())
+            } else {
+                DaemonCallError::Other(self.message.to_string())
+            }
+        }
+    }
 
     #[async_trait]
     impl AircDaemonClient for Canned {
-        async fn publish(&self, _: PublishRequest) -> Result<PublishResponse, String> {
-            Err(self.0.to_string())
+        async fn publish(&self, _: PublishRequest) -> Result<PublishResponse, DaemonCallError> {
+            Err(self.error())
         }
-        async fn inbox(&self, _: InboxRequest) -> Result<InboxResponse, String> {
-            Err(self.0.to_string())
+        async fn inbox(&self, _: InboxRequest) -> Result<InboxResponse, DaemonCallError> {
+            Err(self.error())
         }
     }
 
@@ -173,11 +191,20 @@ mod tests {
     /// stateful factory (the factory is a plain `fn`).
     fn factory(path: PathBuf) -> Arc<dyn AircDaemonClient> {
         if path.ends_with("moved.sock") {
-            Arc::new(Canned(SECOND_CLIENT))
+            Arc::new(Canned {
+                unreachable: false,
+                message: SECOND_CLIENT,
+            })
         } else if path.ends_with("rejects.sock") {
-            Arc::new(Canned("publish rejected: not a member of that channel"))
+            Arc::new(Canned {
+                unreachable: false,
+                message: "publish rejected: not a member of that channel",
+            })
         } else {
-            Arc::new(Canned(UNREACHABLE))
+            Arc::new(Canned {
+                unreachable: true,
+                message: UNREACHABLE,
+            })
         }
     }
 
@@ -233,7 +260,11 @@ mod tests {
 
         let outcome = client.inbox(request()).await;
 
-        assert_eq!(outcome.unwrap_err(), SECOND_CLIENT, "retry must use the re-resolved client");
+        assert_eq!(
+            outcome.unwrap_err().to_string(),
+            SECOND_CLIENT,
+            "retry must use the re-resolved client"
+        );
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 1, "exactly one re-resolve");
     }
 
@@ -248,7 +279,10 @@ mod tests {
 
         let outcome = client.inbox(request()).await;
 
-        assert!(outcome.unwrap_err().contains("not a member"), "original error surfaces");
+        assert!(
+            outcome.unwrap_err().to_string().contains("not a member"),
+            "original error surfaces"
+        );
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 0, "no re-resolve attempted");
     }
 
@@ -262,10 +296,33 @@ mod tests {
         let client =
             ReresolvingDaemonClient::new("dead.sock".into(), resolver.clone(), factory);
 
-        let error = client.inbox(request()).await.unwrap_err();
+        let error = client.inbox(request()).await.unwrap_err().to_string();
 
         assert!(error.contains("not reachable"), "original cause kept: {error}");
         assert!(error.contains("ipc-endpoint"), "re-resolution cause kept: {error}");
+    }
+
+    // what this catches: IntelMac's #3850 review — the recovery must be
+    // keyed to what the REAL client produces, not to this crate's copy of
+    // a message. It exercises `airc_ipc::DaemonClient` against a socket
+    // that does not exist and asserts the error classifies as
+    // `Unreachable`. If airc ever changes how an absent daemon surfaces
+    // (a new ClientError variant, a different io error path), this goes
+    // red HERE instead of silently disabling the re-resolve in production
+    // and re-opening #3849 with every other test still green.
+    #[tokio::test]
+    async fn the_real_clients_absent_daemon_error_classifies_as_unreachable() {
+        let absent = std::env::temp_dir().join("continuum-3849-no-such-airc-socket.sock");
+        let real = DaemonClient::new(absent);
+
+        let error = AircDaemonClient::inbox(&real, request())
+            .await
+            .expect_err("dialing an absent daemon must fail");
+
+        assert!(
+            matches!(error, DaemonCallError::Unreachable(_)),
+            "airc's absent-daemon error must classify as Unreachable, got: {error}"
+        );
     }
 
     // what this catches: the second call must use the client cached by
@@ -280,7 +337,7 @@ mod tests {
         let _ = client.inbox(request()).await;
         let second = client.inbox(request()).await;
 
-        assert_eq!(second.unwrap_err(), SECOND_CLIENT);
+        assert_eq!(second.unwrap_err().to_string(), SECOND_CLIENT);
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 1, "no second re-resolve");
     }
 }

--- a/core/continuum-core/src/modules/airc.rs
+++ b/core/continuum-core/src/modules/airc.rs
@@ -91,8 +91,15 @@ impl AircModule {
                 let from_client = uuid::Uuid::new_v4();
                 Self {
                     queue_client: Arc::new(CliAircQueueClient::new(TokioAircCommandRunner)),
+                    // #3849: the socket is re-resolved when the daemon
+                    // moves. Boot-once resolution meant a daemon restart
+                    // left this path dead for the whole process lifetime
+                    // — the node kept running while silently advertising
+                    // nothing to the grid.
                     event_transport: Arc::new(DaemonAircEventTransport::with_identity(
-                        Arc::new(airc_ipc::DaemonClient::new(socket.clone())),
+                        Arc::new(crate::airc::ReresolvingDaemonClient::against_live_daemon(
+                            socket.clone(),
+                        )),
                         *peer_id,
                         from_client,
                     )),


### PR DESCRIPTION
Closes #3849.

## What was wrong

The airc daemon socket was resolved exactly **once, at boot**
(`ipc/mod.rs:2201` → `AircModule::from_discovery` → `discover_airc_socket()`).
It was never re-resolved.

`DaemonClient` holds only a path and dials **fresh on every call**
(`airc-ipc/src/client.rs:112`), so there is no stale connection to blame — which is
exactly why this was hard to see. If the daemon was not reachable at that single boot
moment, the core kept a dead path for the whole process lifetime.

## What it cost, measured

On BigMama today the daemon died overnight and the core booted without it:

```
grid-capacity offer publish failed: airc/realtime-publish:
  [internal] daemon not reachable: The system cannot find the file specified. (os error 2)
```

**1,216 consecutive failures over seven hours** (05:52–12:39Z), straddling a core
reboot and two daemon restarts — including the five hours the daemon was back up and
its named pipe verifiably accepted connections while `airc ping` returned `pong`.

The node was **not idle — it was unadvertised.** No capacity offer reaches the grid,
so no work is routed to it. GPU at 1% with 27.4 GB resident, and every health surface
reading fine.

Restarting the core with the daemon already live took `tick.error` from ~3/min to
**0**, `airc.cursor.advanced` began flowing, and `inference.prefill.complete` went
from 0-for-an-hour to 16 per 5 min. That restart is what identified boot-once
resolution as the cause rather than anything about the daemon itself.

## The change

`ReresolvingDaemonClient` wraps the daemon client. On a reachability failure it
re-asks the **same authoritative source discovery uses** (`airc ipc-endpoint`) and
retries once, caching the repaired client so later calls do not re-resolve.

## Why this is not the fallback `from_discovery` forbids

That method's docs are explicit that `Degraded` must never construct a real transport
against a stale socket, because the substrate then "looks healthy" while every publish
fails — the [[no-fallbacks-ever]] pattern. This wrapper does not reintroduce it:

- it never derives a path locally and never substitutes a degraded stand-in
- non-reachability errors (a rejected publish — the daemon *is* answering) are
  returned untouched and never trigger a re-resolve
- when the re-ask itself fails, **both** causes are surfaced, never masked

## Tests

Four, one per behaviour that can regress: retry after re-resolution; no re-resolve on
an unrelated error; both causes reported when the re-ask fails; repaired client reused
rather than re-resolved per call.

## Not addressed here

`from_discovery`'s `Degraded | Unreachable` arm falls back to an in-memory
`StoreAircEventTransport`, whose `publish` returns `Ok` into a local store. In that
state a node believes it is advertising capacity while the grid cannot see it, with no
error at all — the silent version of this same bug. I verified this reading
`event_transport.rs:43-49`; note the module doc's claim that downstream "return an
actionable error" is not what that path does today. Left for a separate change since
it is a behavioural decision about what a not-Healthy node should do, not a bug fix.

## Validation

`cargo check -p continuum-core --lib --tests --features test-fixtures` — clean (CI's
exact invocation). `cargo test -p continuum-core --lib reresolving_client` — 4 passed.
Both exit codes read from cargo itself, not from a pipe.
