### PR TITLE
fix(benchmark): a recorded verdict closes the board card — a resolved instance can no longer be re-claimed

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -698,6 +698,25 @@ pub fn record_card_assignee(card_id: Uuid, assignee: Uuid) {
 /// so a re-say can name the instance the way the 2026-09-02 hand-written
 /// operator note did (the note broke a wedged round; the substrate's own
 /// kickoff must carry the same information or the hand stays in the loop).
+/// Every card, across live rounds, that carries `instance` — the set a verdict
+/// must close on the BOARD. A verdict settled the tracker but never the board
+/// card, so a resolved instance read `open` and was re-claimed (sympy-22456,
+/// 2026-09-07: resolved 14:13Z, re-claimed and re-worked by another citizen an
+/// hour later).
+pub fn cards_for_instance(instance: &str) -> Vec<Uuid> {
+    let rounds = ROUNDS.lock().unwrap_or_else(|e| e.into_inner()); // unwrap_or_else: poisoned lock = read the last state, same as every reader here
+    rounds
+        .values()
+        .flat_map(|r| {
+            r.card_instances
+                .iter()
+                .filter(|(_, i)| i.as_str() == instance)
+                .map(|(c, _)| *c)
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 pub fn instance_for_card(card_id: Uuid) -> Option<String> {
     let rounds = ROUNDS.lock().unwrap_or_else(|e| e.into_inner()); // safe: poisoned lock = read the last state, same policy as every ROUNDS lock here
     rounds.values().find_map(|r| {

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3536,6 +3536,52 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
             "VERDICT NOT PERSISTED — this grade is real but the system will forget it"
         ),
     }
+    // THE BOARD FOLLOWS THE VERDICT. Before this only the tracker settled: the
+    // board card of a resolved instance stayed open/claimed and was re-claimed
+    // (sympy-22456, 2026-09-07). Idempotent: an already-closed card is a no-op.
+    if !p.gold.unwrap_or(false) {
+        let cards = crate::cognition::bench_round::cards_for_instance(&verdict.instance_id);
+        if !cards.is_empty() {
+            match crate::persona::operator_peer::operator_airc() {
+                Some(airc) => {
+                    for card in cards {
+                        let card_id = airc_lib::WorkCardId::from_uuid(card);
+                        match crate::modules::work::advance_card_state(
+                            &airc,
+                            card_id,
+                            airc_lib::CardState::Closed,
+                            crate::modules::work::VIA_VERDICT,
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(()) => crate::probe!(
+                                class = "benchmark.verdict.board_closed",
+                                instance = verdict.instance_id.as_str(),
+                                card = %card.to_string().chars().take(8).collect::<String>(),
+                                resolved = verdict.resolved,
+                                "the board card follows the verdict — closed"
+                            ),
+                            Err(e) => crate::probe!(
+                                class = "benchmark.verdict.board_close_failed",
+                                instance = verdict.instance_id.as_str(),
+                                card = %card.to_string().chars().take(8).collect::<String>(),
+                                error = %e,
+                                "the verdict is recorded but the board card could not be closed — it will read open until the next pass"
+                            ),
+                        }
+                    }
+                }
+                None => crate::probe!(
+                    class = "benchmark.verdict.board_close_failed",
+                    instance = verdict.instance_id.as_str(),
+                    card = "-",
+                    error = "operator self-peer not online",
+                    "no airc handle to close the board card with"
+                ),
+            }
+        }
+    }
 
     // #319: a WORKSPACE grade is a citizen's lived, objectively judged work —
     // append it to her experience stream. Only her: the gold/raw-patch arms are

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1729,6 +1729,10 @@ pub(crate) fn checkout_change(root: &std::path::Path) -> ChangeVerdict {
 /// - everything else advances as asked.
 /// One seam for the `work/state` verb and the deterministic held-work settle, so
 /// the gate cannot be bypassed by either.
+/// The feeder label a recorded verdict uses — the one finisher that skips the
+/// review gate, because the grade IS the review.
+pub(crate) const VIA_VERDICT: &'static str = "verdict";
+
 pub(crate) async fn advance_card_state_effective(
     airc: &Arc<Airc>,
     card_id: WorkCardId,
@@ -1798,7 +1802,9 @@ pub(crate) async fn advance_card_state_effective(
             return Ok(next);
         }
     }
-    if finishing && round::review_required(card_id.as_uuid()) {
+    // A VERDICT is the review's outcome: it closes the parent outright. Every
+    // other finisher on a gated card goes to review first.
+    if finishing && via != VIA_VERDICT && round::review_required(card_id.as_uuid()) {
         raw_advance(airc, card_id, CardState::Review, via).await?;
         match open_review_card(airc, card_id).await {
             Ok(review) => crate::probe!(


### PR DESCRIPTION
## A verdict settled the tracker and left the board card open

sympy-22456: resolved 14:13Z, board card `open`, re-claimed at ~15:5x by another citizen who then wrote +9 on a solved instance (card cbd4fd6a / b1cc67b4 family: card truth in two places).

## Change
- `bench_round::cards_for_instance(instance)` — every live-round card carrying the instance.
- After `record_verdict` Ok (non-gold): each such card → Closed via `work::advance_card_state(…, VIA_VERDICT, None)` with the operator self-peer's airc. `advance_card_state_effective` lets the verdict feeder skip the review gate — the grade is the review's outcome. Probes `benchmark.verdict.board_closed` / `board_close_failed` (incl. "operator self-peer not online").

## Acceptance
A verdict file appears → within the same second the board card reads closed; no pull ever names an instance with a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
