### PR TITLE
fix(benchmark): the boot sweep holds the in-flight guard — the tick started a second sweep while the boot's was still grading

### DIFF
--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -112,7 +112,15 @@ impl ServiceModule for BenchmarkGradeModule {
         // Module init must not block on it, and the citizens' first turn must not queue behind
         // it.
         tokio::spawn(async {
+            // The boot sweep holds the same in-flight guard the tick honours:
+            // on 0babe4c78 the 180 s tick started a SECOND sweep at 15:33Z while
+            // the boot's was still grading (the guard only knew about ticks).
+            use std::sync::atomic::Ordering;
+            if crate::cognition::swe_verdict_sweep::SWEEP_IN_FLIGHT.swap(true, Ordering::AcqRel) {
+                return;
+            }
             let report = crate::cognition::swe_verdict_sweep::sweep().await;
+            crate::cognition::swe_verdict_sweep::SWEEP_IN_FLIGHT.store(false, Ordering::Release);
             if report.graded > 0 {
                 tracing::info!(
                     graded = report.graded,


### PR DESCRIPTION
## Two sweeps at once on the first build with the tick

`benchmark.verdict.sweep_started_by_tick` 15:33:52Z while the boot sweep from 15:30:49Z had no `sweep_done` yet: the boot's `initialize` spawn called `sweep()` directly, outside the guard #3851 added for the tick. The boot spawn now swaps `SWEEP_IN_FLIGHT` before sweeping and clears it after, so the tick waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
