### PR TITLE
fix(benchmark): an ungradeable refusal stands until the work changes — the tick sweep re-graded the same fifteen instances every seven minutes

### DIFF
--- a/core/continuum-core/src/cognition/swe_verdict_sweep.rs
+++ b/core/continuum-core/src/cognition/swe_verdict_sweep.rs
@@ -55,6 +55,63 @@ use crate::persona::staged_workspace::{grade_target, owners_of, GradeTarget};
 pub struct PendingGrade {
     pub instance: String,
     pub workspace: PathBuf,
+    /// The newest modification in the chosen copy (ms) — what a refusal is
+    /// remembered against, so the same tree is not re-graded every tick.
+    pub work_mtime_ms: Option<u64>,
+}
+
+/// A refusal ("ungradeable") remembered beside the verdicts, keyed by instance.
+/// Measured 2026-09-07 16:42–16:56Z on 9808f085d: with the tick sweep live and no
+/// memory of a refusal, the same fifteen instances were re-graded every seven
+/// minutes, forever (`pending()` = "worked and no verdict").
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Refusal {
+    pub instance: String,
+    pub reason: String,
+    pub at_ms: u64,
+    pub work_mtime_ms: Option<u64>,
+}
+
+fn refusal_path(instance: &str) -> PathBuf {
+    crate::cognition::swe_bench::verdict_dir().join(format!("{instance}.ungradeable.json"))
+}
+
+pub fn read_refusal(instance: &str) -> Option<Refusal> {
+    let text = std::fs::read_to_string(refusal_path(instance)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+pub fn record_refusal(instance: &str, reason: &str, work_mtime_ms: Option<u64>) {
+    let r = Refusal {
+        instance: instance.to_string(),
+        reason: reason.chars().take(400).collect(),
+        at_ms: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),  // unwrap_or: pre-epoch clock — the marker still records the reason and the work mtime
+        work_mtime_ms,
+    };
+    let path = refusal_path(instance);
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    if let Ok(text) = serde_json::to_string_pretty(&r) {
+        let _ = std::fs::write(&path, text);
+    }
+}
+
+pub fn clear_refusal(instance: &str) {
+    let _ = std::fs::remove_file(refusal_path(instance));
+}
+
+/// Does a remembered refusal still apply? Only while no NEWER work exists than
+/// the work it refused: the same tree is not re-graded; a new edit is. Pure.
+pub fn refusal_stands_at(refused_work_mtime_ms: Option<u64>, newest_work_mtime_ms: Option<u64>) -> bool {
+    match (refused_work_mtime_ms, newest_work_mtime_ms) {
+        (Some(refused), Some(newest)) => newest <= refused,
+        (None, None) => true,
+        _ => false,
+    }
 }
 
 /// What the sweep decided for one instance — every non-grade outcome is NAMED, because
@@ -128,6 +185,17 @@ pub fn pending() -> Vec<PendingGrade> {
         let worked = copies.iter().filter(|c| c.has_work).count();
         match decide(false, grade_target(&copies)) {
             SweepDecision::Grade(workspace) => {
+                let work_mtime_ms = copies
+                    .iter()
+                    .find(|c| c.path == workspace)
+                    .and_then(|c| c.work_mtime_ms);
+                if let Some(r) = read_refusal(&instance) {
+                    if refusal_stands_at(r.work_mtime_ms, work_mtime_ms) {
+                        // Refused before, nothing changed since: not pending. The
+                        // marker file is the record; no row per tick.
+                        continue;
+                    }
+                }
                 if worked > 1 {
                     // The newest of several worked copies was chosen (a card that
                     // changed hands). The OTHERS are named too: their work is not
@@ -147,7 +215,7 @@ pub fn pending() -> Vec<PendingGrade> {
                         "several citizens worked this instance — grading the newest; the others are NOT graded"
                     );
                 }
-                out.push(PendingGrade { instance, workspace })
+                out.push(PendingGrade { instance, workspace, work_mtime_ms })
             }
             SweepDecision::Ambiguous(paths) => crate::probe!(
                 class = "benchmark.verdict.sweep_ambiguous",
@@ -232,6 +300,11 @@ pub async fn sweep() -> SweepReport {
         match crate::commands::benchmark::grade_swe(params).await {
             Ok(result) if result.error.is_some() => {
                 report.ungradeable += 1;
+                record_refusal(
+                    &item.instance,
+                    result.error.as_deref().unwrap_or(""),  // unwrap_or: guarded by the arm — error is Some here
+                    item.work_mtime_ms,
+                );
                 // The REASON rides the row. 2026-09-07: 58 of these in six hours said
                 // "environment fault" and nothing else — 13346 (f2p passes on the
                 // pristine tree) and 14983 (the era env cannot build) were only told
@@ -253,6 +326,7 @@ pub async fn sweep() -> SweepReport {
             }
             Ok(result) => {
                 report.graded += 1;
+                clear_refusal(&item.instance);
                 if result.resolved {
                     report.resolved += 1;
                 }
@@ -337,5 +411,18 @@ mod tests {
         assert!(!should_start_sweep(0, false));
         assert!(!should_start_sweep(3, true));
         assert!(should_start_sweep(1, false));
+    }
+
+    // what this catches: a refusal that never expires (a new edit would never be
+    // graded) or one that never holds (the same tree re-graded every tick). It
+    // stands while no newer work exists; a newer edit lifts it.
+    #[test]
+    fn a_refusal_stands_until_newer_work_appears() {
+        assert!(refusal_stands_at(Some(1_000), Some(1_000)));
+        assert!(refusal_stands_at(Some(1_000), Some(900)));
+        assert!(!refusal_stands_at(Some(1_000), Some(1_001)));
+        assert!(refusal_stands_at(None, None));
+        assert!(!refusal_stands_at(None, Some(5)));
+        assert!(!refusal_stands_at(Some(5), None));
     }
 }


### PR DESCRIPTION
## The tick sweep became a grading storm

9808f085d, 16:42–16:56Z: sweep_start(15) → done(15 ungradeable) → tick → sweep_start(15) → done(15 ungradeable) — the same instances, every seven minutes, because a refusal left no trace and `pending()` is "worked copy without a verdict".

## Change
- `Refusal {instance, reason, at_ms, work_mtime_ms}` written to `<verdict dir>/<instance>.ungradeable.json` on an ungradeable result; removed on a real grade.
- `pending()` skips an instance whose refusal stands: no work newer than the refused tree (`refusal_stands_at`, pure, tested). A new edit lifts the refusal; the marker doubles as the reader-facing record of WHY (d5f4f445: an ungradeable verdict is a state a reader can find).

## Acceptance
After one sweep, the next tick's `sweep_start` reports `pending` ≈ 0 until a checkout changes; `ls verdicts/*.ungradeable.json` lists the fifteen with reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
