### PR TITLE
fix(verdict): a failed grade returns to its holder with the failing tests named — the board follows the verdict both ways

### DIFF
--- a/core/continuum-core/src/cognition/bench_round.rs
+++ b/core/continuum-core/src/cognition/bench_round.rs
@@ -630,6 +630,17 @@ pub fn seal_round(round_id: Uuid) {
 /// to the room of her freshest live claim, so she stops alternating rooms —
 /// measured 2026-08-22: two live claims in two rooms swapped her pinned slot's
 /// room-scoped context every tick, `cached: 0` by her own hand.
+/// The dispatch-time assignee of `card_id`, if the round recorded one. The LIVE holder is
+/// the board's business (`verdict_board::holder_of`); this is the fallback when no board
+/// read is possible.
+pub fn card_assignee(card_id: Uuid) -> Option<Uuid> {
+    ROUNDS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())  // poisoned lock = read the last state, same policy as every ROUNDS lock
+        .values()
+        .find_map(|r| r.card_assignees.get(&card_id).copied())
+}
+
 pub fn room_for_card(card_id: Uuid) -> Option<Uuid> {
     ROUNDS
         .lock()

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -3546,55 +3546,14 @@ pub(crate) async fn grade_swe(p: SweGradeParams) -> Result<SweGradeResult, Comma
             "VERDICT NOT PERSISTED — this grade is real but the system will forget it"
         ),
     }
-    // THE BOARD FOLLOWS THE VERDICT. Before this only the tracker settled: the
-    // board card of a resolved instance stayed open/claimed and was re-claimed
-    // (sympy-22456, 2026-09-07). Idempotent: an already-closed card is a no-op.
-    // Only a RECORDED verdict closes the board. An ungradeable result writes no
-    // verdict (record_verdict → Ok(None)) and must leave the card where it was:
-    // on 7d22a26e6 the first sweep closed 13346/26323/14983's cards on refusals
-    // — a citizen's real patch vanished from the deck without a grade.
+    // THE BOARD FOLLOWS THE VERDICT, both directions — one place for every grading path
+    // (`modules::verdict_board`): resolved closes the card and the room hears it; failed
+    // returns the card to its holder with the failing tests named. Only a RECORDED verdict
+    // moves anything: an ungradeable result (record_verdict → Ok(None)) leaves the card
+    // where it was — on 7d22a26e6 the first sweep closed 13346/26323/14983's cards on
+    // refusals and a citizen's real patch vanished from the deck without a grade.
     if verdict_written && !p.gold.unwrap_or(false) {
-        let cards = crate::cognition::bench_round::cards_for_instance(&verdict.instance_id);
-        if !cards.is_empty() {
-            match crate::persona::operator_peer::operator_airc() {
-                Some(airc) => {
-                    for card in cards {
-                        let card_id = airc_lib::WorkCardId::from_uuid(card);
-                        match crate::modules::work::advance_card_state(
-                            &airc,
-                            card_id,
-                            airc_lib::CardState::Closed,
-                            crate::modules::work::VIA_VERDICT,
-                            None,
-                        )
-                        .await
-                        {
-                            Ok(()) => crate::probe!(
-                                class = "benchmark.verdict.board_closed",
-                                instance = verdict.instance_id.as_str(),
-                                card = %card.to_string().chars().take(8).collect::<String>(),
-                                resolved = verdict.resolved,
-                                "the board card follows the verdict — closed"
-                            ),
-                            Err(e) => crate::probe!(
-                                class = "benchmark.verdict.board_close_failed",
-                                instance = verdict.instance_id.as_str(),
-                                card = %card.to_string().chars().take(8).collect::<String>(),
-                                error = %e,
-                                "the verdict is recorded but the board card could not be closed — it will read open until the next pass"
-                            ),
-                        }
-                    }
-                }
-                None => crate::probe!(
-                    class = "benchmark.verdict.board_close_failed",
-                    instance = verdict.instance_id.as_str(),
-                    card = "-",
-                    error = "operator self-peer not online",
-                    "no airc handle to close the board card with"
-                ),
-            }
-        }
+        crate::modules::verdict_board::follow(&verdict).await;
     }
     if let Some(reason) = board_close_skipped {
         if !p.gold.unwrap_or(false) {

--- a/core/continuum-core/src/modules/benchmark_grade.rs
+++ b/core/continuum-core/src/modules/benchmark_grade.rs
@@ -379,29 +379,6 @@ async fn grade_card(
     .await
     .map_err(|e| format!("grade_swe: {e:?}"))?;
 
-    let msg = if let Some(err) = &verdict.error {
-        // An errored verdict is an ABSENCE, not a zero — say so, never a fake fail.
-        format!("🧪 [bench {bench}] {instance} — grade could not run (infra, not a score): {err}")
-    } else if verdict.resolved {
-        format!(
-            "✅ [bench {bench}] {instance} RESOLVED — {}/{} FAIL_TO_PASS + {}/{} PASS_TO_PASS passed. Nice work.",
-            verdict.fail_to_pass_passed,
-            verdict.fail_to_pass_total,
-            verdict.pass_to_pass_passed,
-            verdict.pass_to_pass_total,
-        )
-    } else {
-        let failing = if verdict.failed_tests.is_empty() {
-            String::new()
-        } else {
-            format!(" — still failing: {}", verdict.failed_tests.join(", "))
-        };
-        format!(
-            "❌ [bench {bench}] {instance} not resolved — {}/{} FAIL_TO_PASS passed{}",
-            verdict.fail_to_pass_passed, verdict.fail_to_pass_total, failing
-        )
-    };
-
     // Post the verdict into the CARD'S room as a participant — the run room the
     // citizens are standing in, not the grading citizen's current room.
     crate::probe!(
@@ -411,9 +388,15 @@ async fn grade_card(
         resolved = verdict.resolved,
         "SWE grade complete — posting verdict into the card's room"
     );
-    crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &msg)
-        .await
-        .map_err(|e| format!("post verdict: {e}"))?;
+    // The room line and the card move live beside `record_verdict` now
+    // (`modules::verdict_board::follow`) so the sweep and the operator paths say the same
+    // thing this path did; an errored verdict is an ABSENCE and posts nothing.
+    if let Some(err) = &verdict.error {
+        let msg = format!("🧪 [bench {bench}] {instance} — grade could not run (infra, not a score): {err}");
+        crate::persona::airc_citizen::publish_text_in_room(&airc, room_id, &msg)
+            .await
+            .map_err(|e| format!("post verdict: {e}"))?;
+    }
     Ok(())
 }
 

--- a/core/continuum-core/src/modules/mod.rs
+++ b/core/continuum-core/src/modules/mod.rs
@@ -95,4 +95,5 @@ pub mod training_completion_sentinel;
 pub mod training_trigger;
 pub mod vdd;
 pub mod vision;
+pub mod verdict_board;
 pub mod work;

--- a/core/continuum-core/src/modules/verdict_board.rs
+++ b/core/continuum-core/src/modules/verdict_board.rs
@@ -177,7 +177,7 @@ async fn say_in_card_room(
         .as_ref()
         .and_then(|r| r.any_live_citizen_other_than(holder))
         .map(|rt| rt.airc().clone())
-        .unwrap_or_else(|| operator.clone());
+        .unwrap_or_else(|| operator.clone()); // unwrap_or: no live citizen other than the holder → the operator speaks (never the holder herself)
     match crate::persona::airc_citizen::publish_text_in_room(&voice, room, &line).await {
         Ok(_) => crate::probe!(
             class = "benchmark.verdict.line_posted",

--- a/core/continuum-core/src/modules/verdict_board.rs
+++ b/core/continuum-core/src/modules/verdict_board.rs
@@ -1,0 +1,216 @@
+//! THE BOARD FOLLOWS THE VERDICT — in both directions.
+//!
+//! One place, for every path that records a SWE verdict (a citizen's `PASS: done`, the
+//! tick sweep, an operator `benchmark/swe-grade`): a RESOLVED instance closes its cards
+//! and the room hears it; a FAILED instance goes BACK to its holder with the failing
+//! tests named, and the card returns to in-progress so she works it again.
+//!
+//! Why the second half exists: django-11749 (2026-09-07) was graded `resolved=false`
+//! with `failed_tests = [test_mutually_exclusive_group_required_options]` at 17:13Z;
+//! the verdict reached her experience stream and nothing else. No room line, no card
+//! change — she spent the next two hours re-running a repro that "looks good", blind to
+//! the one test the grader had already named. A grade is feedback; feedback that never
+//! reaches the hands that can act on it is a number in a file.
+//!
+//! An UNGRADEABLE result writes no verdict and touches nothing here (probe
+//! `benchmark.verdict.board_close_skipped` says so at the call site).
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::cognition::swe_bench::SweVerdict;
+
+/// The line the room hears. Pure so it is tested, not restated.
+pub fn verdict_line(verdict: &SweVerdict, holder_name: Option<&str>) -> String {
+    if verdict.resolved {
+        return format!(
+            "✅ {} RESOLVED — FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}. The card is closed.",
+            verdict.instance_id,
+            verdict.f2p_passed,
+            verdict.f2p_total,
+            verdict.p2p_passed,
+            verdict.p2p_total
+        );
+    }
+    let at = holder_name.map(|n| format!("@{n} ")).unwrap_or_default();
+    let failing = if verdict.failed_tests.is_empty() {
+        String::new()
+    } else {
+        format!(" — still failing: {}", verdict.failed_tests.join(", "))
+    };
+    format!(
+        "❌ {at}{} graded: not resolved — FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}{}. The card \
+         is back with you as in-progress: make the failing test pass in your checkout, then \
+         'PASS: done' again.",
+        verdict.instance_id,
+        verdict.f2p_passed,
+        verdict.f2p_total,
+        verdict.p2p_passed,
+        verdict.p2p_total,
+        failing
+    )
+}
+
+/// What a recorded verdict does to the board. Never called for gold or ungradeable runs.
+pub async fn follow(verdict: &SweVerdict) {
+    let cards = crate::cognition::bench_round::cards_for_instance(&verdict.instance_id);
+    if cards.is_empty() {
+        return;
+    }
+    let short = |c: &Uuid| c.to_string().chars().take(8).collect::<String>();
+    let Some(airc) = crate::persona::operator_peer::operator_airc() else {
+        crate::probe!(
+            class = "benchmark.verdict.board_close_failed",
+            instance = verdict.instance_id.as_str(),
+            card = "-",
+            error = "operator self-peer not online",
+            "no airc handle to move the board card with"
+        );
+        return;
+    };
+    for card in cards {
+        let card_id = airc_lib::WorkCardId::from_uuid(card);
+        let next = if verdict.resolved {
+            airc_lib::CardState::Closed
+        } else {
+            airc_lib::CardState::InProgress
+        };
+        match crate::modules::work::advance_card_state(
+            &airc,
+            card_id,
+            next,
+            crate::modules::work::VIA_VERDICT,
+            None,
+        )
+        .await
+        {
+            Ok(()) if verdict.resolved => crate::probe!(
+                class = "benchmark.verdict.board_closed",
+                instance = verdict.instance_id.as_str(),
+                card = %short(&card),
+                resolved = verdict.resolved,
+                "the board card follows the verdict — closed"
+            ),
+            Ok(()) => crate::probe!(
+                class = "benchmark.verdict.returned_to_holder",
+                instance = verdict.instance_id.as_str(),
+                card = %short(&card),
+                failing = %verdict.failed_tests.join(","),
+                "the board card follows the verdict — back to in-progress with the failing tests named"
+            ),
+            Err(e) => crate::probe!(
+                class = "benchmark.verdict.board_close_failed",
+                instance = verdict.instance_id.as_str(),
+                card = %short(&card),
+                error = %e,
+                "the verdict is recorded but the board card could not be moved — it reads as she left it until the next pass"
+            ),
+        }
+        say_in_card_room(verdict, card, &airc).await;
+    }
+}
+
+/// The room hears the verdict, addressed to the holder. Authored by a live citizen who is
+/// NOT the holder (a citizen's inbound stream skips her own lines, so a mention she
+/// authored would be dropped), else by the operator.
+async fn say_in_card_room(verdict: &SweVerdict, card: Uuid, operator: &Arc<airc_lib::Airc>) {
+    let short = card.to_string().chars().take(8).collect::<String>();
+    let Some(room) = crate::cognition::bench_round::room_for_card(card) else {
+        crate::probe!(
+            class = "benchmark.verdict.line_not_posted",
+            instance = verdict.instance_id.as_str(),
+            card = %short,
+            error = "no room for card",
+            "the verdict has no room to be said in"
+        );
+        return;
+    };
+    let registry = crate::persona::PersonaAircRuntimeRegistry::try_global();
+    let holder = holder_of(card, room, registry.as_ref())
+        .await
+        .or_else(|| crate::cognition::bench_round::card_assignee(card));
+    let holder_name = holder
+        .and_then(|h| registry.as_ref().and_then(|r| r.get(h)))
+        .map(|rt| rt.agent_name().to_string());
+    let line = verdict_line(verdict, holder_name.as_deref());
+    let voice: Arc<airc_lib::Airc> = registry
+        .as_ref()
+        .and_then(|r| r.any_live_citizen_other_than(holder))
+        .map(|rt| rt.airc().clone())
+        .unwrap_or_else(|| operator.clone());
+    match crate::persona::airc_citizen::publish_text_in_room(&voice, room, &line).await {
+        Ok(_) => crate::probe!(
+            class = "benchmark.verdict.line_posted",
+            instance = verdict.instance_id.as_str(),
+            card = %short,
+            room = %room.to_string().chars().take(8).collect::<String>(),
+            holder = %holder_name.unwrap_or_else(|| "-".into()),
+            resolved = verdict.resolved,
+            "the room heard the verdict"
+        ),
+        Err(e) => crate::probe!(
+            class = "benchmark.verdict.line_not_posted",
+            instance = verdict.instance_id.as_str(),
+            card = %short,
+            error = %e,
+            "the verdict is recorded but the room did not hear it"
+        ),
+    }
+}
+
+/// Who holds the card NOW, from the live board (a lapsed or unclaimed card has no holder;
+/// `card.owner` alone is never cleared on reopen). Read through any live citizen's airc —
+/// citizens are seated in the run room; the operator may not be.
+async fn holder_of(
+    card: Uuid,
+    room: Uuid,
+    registry: Option<&crate::persona::PersonaAircRuntimeRegistry>,
+) -> Option<Uuid> {
+    let rt = registry?.any_live_citizen()?;
+    let airc = rt.airc().clone();
+    let set = airc.subscription_set().await.ok()?;
+    let room = set.all().map(|sub| sub.as_room()).find(|r| r.channel.as_uuid() == room)?;
+    let board = airc.work_board_in(&room).await.ok()?.snapshot();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0); // unwrap_or: a clock before 1970 reads every hold as lapsed, which is the safe side
+    let found = board.cards.iter().find(|c| c.card_id.as_uuid() == card)?;
+    match crate::persona::card_holder::hold_of(found, now_ms) {
+        crate::persona::card_holder::Hold::Held => found.owner.map(|o| o.as_uuid()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: a failed grade that names no test, or no holder, or reads like a
+    // score instead of an instruction (django-11749, 2026-09-07: the failing test sat in
+    // the verdict file for two hours while the holder re-ran a repro that "looked good").
+    #[test]
+    fn a_failed_verdict_names_the_holder_and_the_failing_tests_and_hands_the_card_back() {
+        let v = SweVerdict {
+            instance_id: "django__django-11749".into(),
+            resolved: false,
+            f2p_passed: 0,
+            f2p_total: 1,
+            p2p_passed: 34,
+            p2p_total: 34,
+            gate_ok: true,
+            failed_tests: vec!["test_mutually_exclusive_group_required_options".into()],
+            ..Default::default()
+        };
+        let line = verdict_line(&v, Some("Joaquin"));
+        assert!(line.starts_with("❌ @Joaquin django__django-11749 graded: not resolved"), "{line}");
+        assert!(line.contains("still failing: test_mutually_exclusive_group_required_options"));
+        assert!(line.contains("back with you as in-progress"));
+        // No live holder: still a room line, never a panic, never a bare "@".
+        let anon = verdict_line(&v, None);
+        assert!(anon.starts_with("❌ django__django-11749"), "{anon}");
+        let resolved = SweVerdict { resolved: true, f2p_passed: 1, ..v };
+        assert!(verdict_line(&resolved, Some("Joaquin")).starts_with("✅ django__django-11749 RESOLVED"));
+    }
+}

--- a/core/continuum-core/src/modules/verdict_board.rs
+++ b/core/continuum-core/src/modules/verdict_board.rs
@@ -33,7 +33,7 @@ pub fn verdict_line(verdict: &SweVerdict, holder_name: Option<&str>) -> String {
             verdict.p2p_total
         );
     }
-    let at = holder_name.map(|n| format!("@{n} ")).unwrap_or_default();
+    let at = holder_name.map(|n| format!("@{n} ")).unwrap_or_default(); // unwrap_or: no live holder → an undirected room line, never a bare "@"
     let failing = if verdict.failed_tests.is_empty() {
         String::new()
     } else {
@@ -145,7 +145,7 @@ async fn say_in_card_room(verdict: &SweVerdict, card: Uuid, operator: &Arc<airc_
             instance = verdict.instance_id.as_str(),
             card = %short,
             room = %room.to_string().chars().take(8).collect::<String>(),
-            holder = %holder_name.unwrap_or_else(|| "-".into()),
+            holder = %holder_name.unwrap_or_else(|| "-".into()), // unwrap_or: "-" = no live holder, a legible absence in the probe
             resolved = verdict.resolved,
             "the room heard the verdict"
         ),

--- a/core/continuum-core/src/modules/verdict_board.rs
+++ b/core/continuum-core/src/modules/verdict_board.rs
@@ -21,17 +21,33 @@ use uuid::Uuid;
 
 use crate::cognition::swe_bench::SweVerdict;
 
+/// What happened to the board card — the line must say it, never assume it (Astra's
+/// review of #3868: a failed board write must not produce a success claim in the room).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoardMove {
+    Closed,
+    ReturnedToHolder,
+    Failed(String),
+}
+
 /// The line the room hears. Pure so it is tested, not restated.
-pub fn verdict_line(verdict: &SweVerdict, holder_name: Option<&str>) -> String {
+pub fn verdict_line(verdict: &SweVerdict, holder_name: Option<&str>, moved: &BoardMove) -> String {
+    let score = format!(
+        "FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}",
+        verdict.f2p_passed, verdict.f2p_total, verdict.p2p_passed, verdict.p2p_total
+    );
+    let card = match moved {
+        BoardMove::Closed => "The card is closed.".to_string(),
+        BoardMove::ReturnedToHolder => "The card is back with you as in-progress: make the \
+             failing test pass in your checkout, then 'PASS: done' again."
+            .to_string(),
+        BoardMove::Failed(e) => format!(
+            "The board card could NOT be moved ({e}); it reads as you left it — the grade \
+             above still stands."
+        ),
+    };
     if verdict.resolved {
-        return format!(
-            "✅ {} RESOLVED — FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}. The card is closed.",
-            verdict.instance_id,
-            verdict.f2p_passed,
-            verdict.f2p_total,
-            verdict.p2p_passed,
-            verdict.p2p_total
-        );
+        return format!("✅ {} RESOLVED — {score}. {card}", verdict.instance_id);
     }
     let at = holder_name.map(|n| format!("@{n} ")).unwrap_or_default(); // unwrap_or: no live holder → an undirected room line, never a bare "@"
     let failing = if verdict.failed_tests.is_empty() {
@@ -40,15 +56,8 @@ pub fn verdict_line(verdict: &SweVerdict, holder_name: Option<&str>) -> String {
         format!(" — still failing: {}", verdict.failed_tests.join(", "))
     };
     format!(
-        "❌ {at}{} graded: not resolved — FAIL_TO_PASS {}/{}, PASS_TO_PASS {}/{}{}. The card \
-         is back with you as in-progress: make the failing test pass in your checkout, then \
-         'PASS: done' again.",
-        verdict.instance_id,
-        verdict.f2p_passed,
-        verdict.f2p_total,
-        verdict.p2p_passed,
-        verdict.p2p_total,
-        failing
+        "❌ {at}{} graded: not resolved — {score}{failing}. {card}",
+        verdict.instance_id
     )
 }
 
@@ -76,7 +85,7 @@ pub async fn follow(verdict: &SweVerdict) {
         } else {
             airc_lib::CardState::InProgress
         };
-        match crate::modules::work::advance_card_state(
+        let moved = match crate::modules::work::advance_card_state(
             &airc,
             card_id,
             next,
@@ -85,36 +94,50 @@ pub async fn follow(verdict: &SweVerdict) {
         )
         .await
         {
-            Ok(()) if verdict.resolved => crate::probe!(
-                class = "benchmark.verdict.board_closed",
-                instance = verdict.instance_id.as_str(),
-                card = %short(&card),
-                resolved = verdict.resolved,
-                "the board card follows the verdict — closed"
-            ),
-            Ok(()) => crate::probe!(
-                class = "benchmark.verdict.returned_to_holder",
-                instance = verdict.instance_id.as_str(),
-                card = %short(&card),
-                failing = %verdict.failed_tests.join(","),
-                "the board card follows the verdict — back to in-progress with the failing tests named"
-            ),
-            Err(e) => crate::probe!(
-                class = "benchmark.verdict.board_close_failed",
-                instance = verdict.instance_id.as_str(),
-                card = %short(&card),
-                error = %e,
-                "the verdict is recorded but the board card could not be moved — it reads as she left it until the next pass"
-            ),
-        }
-        say_in_card_room(verdict, card, &airc).await;
+            Ok(()) if verdict.resolved => {
+                crate::probe!(
+                    class = "benchmark.verdict.board_closed",
+                    instance = verdict.instance_id.as_str(),
+                    card = %short(&card),
+                    resolved = verdict.resolved,
+                    "the board card follows the verdict — closed"
+                );
+                BoardMove::Closed
+            }
+            Ok(()) => {
+                crate::probe!(
+                    class = "benchmark.verdict.returned_to_holder",
+                    instance = verdict.instance_id.as_str(),
+                    card = %short(&card),
+                    failing = %verdict.failed_tests.join(","),
+                    "the board card follows the verdict — back to in-progress with the failing tests named"
+                );
+                BoardMove::ReturnedToHolder
+            }
+            Err(e) => {
+                crate::probe!(
+                    class = "benchmark.verdict.board_close_failed",
+                    instance = verdict.instance_id.as_str(),
+                    card = %short(&card),
+                    error = %e,
+                    "the verdict is recorded but the board card could not be moved — it reads as she left it until the next pass"
+                );
+                BoardMove::Failed(e)
+            }
+        };
+        say_in_card_room(verdict, card, &airc, &moved).await;
     }
 }
 
 /// The room hears the verdict, addressed to the holder. Authored by a live citizen who is
 /// NOT the holder (a citizen's inbound stream skips her own lines, so a mention she
 /// authored would be dropped), else by the operator.
-async fn say_in_card_room(verdict: &SweVerdict, card: Uuid, operator: &Arc<airc_lib::Airc>) {
+async fn say_in_card_room(
+    verdict: &SweVerdict,
+    card: Uuid,
+    operator: &Arc<airc_lib::Airc>,
+    moved: &BoardMove,
+) {
     let short = card.to_string().chars().take(8).collect::<String>();
     let Some(room) = crate::cognition::bench_round::room_for_card(card) else {
         crate::probe!(
@@ -127,13 +150,29 @@ async fn say_in_card_room(verdict: &SweVerdict, card: Uuid, operator: &Arc<airc_
         return;
     };
     let registry = crate::persona::PersonaAircRuntimeRegistry::try_global();
-    let holder = holder_of(card, room, registry.as_ref())
-        .await
-        .or_else(|| crate::cognition::bench_round::card_assignee(card));
+    // Three answers, kept apart (Astra's review): the board says WHO holds it, the board
+    // says NOBODY holds it (a lapsed or unclaimed card — do not resurrect the dispatch
+    // assignee over the board's word), or the board could not be read at all (then the
+    // dispatch-time assignee is the best historical guess, and is labelled so).
+    let (holder, historical) = match holder_of(card, room, registry.as_ref()).await {
+        HolderRead::Held(h) => (Some(h), false),
+        HolderRead::Unheld => (None, false),
+        HolderRead::Unavailable(why) => {
+            crate::probe!(
+                class = "benchmark.verdict.holder_unavailable",
+                instance = verdict.instance_id.as_str(),
+                card = %short,
+                why = %why,
+                "the live board could not be read — addressing the dispatch-time assignee as a historical guess"
+            );
+            (crate::cognition::bench_round::card_assignee(card), true)
+        }
+    };
     let holder_name = holder
         .and_then(|h| registry.as_ref().and_then(|r| r.get(h)))
-        .map(|rt| rt.agent_name().to_string());
-    let line = verdict_line(verdict, holder_name.as_deref());
+        .map(|rt| rt.agent_name().to_string())
+        .map(|n| if historical { format!("{n} (dispatch assignee; live board unavailable)") } else { n });
+    let line = verdict_line(verdict, holder_name.as_deref(), moved);
     let voice: Arc<airc_lib::Airc> = registry
         .as_ref()
         .and_then(|r| r.any_live_citizen_other_than(holder))
@@ -159,27 +198,55 @@ async fn say_in_card_room(verdict: &SweVerdict, card: Uuid, operator: &Arc<airc_
     }
 }
 
-/// Who holds the card NOW, from the live board (a lapsed or unclaimed card has no holder;
-/// `card.owner` alone is never cleared on reopen). Read through any live citizen's airc —
-/// citizens are seated in the run room; the operator may not be.
+/// What the live board says about the card's holder — three distinct answers.
+#[derive(Debug, PartialEq, Eq)]
+pub enum HolderRead {
+    Held(Uuid),
+    /// The board was read and no one holds the card (lapsed or unclaimed).
+    Unheld,
+    /// The board could not be read; the reason names the joint that failed.
+    Unavailable(&'static str),
+}
+
+/// Who holds the card NOW, from the live board (`card.owner` alone is never cleared on
+/// reopen, so the hold is decided by `card_holder::hold_of`). Read through any live
+/// citizen's airc — citizens are seated in the run room; the operator may not be. A clock
+/// that cannot be read is an unavailable read, never a made-up timestamp: zero would sort
+/// before every lease expiry and call a lapsed hold live.
 async fn holder_of(
     card: Uuid,
     room: Uuid,
     registry: Option<&crate::persona::PersonaAircRuntimeRegistry>,
-) -> Option<Uuid> {
-    let rt = registry?.any_live_citizen()?;
+) -> HolderRead {
+    let Some(rt) = registry.and_then(|r| r.any_live_citizen()) else {
+        return HolderRead::Unavailable("no live citizen to read the board through");
+    };
     let airc = rt.airc().clone();
-    let set = airc.subscription_set().await.ok()?;
-    let room = set.all().map(|sub| sub.as_room()).find(|r| r.channel.as_uuid() == room)?;
-    let board = airc.work_board_in(&room).await.ok()?.snapshot();
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0); // unwrap_or: a clock before 1970 reads every hold as lapsed, which is the safe side
-    let found = board.cards.iter().find(|c| c.card_id.as_uuid() == card)?;
+    let Ok(set) = airc.subscription_set().await else {
+        return HolderRead::Unavailable("subscription set unreadable");
+    };
+    let Some(room) = set.all().map(|sub| sub.as_room()).find(|r| r.channel.as_uuid() == room) else {
+        return HolderRead::Unavailable("reading citizen is not subscribed to the card's room");
+    };
+    let Ok(board) = airc.work_board_in(&room).await else {
+        return HolderRead::Unavailable("board read failed");
+    };
+    let board = board.snapshot();
+    let Ok(now) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) else {
+        return HolderRead::Unavailable("clock before the epoch");
+    };
+    let now_ms = now.as_millis() as u64;
+    let Some(found) = board.cards.iter().find(|c| c.card_id.as_uuid() == card) else {
+        return HolderRead::Unavailable("card not on the board");
+    };
     match crate::persona::card_holder::hold_of(found, now_ms) {
-        crate::persona::card_holder::Hold::Held => found.owner.map(|o| o.as_uuid()),
-        _ => None,
+        crate::persona::card_holder::Hold::Held => match found.owner {
+            Some(o) => HolderRead::Held(o.as_uuid()),
+            None => HolderRead::Unheld,
+        },
+        crate::persona::card_holder::Hold::Lapsed | crate::persona::card_holder::Hold::Unclaimed => {
+            HolderRead::Unheld
+        }
     }
 }
 
@@ -190,9 +257,8 @@ mod tests {
     // what this catches: a failed grade that names no test, or no holder, or reads like a
     // score instead of an instruction (django-11749, 2026-09-07: the failing test sat in
     // the verdict file for two hours while the holder re-ran a repro that "looked good").
-    #[test]
-    fn a_failed_verdict_names_the_holder_and_the_failing_tests_and_hands_the_card_back() {
-        let v = SweVerdict {
+    fn failed_11749() -> SweVerdict {
+        SweVerdict {
             instance_id: "django__django-11749".into(),
             resolved: false,
             f2p_passed: 0,
@@ -202,15 +268,38 @@ mod tests {
             gate_ok: true,
             failed_tests: vec!["test_mutually_exclusive_group_required_options".into()],
             ..Default::default()
-        };
-        let line = verdict_line(&v, Some("Joaquin"));
+        }
+    }
+
+    #[test]
+    fn a_failed_verdict_names_the_holder_and_the_failing_tests_and_hands_the_card_back() {
+        let v = failed_11749();
+        let line = verdict_line(&v, Some("Joaquin"), &BoardMove::ReturnedToHolder);
         assert!(line.starts_with("❌ @Joaquin django__django-11749 graded: not resolved"), "{line}");
         assert!(line.contains("still failing: test_mutually_exclusive_group_required_options"));
         assert!(line.contains("back with you as in-progress"));
         // No live holder: still a room line, never a panic, never a bare "@".
-        let anon = verdict_line(&v, None);
+        let anon = verdict_line(&v, None, &BoardMove::ReturnedToHolder);
         assert!(anon.starts_with("❌ django__django-11749"), "{anon}");
         let resolved = SweVerdict { resolved: true, f2p_passed: 1, ..v };
-        assert!(verdict_line(&resolved, Some("Joaquin")).starts_with("✅ django__django-11749 RESOLVED"));
+        let ok = verdict_line(&resolved, Some("Joaquin"), &BoardMove::Closed);
+        assert!(ok.starts_with("✅ django__django-11749 RESOLVED") && ok.ends_with("The card is closed."), "{ok}");
     }
+
+    // what this catches: a failed board write producing a success claim in the room
+    // (Astra's review of #3868) — the grade must still be said, the move must be named
+    // as failed, and neither "closed" nor "back with you" may appear.
+    #[test]
+    fn a_failed_board_move_is_named_in_the_line_and_never_claims_success() {
+        let v = failed_11749();
+        let failed = BoardMove::Failed("state machine refused Review → InProgress".into());
+        let line = verdict_line(&v, Some("Joaquin"), &failed);
+        assert!(line.contains("still failing: test_mutually_exclusive_group_required_options"), "{line}");
+        assert!(line.contains("could NOT be moved (state machine refused Review → InProgress)"), "{line}");
+        assert!(!line.contains("back with you") && !line.contains("is closed"), "{line}");
+        let resolved = SweVerdict { resolved: true, f2p_passed: 1, ..v };
+        let line = verdict_line(&resolved, None, &failed);
+        assert!(line.starts_with("✅") && line.contains("could NOT be moved") && !line.contains("is closed"), "{line}");
+    }
+
 }


### PR DESCRIPTION
fix(verdict): a failed grade returns to its holder with the failing tests named — the board follows the verdict in both directions (one place for every grading path)

django-11749 (2026-09-07): graded resolved=false at 17:13Z with the failing test
named in the verdict file; the line reached her experience stream and nothing else.
No room line, no card change — Joaquin spent two hours re-running a repro that
"looked good", blind to the one test the grader had already named.

modules/verdict_board.rs is the one place beside record_verdict: resolved → the
card closes and the room hears ✅; failed → the card goes back to in-progress and
the room hears ❌ @holder with "still failing: <tests>", authored by a live citizen
who is not the holder (a citizen's stream skips her own lines) or the operator.
The holder is read from the live board (hold_of == Held → owner), falling back to
the dispatch assignee. benchmark_grade.rs no longer posts its own ✅/❌ (it kept the
infra-fault line and its probe) so the sweep, the operator grade, and the settle
path all say the same thing. Probes: benchmark.verdict.returned_to_holder,
line_posted, line_not_posted; board_closed unchanged.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
