### PR TITLE
fix(benchmark): only a RECORDED verdict closes the board card — an ungradeable refusal left cards closed without a grade

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3521,6 +3521,14 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
     // never be laundered by a positive control or an env fault (see its doc).
     let recorded = swe_bench::record_verdict(&verdict, p.gold.unwrap_or(false));
     let verdict_written = matches!(recorded, Ok(Some(_)));
+    // A close that does NOT happen must be a row, never an absence (IntelMac,
+    // batch8 read): a fix that makes the system say less ships the probe for its
+    // new quiet state, or the next reader mistakes "skipped" for "nothing to do".
+    let board_close_skipped: Option<&str> = match &recorded {
+        Ok(Some(_)) => None,
+        Ok(None) => Some("no_verdict_written"),
+        Err(_) => Some("verdict_not_persisted"),
+    };
     match recorded {
         Ok(Some(path)) => crate::probe!(
             class = "benchmark.verdict.recorded",
@@ -3586,6 +3594,16 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
                     "no airc handle to close the board card with"
                 ),
             }
+        }
+    }
+    if let Some(reason) = board_close_skipped {
+        if !p.gold.unwrap_or(false) {
+            crate::probe!(
+                class = "benchmark.verdict.board_close_skipped",
+                instance = verdict.instance_id.as_str(),
+                reason,
+                "no verdict was written, so the board card stays where it was — the instance is not settled"
+            );
         }
     }
 

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3519,7 +3519,9 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
     // stated from anything the system held. A measurement the system cannot remember is not a
     // measurement. `record_verdict` itself refuses gold and errored verdicts, so the board can
     // never be laundered by a positive control or an env fault (see its doc).
-    match swe_bench::record_verdict(&verdict, p.gold.unwrap_or(false)) {
+    let recorded = swe_bench::record_verdict(&verdict, p.gold.unwrap_or(false));
+    let verdict_written = matches!(recorded, Ok(Some(_)));
+    match recorded {
         Ok(Some(path)) => crate::probe!(
             class = "benchmark.verdict.recorded",
             instance = %verdict.instance_id,
@@ -3539,7 +3541,11 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
     // THE BOARD FOLLOWS THE VERDICT. Before this only the tracker settled: the
     // board card of a resolved instance stayed open/claimed and was re-claimed
     // (sympy-22456, 2026-09-07). Idempotent: an already-closed card is a no-op.
-    if !p.gold.unwrap_or(false) {
+    // Only a RECORDED verdict closes the board. An ungradeable result writes no
+    // verdict (record_verdict → Ok(None)) and must leave the card where it was:
+    // on 7d22a26e6 the first sweep closed 13346/26323/14983's cards on refusals
+    // — a citizen's real patch vanished from the deck without a grade.
+    if verdict_written && !p.gold.unwrap_or(false) {
         let cards = crate::cognition::bench_round::cards_for_instance(&verdict.instance_id);
         if !cards.is_empty() {
             match crate::persona::operator_peer::operator_airc() {


### PR DESCRIPTION
## #3855 closed cards on refusals

Acceptance read on 7d22a26e6: `benchmark.verdict.board_closed` rows for django-13346, scikit-learn-26323 and -14983 at the exact moments the sweep REFUSED them (`sweep_ungradeable`, no verdict file). The board block sat after the match on `record_verdict` and ran for `Ok(None)` too.

## Change
`let recorded = record_verdict(...)`; the board close runs only when `matches!(recorded, Ok(Some(_)))`. A refusal leaves the card as it was.

## Acceptance
Next sweep: `board_closed` rows only alongside `benchmark.verdict.recorded`; refused instances' cards stay open/ungraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
