### PR TITLE
fix(staging): a settled instance restages pristine on its next claim — work older than its verdict is finished work, not hers (card cbd4fd6a)

### DIFF
--- a/core/continuum-core/src/modules/card_staging.rs
+++ b/core/continuum-core/src/modules/card_staging.rs
@@ -233,13 +233,51 @@ async fn stage_shell(workspace: &Path, shell: &str) -> Staging {
     }
 }
 
+/// Does an existing checkout restage pristine for a new claim? Only when the instance
+/// has a recorded verdict and the checkout's work is not newer than it: that work was
+/// graded (or is clean), so it belongs to the settled round. No verdict, or work newer
+/// than the verdict (she kept going after a failed grade), keeps the tree.
+fn restages_pristine(verdict_ms: Option<u64>, work_ms: Option<u64>) -> bool {
+    match (verdict_ms, work_ms) {
+        (None, _) => false,
+        (Some(_), None) => true,
+        (Some(v), Some(w)) => v >= w,
+    }
+}
+
 async fn stage_swe(workspace: &Path, instance: &crate::cognition::swe_bench::SweInstance) -> Staging {
     use crate::cognition::swe_bench;
     let dir = workspace.join("swe").join(&instance.instance_id);
     if dir.join(".git").exists() {
-        // Already staged (a prior claim, or a re-claim after a reboot). Self-heal
-        // pre-shield checkouts so substrate artifacts never enter her patch.
-        swe_bench::shield_workspace_excludes(&dir);
+        // Already staged (a prior claim, or a re-claim after a reboot). A checkout
+        // whose work is OLDER than the instance's recorded verdict is finished work
+        // from a settled round, not hers in progress: seed-3 re-dispatched
+        // astropy-13236 (resolved 2026-08-26) and staged the claimer onto the August
+        // checkout, whose diff the sweep then rightly refused to re-grade. A settled
+        // instance starts pristine on its next claim; in-progress work (newer than
+        // any verdict, or no verdict at all) is kept.
+        let verdict_ms = std::fs::metadata(swe_bench::verdict_path(&instance.instance_id))
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as u64);
+        let work_ms = crate::persona::staged_workspace::work_mtime_of(&dir);
+        if restages_pristine(verdict_ms, work_ms) {
+            crate::probe!(
+                class = "benchmark.staging.reset_after_verdict",
+                instance = %instance.instance_id,
+                verdict_ms = verdict_ms.unwrap_or(0),
+                work_ms = work_ms.unwrap_or(0),
+                "the checkout carried work older than the instance's verdict — settled work \
+                 from an earlier round; restaging pristine for this claim"
+            );
+            if let Err(error) = swe_bench::clone_at(instance, &dir).await {
+                return Staging::Failed { stage: "checkout", error };
+            }
+        } else {
+            // Self-heal pre-shield checkouts so substrate artifacts never enter her patch.
+            swe_bench::shield_workspace_excludes(&dir);
+        }
     } else if let Err(error) = swe_bench::clone_at(instance, &dir).await {
         return Staging::Failed { stage: "checkout", error };
     }
@@ -332,4 +370,18 @@ mod tests {
             Staging::Failed { stage: "setup_shell", error: "boom".to_string() }
         );
     }
+
+    // what this catches: a re-dispatched, already-settled instance staged onto the
+    // previous round's graded checkout (astropy-13236, 2026-09-07: resolved Aug 26 by
+    // Atlas, re-dispatched by seed 3, the claimer inherited the August diff).
+    #[test]
+    fn a_settled_checkout_restages_pristine_but_in_progress_work_is_kept() {
+        assert!(!restages_pristine(None, None), "no verdict: a fresh clean tree is reused");
+        assert!(!restages_pristine(None, Some(10)), "no verdict: her work in progress stays");
+        assert!(restages_pristine(Some(20), None), "settled and clean: pristine costs nothing");
+        assert!(restages_pristine(Some(20), Some(10)), "work older than the verdict was graded");
+        assert!(restages_pristine(Some(20), Some(20)), "work at the verdict instant was graded");
+        assert!(!restages_pristine(Some(20), Some(30)), "work after a grade is a new attempt");
+    }
+
 }

--- a/core/continuum-core/src/persona/staged_workspace.rs
+++ b/core/continuum-core/src/persona/staged_workspace.rs
@@ -226,6 +226,20 @@ pub fn grade_target(copies: &[StagedCopy]) -> GradeTarget {
     }
 }
 
+/// The newest work mtime (ms) of a checkout on disk, or None when it is clean or
+/// unreadable. The porcelain read plus [`newest_work_mtime_ms`], for callers that
+/// hold a path rather than a `StagedCopy` (claim-time staging).
+pub(crate) fn work_mtime_of(root: &std::path::Path) -> Option<u64> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()?;
+    let porcelain = String::from_utf8_lossy(&out.stdout);
+    newest_work_mtime_ms(root, &porcelain)
+}
+
 /// The newest mtime (ms) among the paths `git status --porcelain` lists.
 fn newest_work_mtime_ms(root: &std::path::Path, porcelain: &str) -> Option<u64> {
     porcelain


### PR DESCRIPTION
fix(staging): a settled instance restages pristine on its next claim (card cbd4fd6a)

Seed-3 re-dispatched astropy-13236, which Atlas resolved on 2026-08-26. Claim-time
staging found the August checkout and reused it (a re-claim after a reboot looks the
same), so the new claimer inherited a graded diff and the sweep rightly refused to
re-grade it. The seeded sample must not change (`(dataset, seed, n)` is the
replication contract), so the fix is at staging:

- `restages_pristine(verdict_ms, work_ms)`: an existing checkout restages pristine
  only when the instance has a recorded verdict and the checkout's work is not newer
  than it. No verdict, or work newer than the verdict (she kept going after a failed
  grade), keeps the tree. Pure, tested.
- `staged_workspace::work_mtime_of(root)` exposes the porcelain + newest-mtime read
  for callers holding a path.
- Probe `benchmark.staging.reset_after_verdict {instance, verdict_ms, work_ms}` on the
  reset path — a tree that vanished says why.

card_staging tests 4/4 in the worktree. Acceptance: the next re-dispatch of a resolved
instance shows the probe and a clean checkout at base_commit for the claimer.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
