### PR TITLE
fix(benchmark): the verdict sweep runs on the module tick and names why a card is ungradeable

### DIFF
--- a/core/continuum-core/src/cognition/swe_verdict_sweep.rs
+++ b/core/continuum-core/src/cognition/swe_verdict_sweep.rs
@@ -154,6 +154,36 @@ pub struct SweepReport {
 /// suite; N of those in parallel would compete with the citizens' own serving lane for the
 /// machine the round is being measured on ([[measured-work-gets-an-exclusive-warm-slot]]).
 /// The sweep is background work that must never become the reason a turn is slow.
+/// Whether a tick starts a sweep: something is pending and no sweep is already
+/// running. Pure — the tick's only decision. Before this the sweep ran ONCE, at
+/// module initialize, so a citizen's finished card waited for the next reboot
+/// to be graded (2026-09-07: sympy-22456 was graded by the 14:13Z boot's sweep,
+/// hours after the work).
+pub fn should_start_sweep(pending: usize, in_flight: bool) -> bool {
+    pending > 0 && !in_flight
+}
+
+/// One sweep at a time across ticks and boots.
+pub static SWEEP_IN_FLIGHT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// The tick's entry: start a sweep in its own task when one is due. Returns
+/// whether one was started.
+pub fn sweep_if_due() -> bool {
+    use std::sync::atomic::Ordering;
+    let due = should_start_sweep(pending().len(), SWEEP_IN_FLIGHT.load(Ordering::Relaxed));
+    if !due {
+        return false;
+    }
+    if SWEEP_IN_FLIGHT.swap(true, Ordering::AcqRel) {
+        return false;
+    }
+    tokio::spawn(async {
+        let _report = sweep().await;
+        SWEEP_IN_FLIGHT.store(false, Ordering::Release);
+    });
+    true
+}
+
 pub async fn sweep() -> SweepReport {
     let mut report = SweepReport::default();
     let work = pending();
@@ -179,9 +209,22 @@ pub async fn sweep() -> SweepReport {
         match crate::commands::benchmark::grade_swe(params).await {
             Ok(result) if result.error.is_some() => {
                 report.ungradeable += 1;
+                // The REASON rides the row. 2026-09-07: 58 of these in six hours said
+                // "environment fault" and nothing else — 13346 (f2p passes on the
+                // pristine tree) and 14983 (the era env cannot build) were only told
+                // apart by hand grades. A reason a reader can histogram is the
+                // difference between one env fix and twenty-five mysteries.
+                let reason: String = result
+                    .error
+                    .as_deref()
+                    .unwrap_or("")  // unwrap_or: guarded by the arm — error is Some here
+                    .chars()
+                    .take(160)
+                    .collect();
                 crate::probe!(
                     class = "benchmark.verdict.sweep_ungradeable",
                     instance = item.instance.as_str(),
+                    reason = %reason,
                     "environment fault, NOT a capability zero — nothing recorded",
                 );
             }
@@ -261,5 +304,15 @@ mod tests {
                  idempotence must not depend on the workspace still being dirty"
             );
         }
+    }
+
+    // what this catches: a sweep that never runs between boots, or two sweeps
+    // grading the same instance at once. The tick starts one only when work is
+    // pending and none is in flight.
+    #[test]
+    fn a_tick_starts_a_sweep_only_when_pending_and_idle() {
+        assert!(!should_start_sweep(0, false));
+        assert!(!should_start_sweep(3, true));
+        assert!(should_start_sweep(1, false));
     }
 }

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -72,6 +72,15 @@ impl ServiceModule for BenchmarkGradeModule {
     }
 
     async fn tick(&self) -> Result<(), String> {
+        // Finished work is graded on the tick, not at the next boot: the verdict
+        // sweep starts here when something is pending and none is in flight
+        // (one sweep at a time; it scans directories, then grades serially).
+        if crate::cognition::swe_verdict_sweep::sweep_if_due() {
+            crate::probe!(
+                class = "benchmark.verdict.sweep_started_by_tick",
+                "pending citizen work found on the tick — grading now, not at the next boot"
+            );
+        }
         sweep_lapsed_bench_cards(&self.registry).await
     }
 


### PR DESCRIPTION
## Finished work waited for a reboot to be graded, and the refusal had no reason

Card d5f4f445. `swe_verdict_sweep::sweep()` ran once at module initialize; today's sympy-22456 resolve was written by the 14:13Z boot sweep, hours after the work. The `sweep_ungradeable` row carried only the instance: 58 rows in six hours read "environment fault", and telling 13346 (f2p passes pristine) from 14983 (env cannot build) took two hand grades.

## Change
- `sweep_if_due()` on the 180 s tick: starts a sweep when `pending()` is non-empty and none is in flight (`SWEEP_IN_FLIGHT`), in its own task; probe `benchmark.verdict.sweep_started_by_tick`.
- `sweep_ungradeable` carries `reason` (the grader's error, 160 chars).
- Pure `should_start_sweep` + test.

## Acceptance
A citizen's `done` on a card with a diff → a verdict file within ~3–10 min without a reboot; `ledger_tail.py benchmark.verdict.sweep_ungradeable` rows histogram by reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
