### PR TITLE
fix(benchmark): when two citizens worked one instance the sweep grades the newest work, not neither

### DIFF
--- a/core/continuum-core/src/cognition/swe_verdict_sweep.rs
+++ b/core/continuum-core/src/cognition/swe_verdict_sweep.rs
@@ -124,8 +124,24 @@ pub fn pending() -> Vec<PendingGrade> {
         if has_verdict {
             continue;
         }
-        match decide(false, grade_target(&owners_of(&instance))) {
-            SweepDecision::Grade(workspace) => out.push(PendingGrade { instance, workspace }),
+        let copies = owners_of(&instance);
+        let worked = copies.iter().filter(|c| c.has_work).count();
+        match decide(false, grade_target(&copies)) {
+            SweepDecision::Grade(workspace) => {
+                if worked > 1 {
+                    // The newest of several worked copies was chosen (a card that
+                    // changed hands). Named, so a wrong pick is visible in the
+                    // ledger beside the verdict it produced (IntelMac, #3852).
+                    crate::probe!(
+                        class = "benchmark.verdict.sweep_chose_newest",
+                        instance = instance.as_str(),
+                        chosen = %workspace.display(),
+                        worked_copies = worked as u64,
+                        "several citizens worked this instance — grading the newest work"
+                    );
+                }
+                out.push(PendingGrade { instance, workspace })
+            }
             SweepDecision::Ambiguous(paths) => crate::probe!(
                 class = "benchmark.verdict.sweep_ambiguous",
                 instance = instance.as_str(),

--- a/core/continuum-core/src/cognition/swe_verdict_sweep.rs
+++ b/core/continuum-core/src/cognition/swe_verdict_sweep.rs
@@ -130,14 +130,21 @@ pub fn pending() -> Vec<PendingGrade> {
             SweepDecision::Grade(workspace) => {
                 if worked > 1 {
                     // The newest of several worked copies was chosen (a card that
-                    // changed hands). Named, so a wrong pick is visible in the
-                    // ledger beside the verdict it produced (IntelMac, #3852).
+                    // changed hands). The OTHERS are named too: their work is not
+                    // graded, and whoever asks later what happened to it must find
+                    // a row, not archaeology (IntelMac, #3852).
+                    let not_graded: Vec<String> = copies
+                        .iter()
+                        .filter(|c| c.has_work && c.path != workspace)
+                        .map(|c| c.path.display().to_string())
+                        .collect();
                     crate::probe!(
-                        class = "benchmark.verdict.sweep_chose_newest",
+                        class = "benchmark.verdict.multiple_worked_copies",
                         instance = instance.as_str(),
-                        chosen = %workspace.display(),
+                        graded = %workspace.display(),
+                        not_graded = %not_graded.join(","),
                         worked_copies = worked as u64,
-                        "several citizens worked this instance — grading the newest work"
+                        "several citizens worked this instance — grading the newest; the others are NOT graded"
                     );
                 }
                 out.push(PendingGrade { instance, workspace })

--- a/core/continuum-core/src/persona/staged_workspace.rs
+++ b/core/continuum-core/src/persona/staged_workspace.rs
@@ -231,6 +231,8 @@ fn newest_work_mtime_ms(root: &std::path::Path, porcelain: &str) -> Option<u64> 
     porcelain
         .lines()
         .filter_map(|l| l.get(3..))
+        // A rename line reads `R  old -> new`; the file that exists is `new`.
+        .map(|rel| rel.rsplit(" -> ").next().unwrap_or(rel))  // unwrap_or: rsplit always yields at least the whole string
         .map(|rel| rel.trim().trim_end_matches('/'))
         .filter_map(|rel| std::fs::metadata(root.join(rel)).ok())
         .filter_map(|m| m.modified().ok())

--- a/core/continuum-core/src/persona/staged_workspace.rs
+++ b/core/continuum-core/src/persona/staged_workspace.rs
@@ -120,6 +120,12 @@ pub struct StagedCopy {
     pub path: PathBuf,
     /// The checkout carries uncommitted changes — a real candidate patch lives here.
     pub has_work: bool,
+    /// The newest modification among the files `git status` lists, ms since
+    /// the epoch — when two citizens both worked one instance (a card that
+    /// changed hands), the sweep grades the copy with the latest work instead
+    /// of refusing both (2026-09-07: astropy-13236 held Atlas's fix beside
+    /// Joaquin's earlier attempt). None when no work or unreadable.
+    pub work_mtime_ms: Option<u64>,
 }
 
 /// Which citizen's copy of `instance` should be GRADED — the inverse of the per-peer
@@ -159,17 +165,22 @@ pub fn owners_of(instance: &str) -> Vec<StagedCopy> {
         if !path.join(".git").exists() {
             continue;
         }
-        let has_work = std::process::Command::new("git")
+        let porcelain = std::process::Command::new("git")
             .arg("-C")
             .arg(&path)
             .args(["status", "--porcelain"])
             .output()
-            .map(|o| o.status.success() && !o.stdout.is_empty())
-            .unwrap_or(false);
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+            .unwrap_or_default();  // unwrap_or: an unreadable status reads as "no work" — the same as before, never a guessed diff
+        let has_work = !porcelain.is_empty();
+        let work_mtime_ms = newest_work_mtime_ms(&path, &porcelain);
         out.push(StagedCopy {
             peer,
             path,
             has_work,
+            work_mtime_ms,
         });
     }
     out.sort_by(|a, b| a.peer.cmp(&b.peer));
@@ -196,8 +207,36 @@ pub fn grade_target(copies: &[StagedCopy]) -> GradeTarget {
     match worked.as_slice() {
         [one] => GradeTarget::One(one.path.clone()),
         [] => GradeTarget::NoWork,
-        many => GradeTarget::Ambiguous(many.iter().map(|c| c.path.clone()).collect()),
+        many => {
+            // Several citizens worked this instance. The newest work is the
+            // candidate — strictly newest and known; a tie or an unreadable
+            // mtime stays Ambiguous (never a guess between two real patches).
+            let mut known: Vec<&&StagedCopy> =
+                many.iter().filter(|c| c.work_mtime_ms.is_some()).collect();
+            known.sort_by_key(|c| std::cmp::Reverse(c.work_mtime_ms));
+            match known.as_slice() {
+                [newest, second, ..]
+                    if known.len() == many.len() && newest.work_mtime_ms > second.work_mtime_ms =>
+                {
+                    GradeTarget::One(newest.path.clone())
+                }
+                _ => GradeTarget::Ambiguous(many.iter().map(|c| c.path.clone()).collect()),
+            }
+        }
     }
+}
+
+/// The newest mtime (ms) among the paths `git status --porcelain` lists.
+fn newest_work_mtime_ms(root: &std::path::Path, porcelain: &str) -> Option<u64> {
+    porcelain
+        .lines()
+        .filter_map(|l| l.get(3..))
+        .map(|rel| rel.trim().trim_end_matches('/'))
+        .filter_map(|rel| std::fs::metadata(root.join(rel)).ok())
+        .filter_map(|m| m.modified().ok())
+        .filter_map(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .max()
 }
 
 /// The matching rule alone, with the filesystem taken out of it.
@@ -318,7 +357,23 @@ mod tests {
             peer: uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, name.as_bytes()),
             path: PathBuf::from(format!("/peers/{name}/workspace/swe/astropy__astropy-14995")),
             has_work,
+            work_mtime_ms: None,
         }
+    }
+
+    fn copy_at(name: &str, mtime_ms: u64) -> StagedCopy {
+        StagedCopy { work_mtime_ms: Some(mtime_ms), ..copy(name, true) }
+    }
+
+    // what this catches: two real patches on one instance (a card that changed
+    // hands) read as Ambiguous forever, so neither is ever graded. The newest
+    // known work is the candidate; a tie or an unknown mtime stays Ambiguous.
+    #[test]
+    fn two_worked_copies_grade_the_newest_and_a_tie_stays_ambiguous() {
+        let newest = grade_target(&[copy_at("kira", 1_000), copy_at("atlas", 2_000)]);
+        assert_eq!(newest, GradeTarget::One(PathBuf::from("/peers/atlas/workspace/swe/astropy__astropy-14995")));
+        assert!(matches!(grade_target(&[copy_at("kira", 2_000), copy_at("atlas", 2_000)]), GradeTarget::Ambiguous(_)));
+        assert!(matches!(grade_target(&[copy("kira", true), copy_at("atlas", 2_000)]), GradeTarget::Ambiguous(_)));
     }
 
     // what this catches: the false-zero generator. The SAME instance is legitimately staged


### PR DESCRIPTION
## Two real patches, zero verdicts

Card d5f4f445, third cause. When a card changes hands both citizens' checkouts hold work; `grade_target` returned Ambiguous and the sweep refused both (`benchmark.verdict.sweep_ambiguous` ×4 today). astropy-13236 right now: Atlas −7 beside Joaquin's +2/−6.

## Change
`StagedCopy.work_mtime_ms` (newest mtime among `git status` paths). Among several worked copies the strictly newest known one is graded; a tie or an unknown mtime stays Ambiguous. Test covers newest / tie / unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
