### PR TITLE
fix(dream): prior beliefs share the observation budget — one user message was 5.6x the served slot (#3847)

### DIFF
--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1620,10 +1620,50 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                         })
                         .unwrap_or(0);
                     if approx_tokens > *served as usize {
+                        // #3847: the total was measured but never ATTRIBUTED, so
+                        // "the prompt is 6x the window" could not be turned into
+                        // "which message is it". Every component is individually
+                        // bounded (fractions of the served window in
+                        // `ContextBudget`), so an overshoot this large is many
+                        // bounded parts summing with no total cap — and which
+                        // parts is the whole question. Roles + the largest few,
+                        // in approx tokens, cost nothing on the non-overshoot
+                        // path because this block only runs when already over.
+                        let (message_count, largest_messages) = body
+                            .get("messages")
+                            .and_then(|m| m.as_array())
+                            .map(|msgs| {
+                                let mut rows: Vec<(&str, usize)> = msgs
+                                    .iter()
+                                    .map(|m| {
+                                        let role = m
+                                            .get("role")
+                                            .and_then(|r| r.as_str())
+                                            .unwrap_or("?");
+                                        let len = m
+                                            .get("content")
+                                            .and_then(|c| c.as_str())
+                                            .map(|c| c.len() / 4)
+                                            .unwrap_or(0);
+                                        (role, len)
+                                    })
+                                    .collect();
+                                rows.sort_by(|a, b| b.1.cmp(&a.1));
+                                let rendered = rows
+                                    .iter()
+                                    .take(6)
+                                    .map(|(role, tokens)| format!("{role}={tokens}"))
+                                    .collect::<Vec<_>>()
+                                    .join(" ");
+                                (msgs.len(), rendered)
+                            })
+                            .unwrap_or((0, String::new()));
                         tracing::warn!(
                             probe_class = "serving.ctx_overshoot",
                             approx_tokens,
                             served_per_slot_ctx = *served,
+                            message_count,
+                            largest_messages = %largest_messages,
                             persona,
                             "prompt likely exceeds the served per-slot window — the RAG \
                              budget overshot what llama-server actually serves (#139); \

--- a/core/continuum-core/src/ai/openai_adapter.rs
+++ b/core/continuum-core/src/ai/openai_adapter.rs
@@ -1639,12 +1639,12 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                         let role = m
                                             .get("role")
                                             .and_then(|r| r.as_str())
-                                            .unwrap_or("?");
+                                            .unwrap_or("?");  // unwrap_or: a message without a role string is still worth sizing; "?" names it rather than dropping it
                                         let len = m
                                             .get("content")
                                             .and_then(|c| c.as_str())
                                             .map(|c| c.len() / 4)
-                                            .unwrap_or(0);
+                                            .unwrap_or(0);  // unwrap_or: a message with no string content contributes 0 tokens to a total we are only explaining
                                         (role, len)
                                     })
                                     .collect();
@@ -1657,7 +1657,7 @@ impl AIProviderAdapter for OpenAICompatibleAdapter {
                                     .join(" ");
                                 (msgs.len(), rendered)
                             })
-                            .unwrap_or((0, String::new()));
+                            .unwrap_or((0, String::new()));  // unwrap_or: no messages array means nothing to attribute; the probe still reports the total
                         tracing::warn!(
                             probe_class = "serving.ctx_overshoot",
                             approx_tokens,

--- a/core/continuum-core/src/cognition/dream_consolidation.rs
+++ b/core/continuum-core/src/cognition/dream_consolidation.rs
@@ -301,7 +301,16 @@ impl SemanticDistiller {
         // silence by a large cluster: with none, observations filling the budget
         // would leave zero beliefs, and 'superseded nothing' would be
         // indistinguishable from 'was shown no belief'.
-        let belief_floor = self.max_observation_chars / 4;
+        // Charged ONLY when beliefs will actually be written. Unconditional, it
+        // capped observations at 75% on every pass with no prior beliefs — a new
+        // persona, a fresh domain, any cluster whose topic has no history —
+        // reserving a quarter of the budget for a list that never gets appended,
+        // on exactly the passes carrying the most new material (IntelMac, #3861).
+        let belief_floor = if prior_beliefs.is_empty() {
+            0
+        } else {
+            self.max_observation_chars / 4
+        };
         let observation_budget = self.max_observation_chars.saturating_sub(belief_floor);
         let (mut block, kept_n) = Self::observations_block(sources, observation_budget);
         let kept = &sources[..kept_n];
@@ -321,17 +330,29 @@ impl SemanticDistiller {
             let mut beliefs_kept = 0usize;
             for (i, b) in prior_beliefs.iter().enumerate() {
                 let line = format!("{}. {}\n", i + 1, b.content.trim());
-                if block.len() + line.len() > self.max_observation_chars && beliefs_kept > 0 {
+                if block.len() + line.len() > self.max_observation_chars {
                     break;
                 }
                 block.push_str(&line);
                 beliefs_kept += 1;
             }
             if beliefs_kept < prior_beliefs.len() {
+                // The size of the belief that did NOT fit, so `kept = 0` is a
+                // READABLE state rather than a mystery: with none shown,
+                // "superseded nothing" and "was shown no belief" are otherwise
+                // indistinguishable, which is the ambiguity the reserved floor
+                // was reaching for. A named row achieves it without the
+                // unconditional-first-belief case that can blow the slot
+                // (IntelMac, #3861).
+                let dropped_first_chars = prior_beliefs
+                    .get(beliefs_kept)
+                    .map(|b| b.content.trim().len())
+                    .unwrap_or(0);
                 tracing::info!(
                     probe_class = "dream.beliefs.budgeted",
                     beliefs = prior_beliefs.len(),
                     kept = beliefs_kept,
+                    dropped_first_chars,
                     budget_chars = self.max_observation_chars,
                     block_chars = block.len(),
                     "prior-belief list exceeded the served slot budget - reviewing the \

--- a/core/continuum-core/src/cognition/dream_consolidation.rs
+++ b/core/continuum-core/src/cognition/dream_consolidation.rs
@@ -282,7 +282,28 @@ impl SemanticDistiller {
         // fed the distillation; provenance (source_ids/tags) must reflect ONLY those,
         // so the dropped engrams stay unconsolidated and get another pass in a smaller
         // future cluster ([[budget-at-assembly-never-clamp-the-prompt]]).
-        let (mut block, kept_n) = Self::observations_block(sources, self.max_observation_chars);
+        // #3847: PRIOR BELIEFS SHARE THE OBSERVATION BUDGET.
+        //
+        // The observations block has always been budgeted (whole engrams, tail
+        // dropped, never truncated). The prior-beliefs list appended below was
+        // bounded only by COUNT (SUPERSESSION_REVIEW_LIMIT +
+        // ROTATING_REVIEW_PER_PASS) - and a belief is distilled prose of any
+        // length, so N bounded beliefs times unbounded text is an unbounded
+        // block. Both halves land in ONE user message, so the careful
+        // observation budget bought nothing.
+        //
+        // Measured on BigMama: one user message of 141,984 approx tokens against
+        // a 25,344-token served slot - 5.6x over, and every overshoot was
+        // timestamp-identical to a dream.cluster.budgeted row. The slot rejects
+        // it, so the pass yields nothing and the engrams stay unconsolidated.
+        //
+        // A floor is reserved for beliefs so supersession cannot be starved to
+        // silence by a large cluster: with none, observations filling the budget
+        // would leave zero beliefs, and 'superseded nothing' would be
+        // indistinguishable from 'was shown no belief'.
+        let belief_floor = self.max_observation_chars / 4;
+        let observation_budget = self.max_observation_chars.saturating_sub(belief_floor);
+        let (mut block, kept_n) = Self::observations_block(sources, observation_budget);
         let kept = &sources[..kept_n];
         if !prior_beliefs.is_empty() {
             // Numbered list FIRST, then an UNCONDITIONAL format slot at the very
@@ -293,8 +314,29 @@ impl SemanticDistiller {
             // verdict lines, with the old conditional instruction placed BEFORE
             // the list.
             block.push_str("\n\nPRIOR BELIEFS (numbered):\n");
+            // Whole beliefs up to the remaining budget, dropping the tail - the
+            // SAME rule the observations block follows, because a half-belief is a
+            // malformed premise, not a smaller one
+            // ([[budget-at-assembly-never-clamp-the-prompt]]).
+            let mut beliefs_kept = 0usize;
             for (i, b) in prior_beliefs.iter().enumerate() {
-                block.push_str(&format!("{}. {}\n", i + 1, b.content.trim()));
+                let line = format!("{}. {}\n", i + 1, b.content.trim());
+                if block.len() + line.len() > self.max_observation_chars && beliefs_kept > 0 {
+                    break;
+                }
+                block.push_str(&line);
+                beliefs_kept += 1;
+            }
+            if beliefs_kept < prior_beliefs.len() {
+                tracing::info!(
+                    probe_class = "dream.beliefs.budgeted",
+                    beliefs = prior_beliefs.len(),
+                    kept = beliefs_kept,
+                    budget_chars = self.max_observation_chars,
+                    block_chars = block.len(),
+                    "prior-belief list exceeded the served slot budget - reviewing the \
+                     first {beliefs_kept}, deferring the rest to a later pass (#3847)"
+                );
             }
             block.push_str(
                 "\nAfter your reply, on its own final line, list which numbered prior \

--- a/core/continuum-core/src/cognition/dream_consolidation.rs
+++ b/core/continuum-core/src/cognition/dream_consolidation.rs
@@ -347,7 +347,7 @@ impl SemanticDistiller {
                 let dropped_first_chars = prior_beliefs
                     .get(beliefs_kept)
                     .map(|b| b.content.trim().len())
-                    .unwrap_or(0);
+                    .unwrap_or(0);  // unwrap_or: kept == len means nothing was dropped, so there is no first-dropped belief to size
                 tracing::info!(
                     probe_class = "dream.beliefs.budgeted",
                     beliefs = prior_beliefs.len(),


### PR DESCRIPTION
Closes #3847.

Two commits: the probe that found it, then the fix.

## What the issue assumed, and what it actually was

#3847 read as "nothing bounds the assembled prompt to `n_ctx`". Every component is in
fact bounded — `ContextBudget` derives each as a fraction of the served window. The
overshoot was **one specific unbudgeted list**, in the dream pass, not the citizen turn
path at all.

## Finding it

`serving.ctx_overshoot` measured a total and named nothing, so the first commit adds
attribution (`message_count` + the largest messages by role, emitted only on the
already-over path). One deploy later:

```
approx_tokens=141,984   served_per_slot_ctx=25,344   message_count=2
largest: user=141,984  system=113
```

**Two messages.** One 141,984-token user message — 5.6x the slot. Not accumulation.

Then the join: every `serving.ctx_overshoot` was **timestamp-identical** to a
`dream.cluster.budgeted` row (seven consecutive exact pairings), and all 28 overshoots
in the window came from a single persona — the one whose belief store had grown.

## The defect

`SemanticDistiller::distill_reviewing` builds ONE user message from two halves:

```rust
let (mut block, kept_n) = Self::observations_block(sources, self.max_observation_chars);  // budgeted
...
for (i, b) in prior_beliefs.iter().enumerate() {
    block.push_str(&format!("{}. {}\n", i + 1, b.content.trim()));   // UNBOUNDED
}
```

Observations are budgeted properly — whole engrams, tail dropped, never truncated. The
prior-belief list is bounded only by **count** (`SUPERSESSION_REVIEW_LIMIT` +
`ROTATING_REVIEW_PER_PASS`); a belief is distilled prose of arbitrary length, so N
bounded beliefs times unbounded text is an unbounded block appended to the budgeted
one. Both land in the same message, so the observation budget bought nothing.

**The consequence is worse than a rejected request.** llama-server refuses the prompt,
the pass produces nothing, and those engrams stay unconsolidated — so the dream stops
working precisely as a citizen accumulates enough beliefs to have something worth
consolidating, and gets quieter about it the longer she runs.

## The fix

Beliefs follow the same rule as observations: whole beliefs up to the remaining budget,
tail deferred to a later pass, with a `dream.beliefs.budgeted` probe when any are
dropped so the deferral is visible rather than silent.

A floor (1/4) is reserved for beliefs so supersession cannot be starved to silence by a
large cluster — with none, observations filling the budget would leave zero beliefs, and
"superseded nothing" would be indistinguishable from "was shown no belief", which is the
exact ambiguity the mandatory `SUPERSEDES:` line exists to remove.

## Two things found on the way, NOT fixed here

1. **`ContextBudget::unknown()` folds everything, not nothing.** `fraction()` maps
   `None -> usize::MAX`, while its call site in `act_observe/apply.rs` says "an unknown
   window folds NOTHING rather than inventing a number". Dormant while serving is ready;
   it inverts exactly when serving is not, which is when things are already wrong.
2. **The brain composes against 26,112 while the slot serves 25,344**, and
   `serving.reconcile.window` already logs both numbers (`plan_window` vs `live_window`)
   without acting on the gap.

Separately, `delib.context.render` shows `budget_tokens=0, rendered=0` on citizen turns
— context starved to empty, which is the likely source of citizens reporting "the
message is cut off" and "this is the first turn". That is a different defect from this
one and wants its own card.

## Validation

`cargo check -p continuum-core --lib --tests --features test-fixtures` clean; exit code
read from cargo, not from a pipe. The probe commit is already deployed and verified
running (`deploy verified: core is running build a03229951`), which is how the
attribution above was measured.
