### PR TITLE
fix(desktop): restore project rooms with their scoped work board

### DIFF
--- a/apps/tui/src/ansiTarget.ts
+++ b/apps/tui/src/ansiTarget.ts
@@ -82,9 +82,10 @@ export function createAnsiTarget(useColor = true): RenderTarget<string> {
   const content = createContentRegistry<string>();
   content.register<ProjectContentBody>(PROJECT_PURPOSE, (body) => [
     `${body.title} — Work board`,
-    body.board === undefined ? 'Waiting for this room\'s work board…'
-      : body.board.cards.length === 0 ? 'No work cards in this room yet.'
-      : body.board.cards.map((card) => `${card.priority} [${card.state}] ${card.title} — ${card.assignee_name ?? 'Unclaimed'} (${card.hold})`).join('\n'),
+    body.board.status === 'awaiting' ? 'Waiting for this room\'s work board…'
+      : body.board.status === 'rejected' ? 'Work board unavailable: received a board for another room.'
+      : body.board.snapshot.cards.length === 0 ? 'No work cards in this room yet.'
+      : body.board.snapshot.cards.map((card) => `${card.priority} [${card.state}] ${card.title} — ${card.assignee_name ?? 'Unclaimed'} (${card.hold})`).join('\n'),
     'Conversation',
     body.chat.isEmpty ? 'No messages yet — say hello.' : body.chat.messages.map(messageLine).join('\n'),
   ].join('\n'));

--- a/apps/tui/src/ansiTarget.ts
+++ b/apps/tui/src/ansiTarget.ts
@@ -14,6 +14,7 @@
 
 import { createContentRegistry, type RenderTarget, type WorkspaceView, type ListingView, type ListingCell, type ContentView, type ContextPanelView, type PanelWidget, type GaugeView, type ContinuonView, type ServingPanelView, type SystemPanelView } from '@continuum/patterns';
 import type { ChatContentBody, MessageRowVM, MemberKind } from '@continuum/chat-view';
+import { PROJECT_PURPOSE, type ProjectContentBody } from '@continuum/chat-view';
 
 /** Unicode block ramp for terminal sparklines — the gauge's ANSI face. */
 const BLOCKS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'] as const;
@@ -79,6 +80,14 @@ export function createAnsiTarget(useColor = true): RenderTarget<string> {
   };
 
   const content = createContentRegistry<string>();
+  content.register<ProjectContentBody>(PROJECT_PURPOSE, (body) => [
+    `${body.title} — Work board`,
+    body.board === undefined ? 'Waiting for this room\'s work board…'
+      : body.board.cards.length === 0 ? 'No work cards in this room yet.'
+      : body.board.cards.map((card) => `${card.priority} [${card.state}] ${card.title} — ${card.assignee_name ?? 'Unclaimed'} (${card.hold})`).join('\n'),
+    'Conversation',
+    body.chat.isEmpty ? 'No messages yet — say hello.' : body.chat.messages.map(messageLine).join('\n'),
+  ].join('\n'));
   content.register<ChatContentBody>('chat', (body) =>
     body.isEmpty
       ? paint('dim', '  No messages yet — say hello.')

--- a/apps/tui/src/renderChat.spec.ts
+++ b/apps/tui/src/renderChat.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { ChatViewModel } from '@continuum/chat-view';
 import { renderChat } from './renderChat';
+import { chatWorkspace } from '@continuum/chat-view';
+import { createAnsiTarget } from './ansiTarget';
 
 /** A minimal view model builder so each test states only what it exercises. */
 function vm(overrides: Partial<ChatViewModel> = {}): ChatViewModel {
@@ -19,6 +21,20 @@ function vm(overrides: Partial<ChatViewModel> = {}): ChatViewModel {
 }
 
 describe('renderChat (ANSI)', () => {
+  // Regression #3869: a foreign-room snapshot must be visibly rejected, never
+  // displayed as this room's board or mistaken for an awaiting/empty feed.
+  it('distinguishes awaiting, ready-empty, and rejected project boards', () => {
+    const project = vm({ purpose: 'project' });
+    const target = createAnsiTarget(false);
+    const board = { room_id: project.roomId, lanes: [], cards: [] };
+    expect(target.content(chatWorkspace(project).content)).toContain('Waiting for this room');
+    expect(target.content(chatWorkspace(project, { board }).content)).toContain('No work cards');
+    const rejected = target.content(chatWorkspace(project, { board: { ...board, room_id: 'other-room' } }).content);
+    expect(rejected).toContain('received a board for another room');
+    expect(rejected).not.toContain('Waiting for this room');
+    expect(rejected).not.toContain('No work cards');
+  });
+
   it('renders an honest empty state, not an error, when there are no messages', () => {
     // what this catches: a blank/erroring conversation panel when a room is quiet
     // — the empty state is a normal render, matching the web widget's contract.

--- a/apps/web/src/chat/ChatWidget.ts
+++ b/apps/web/src/chat/ChatWidget.ts
@@ -20,6 +20,7 @@ import { LitElement, html, css, nothing, type PropertyValues, type TemplateResul
 import type { ArenaViewState, CanvasViewState, ChatState } from '@continuum/chat-view';
 import {
   chatViewModel,
+  PROJECT_PURPOSE,
   focusedLiveTab,
   focusedPersonaTab,
   historyRowsFromPoll,
@@ -1315,6 +1316,14 @@ export class ChatWidget extends LitElement {
       color: var(--content-tertiary, #667);
       padding: var(--spacing-xs) 0;
     }
+    .project-workspace { padding: var(--spacing-md); min-width: 0; }
+    .project-heading { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+    .project-heading h2 { margin: 0; }
+    .project-cards { list-style: none; padding: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr)); gap: 0.75rem; }
+    .project-card { border: 1px solid var(--border-color, #384350); border-radius: 0.6rem; padding: 1rem; overflow-wrap: anywhere; }
+    .project-card h3 { font-size: 1rem; margin: 0.6rem 0; }
+    .project-card-meta { display: flex; justify-content: space-between; gap: 0.5rem; font-size: 0.8rem; }
+    .project-description { white-space: pre-wrap; }
     /* ACADEMY LANDING — the campus page: hero strip, live board, chat below. */
     .academy-landing {
       display: flex;
@@ -5926,7 +5935,7 @@ export class ChatWidget extends LitElement {
     }
     // Pin to the live edge on new content (messages AND stream deltas)
     // unless the READER deliberately scrolled up — intent, not position.
-    if ((changed.has('state') || changed.has('_typing')) && !persona && !this._userScrolledUp) {
+    if ((changed.has('state') || changed.has('_typing')) && !persona && this.state?.purpose !== PROJECT_PURPOSE && !this._userScrolledUp) {
       this._autoScrolling = true;
       this.scrollToLatest();
       // Release after the scroll's events flush (scroll events are sync-ish

--- a/apps/web/src/content/registry.spec.ts
+++ b/apps/web/src/content/registry.spec.ts
@@ -30,12 +30,16 @@ describe('webContentRegistry — purpose dispatch', () => {
   // Regression b742642d: selecting a project used to replace the whole app with
   // an unregistered-purpose error. Missing feed and empty board are distinct.
   it('renders project content before and after the room board arrives', () => {
-    const body = { title: 'Example project', chat: { messages: [], transcript: [], isEmpty: true } };
+    const body = { title: 'Example project', board: { status: 'awaiting' }, chat: { messages: [], transcript: [], isEmpty: true } };
     expect(markup(webContentRegistry.render({ purpose: 'project', body }))).toContain('Waiting for this room');
-    const loaded = markup(webContentRegistry.render({ purpose: 'project', body: { ...body, board: { room_id: 'room', lanes: [], cards: [] } } }));
+    const loaded = markup(webContentRegistry.render({ purpose: 'project', body: { ...body, board: { status: 'ready', snapshot: { room_id: 'room', lanes: [], cards: [] } } } }));
     expect(loaded).toContain('No work cards');
     expect(loaded).toContain('Conversation');
     expect(loaded).not.toContain('Waiting for this room');
+    const rejected = markup(webContentRegistry.render({ purpose: 'project', body: { ...body, board: { status: 'rejected', reason: 'foreign-room' } } }));
+    expect(rejected).toContain('received a board for another room');
+    expect(rejected).not.toContain('Waiting for this room');
+    expect(rejected).not.toContain('No work cards');
   });
   const model = (over: Partial<ForgeModelView> = {}): ForgeModelView => ({
     model_id: 'qwen3-coder',

--- a/apps/web/src/content/registry.spec.ts
+++ b/apps/web/src/content/registry.spec.ts
@@ -27,6 +27,16 @@ function flatten(node: unknown, out: string[] = []): string[] {
 const markup = (n: unknown): string => flatten(n).join('');
 
 describe('webContentRegistry — purpose dispatch', () => {
+  // Regression b742642d: selecting a project used to replace the whole app with
+  // an unregistered-purpose error. Missing feed and empty board are distinct.
+  it('renders project content before and after the room board arrives', () => {
+    const body = { title: 'Example project', chat: { messages: [], transcript: [], isEmpty: true } };
+    expect(markup(webContentRegistry.render({ purpose: 'project', body }))).toContain('Waiting for this room');
+    const loaded = markup(webContentRegistry.render({ purpose: 'project', body: { ...body, board: { room_id: 'room', lanes: [], cards: [] } } }));
+    expect(loaded).toContain('No work cards');
+    expect(loaded).toContain('Conversation');
+    expect(loaded).not.toContain('Waiting for this room');
+  });
   const model = (over: Partial<ForgeModelView> = {}): ForgeModelView => ({
     model_id: 'qwen3-coder',
     display_name: 'Qwen3 Coder',

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -30,6 +30,7 @@ import {
   type SettingsContentBody,
 } from '@continuum/patterns';
 import type { ChatContentBody } from '@continuum/chat-view';
+import { PROJECT_PURPOSE, type ProjectContentBody } from '@continuum/chat-view';
 import { modelCell, type ForgeContentBody } from '@continuum/foundry-view';
 import { actGroupRow, listingCell, messageRow } from '../render/parts';
 import { ACADEMY_PURPOSE, type AcademyContentBody } from '@continuum/chat-view';
@@ -102,6 +103,23 @@ export const webContentRegistry: ContentRegistry<TemplateResult> =
   createContentRegistry<TemplateResult>();
 
 webContentRegistry.register<ChatContentBody>('chat', (body) => chatContent(body));
+webContentRegistry.register<ProjectContentBody>(PROJECT_PURPOSE, (body) => html`
+  <section class="project-workspace" aria-label="Project workspace">
+    <header class="project-heading"><h2>${body.title}</h2><span>Work board</span></header>
+    ${body.board === undefined
+      ? html`<p role="status">Waiting for this room's work board…</p>`
+      : body.board.cards.length === 0
+        ? html`<p>No work cards in this room yet.</p>`
+        : html`<ul class="project-cards">${body.board.cards.map((card) => html`
+          <li class="project-card">
+            <div class="project-card-meta"><span>${card.priority}</span><span>${card.state.replaceAll('_', ' ')}</span></div>
+            <h3>${card.title}</h3>
+            <p>${card.hold === 'lapsed' ? `Available · previous holder ${card.assignee_name ?? card.assignee_id}` : card.assignee_name ?? 'Unclaimed'}</p>
+            ${card.body ? html`<details><summary>Description</summary><p class="project-description">${card.body}</p></details>` : ''}
+            ${card.pull_request ? html`<p>${card.pull_request.repo} #${card.pull_request.number}</p>` : ''}
+          </li>` )}</ul>`}
+    <details aria-label="Room conversation"><summary>Conversation</summary>${chatContent(body.chat)}</details>
+  </section>`);
 webContentRegistry.register<ForgeContentBody>('foundry', (body) => foundryContent(body));
 // The persona HOME — the profile + brain HUD center, dispatched when the
 // focused tab is persona-kind (the projection publishes purpose "persona").

--- a/apps/web/src/content/registry.ts
+++ b/apps/web/src/content/registry.ts
@@ -106,11 +106,13 @@ webContentRegistry.register<ChatContentBody>('chat', (body) => chatContent(body)
 webContentRegistry.register<ProjectContentBody>(PROJECT_PURPOSE, (body) => html`
   <section class="project-workspace" aria-label="Project workspace">
     <header class="project-heading"><h2>${body.title}</h2><span>Work board</span></header>
-    ${body.board === undefined
+    ${body.board.status === 'awaiting'
       ? html`<p role="status">Waiting for this room's work board…</p>`
-      : body.board.cards.length === 0
+      : body.board.status === 'rejected'
+        ? html`<p role="alert">Work board unavailable: received a board for another room.</p>`
+      : body.board.snapshot.cards.length === 0
         ? html`<p>No work cards in this room yet.</p>`
-        : html`<ul class="project-cards">${body.board.cards.map((card) => html`
+        : html`<ul class="project-cards">${body.board.snapshot.cards.map((card) => html`
           <li class="project-card">
             <div class="project-card-meta"><span>${card.priority}</span><span>${card.state.replaceAll('_', ' ')}</span></div>
             <h3>${card.title}</h3>

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -20,6 +20,8 @@ export { SERVING_KIND, servingFromEnvelope } from './ServingState';
 export { BENCH_KIND, benchFromEnvelope } from './BenchState';
 export { benchContentBody, benchWidget } from './benchProjections';
 export { KANBAN_KIND, kanbanStateFromEnvelope } from './KanbanState';
+export { PROJECT_PURPOSE, projectContentBody } from './projectProjections';
+export type { ProjectContentBody } from './projectProjections';
 export type { ChatState } from './ChatState';
 
 export { chatViewModel, formatTimeOfDay } from './chatViewModel';

--- a/packages/chat-view/index.ts
+++ b/packages/chat-view/index.ts
@@ -21,7 +21,7 @@ export { BENCH_KIND, benchFromEnvelope } from './BenchState';
 export { benchContentBody, benchWidget } from './benchProjections';
 export { KANBAN_KIND, kanbanStateFromEnvelope } from './KanbanState';
 export { PROJECT_PURPOSE, projectContentBody } from './projectProjections';
-export type { ProjectContentBody } from './projectProjections';
+export type { ProjectContentBody, ProjectBoardState } from './projectProjections';
 export type { ChatState } from './ChatState';
 
 export { chatViewModel, formatTimeOfDay } from './chatViewModel';

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -56,10 +56,11 @@ describe('chat → pattern projections', () => {
     const project = { ...vm, purpose: 'project' };
     const board = { room_id: vm.roomId, lanes: [], cards: [] };
     expect(chatWorkspace(project, { board }).content).toMatchObject({
-      purpose: 'project', body: { title: vm.roomName, board, chat: { messages: vm.messages } },
+      purpose: 'project', body: { title: vm.roomName, board: { status: 'ready', snapshot: board }, chat: { messages: vm.messages } },
     });
-    expect(chatWorkspace(project, { board: { ...board, room_id: 'other-room' } }).content.body).not.toHaveProperty('board');
-    expect(chatWorkspace(project).content.body).not.toHaveProperty('board');
+    expect(chatWorkspace(project, { board: { ...board, room_id: 'other-room' } }).content.body).toMatchObject({ board: { status: 'rejected', reason: 'foreign-room' } });
+    expect(chatWorkspace(project, { board: { ...board, room_id: 'other-room' } }).content.body).not.toHaveProperty('board.snapshot');
+    expect(chatWorkspace(project).content.body).toMatchObject({ board: { status: 'awaiting' } });
   });
   // what this catches: the roster projects to the people-`Listing` — the cell
   // template resolves glyph/badges/status so a target only draws them.

--- a/packages/chat-view/patternProjections.spec.ts
+++ b/packages/chat-view/patternProjections.spec.ts
@@ -50,6 +50,17 @@ const vm: ChatViewModel = {
 };
 
 describe('chat → pattern projections', () => {
+  // Regression b742642d: project rooms must carry a board body, and a late
+  // snapshot from another room must never appear as the selected room's work.
+  it('projects project content with only its own board snapshot', () => {
+    const project = { ...vm, purpose: 'project' };
+    const board = { room_id: vm.roomId, lanes: [], cards: [] };
+    expect(chatWorkspace(project, { board }).content).toMatchObject({
+      purpose: 'project', body: { title: vm.roomName, board, chat: { messages: vm.messages } },
+    });
+    expect(chatWorkspace(project, { board: { ...board, room_id: 'other-room' } }).content.body).not.toHaveProperty('board');
+    expect(chatWorkspace(project).content.body).not.toHaveProperty('board');
+  });
   // what this catches: the roster projects to the people-`Listing` — the cell
   // template resolves glyph/badges/status so a target only draws them.
   it('projects the roster into the people Listing', () => {

--- a/packages/chat-view/patternProjections.ts
+++ b/packages/chat-view/patternProjections.ts
@@ -48,6 +48,7 @@ import { liveContentBody, liveFaceOpen, type LiveCallOverlay } from './liveProje
 import { benchContentBody } from './benchProjections';
 import { arenaContentBody, type ArenaViewState } from './arenaProjections';
 import { canvasContentBody, type CanvasViewState } from './canvasProjections';
+import { PROJECT_PURPOSE, projectContentBody, type ProjectContentBody } from './projectProjections';
 
 /** Leading glyph per member kind — the neutral human/agent/system discriminant, as a
  *  display token the Listing carries (targets draw it, they don't re-derive it). */
@@ -652,6 +653,7 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
     | ContentView<BenchContentBody>
     | ContentView<AcademyContentBody>
     | ContentView<CanvasContentBody>
+    | ContentView<ProjectContentBody>
     | ContentView<SettingsContentBody> = settingsBody
     ? { purpose: SETTINGS_PURPOSE, body: settingsBody }
     : personaBody
@@ -670,6 +672,8 @@ export function chatWorkspace(vm: ChatViewModel, live?: WorkspaceLive): Workspac
                 ? { purpose: CANVAS_PURPOSE, body: canvasBody }
                 : academyBody
                   ? { purpose: ACADEMY_PURPOSE, body: academyBody }
+                  : vm.purpose === PROJECT_PURPOSE
+                    ? { purpose: PROJECT_PURPOSE, body: projectContentBody(vm, live?.board) }
                   : {
                       purpose: vm.purpose,
                       body: { messages: vm.messages, transcript: vm.transcript, isEmpty: vm.isEmpty },

--- a/packages/chat-view/projectProjections.ts
+++ b/packages/chat-view/projectProjections.ts
@@ -1,0 +1,21 @@
+import type { KanbanViewState } from '@continuum/sdk-typescript';
+import type { ChatViewModel } from './chatViewModel';
+import type { ChatContentBody } from './patternProjections';
+
+export const PROJECT_PURPOSE = 'project';
+
+/** Shared project surface: the room's authoritative board and conversation.
+ * A previous room's late snapshot must never masquerade as this room's work. */
+export interface ProjectContentBody {
+  readonly title: string;
+  readonly board?: KanbanViewState;
+  readonly chat: ChatContentBody;
+}
+
+export function projectContentBody(vm: ChatViewModel, board?: KanbanViewState): ProjectContentBody {
+  return {
+    title: vm.roomName,
+    ...(board?.room_id === vm.roomId ? { board } : {}),
+    chat: { messages: vm.messages, transcript: vm.transcript, isEmpty: vm.isEmpty },
+  };
+}

--- a/packages/chat-view/projectProjections.ts
+++ b/packages/chat-view/projectProjections.ts
@@ -4,18 +4,27 @@ import type { ChatContentBody } from './patternProjections';
 
 export const PROJECT_PURPOSE = 'project';
 
+export type ProjectBoardState =
+  | { readonly status: 'awaiting' }
+  | { readonly status: 'rejected'; readonly reason: 'foreign-room' }
+  | { readonly status: 'ready'; readonly snapshot: KanbanViewState };
+
 /** Shared project surface: the room's authoritative board and conversation.
  * A previous room's late snapshot must never masquerade as this room's work. */
 export interface ProjectContentBody {
   readonly title: string;
-  readonly board?: KanbanViewState;
+  readonly board: ProjectBoardState;
   readonly chat: ChatContentBody;
 }
 
 export function projectContentBody(vm: ChatViewModel, board?: KanbanViewState): ProjectContentBody {
   return {
     title: vm.roomName,
-    ...(board?.room_id === vm.roomId ? { board } : {}),
+    board: board === undefined
+      ? { status: 'awaiting' }
+      : board.room_id === vm.roomId
+        ? { status: 'ready', snapshot: board }
+        : { status: 'rejected', reason: 'foreign-room' },
     chat: { messages: vm.messages, transcript: vm.transcript, isEmpty: vm.isEmpty },
   };
 }


### PR DESCRIPTION
Selecting a project room currently replaces the desktop with an unregistered-purpose error. Add project content to the shared workspace projection and render its room-scoped work board and conversation in web and ANSI targets. Distinguish awaiting data from an empty board, reject a board snapshot for another room, and keep message updates from scrolling the project board out of sight.

Verified against the running BigMama core through an isolated web preview: the original :8975 page errors on project; :8976 shows real cards and the room transcript. No core deployment or AIRC restart. Shared projection/web/terminal typechecks pass; 19 targeted tests pass; diff check and focused new renderer/projection lint pass. Broader lint reports 31 errors in existing large files, so this is not a clean full-lint claim.

First slice of AIRC card b742642d-741c-43e9-889c-37cb77648db5. Navigation still labels the project as chat; responsive chrome, board grouping/actions, and full live-call restoration remain follow-up work. Please review the room-scope gate and content dispatch before merge.
