### PR TITLE
fix(power): a hosting node holds a sleep assertion for the core's lifetime and says when it was suspended (card 94a95a98)

### DIFF
--- a/core/continuum-core/src/main.rs
+++ b/core/continuum-core/src/main.rs
@@ -569,6 +569,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // task simply parks on `rx.changed()` for the process lifetime — zero
     // CPU. The 30s give-up window from the old code was misleading anyway:
     // it never timed out the actual Bevy init, only this task's patience.
+    // The node says when it was suspended (card 94a95a98) — one row per hole in the ledger.
+    continuum_core::system_resources::absence_watch::spawn();
+
     let pm_clone = pressure_monitor.clone();
     tokio::spawn(async move {
         let mut rx = continuum_core::live::video::bevy_renderer::subscribe_ready();

--- a/core/continuum-core/src/system_resources/absence_watch.rs
+++ b/core/continuum-core/src/system_resources/absence_watch.rs
@@ -1,0 +1,98 @@
+//! ABSENCE WATCH — the node says when it was suspended, instead of leaving a hole in the
+//! ledger for a reader to infer the next day.
+//!
+//! One task, one `tokio::time::interval`, one probe class. Every tick compares the wall
+//! clock against the previous tick; a gap far longer than the period means the process
+//! was not running (system sleep, SIGSTOP, a VM pause, a laptop lid). The 2026-09-07
+//! power outage produced a 15-minute hole with ZERO rows — even the pure-timer catch-up
+//! tick — and the only way to learn the machine had slept was `pmset -g log` afterwards.
+//! Walking that tick back showed the M5 had been sleeping in cycles for three hours.
+//!
+//! Emits `boot.absent {from_ms, to_ms, gap_s, cause}` once per gap. `cause` is what the
+//! process can know on its own: `suspended` (the clock jumped; the OS did not run us).
+//! Deciding WHY (battery idle sleep, thermal, lid) is the operator's `pmset -g log`, and
+//! the row carries enough to line the two up.
+//!
+//! RTOS shape per CONCURRENCY-STYLE-GUIDE: own task, `interval`, no locks, no blocking,
+//! nothing on the hot path; the only side effect is a probe row.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// How often the watch ticks. Short enough that a tick gap names the absence to the
+/// nearest half-minute; long enough to cost nothing.
+pub const PERIOD: Duration = Duration::from_secs(30);
+
+/// A gap is an absence when the wall clock advanced by more than this many periods
+/// between two consecutive ticks. Three periods (90 s) sits above every scheduler
+/// hiccup and GC-class stall seen on the M5 and below the shortest dark-wake cycle.
+pub const ABSENT_AFTER_PERIODS: u32 = 3;
+
+/// The decision, pure: did the wall clock jump enough to call it an absence?
+pub fn absence_gap_s(prev_ms: u64, now_ms: u64) -> Option<u64> {
+    let gap_ms = now_ms.saturating_sub(prev_ms);
+    let threshold_ms = PERIOD.as_millis() as u64 * ABSENT_AFTER_PERIODS as u64;
+    (gap_ms > threshold_ms).then_some(gap_ms / 1000)
+}
+
+fn now_ms() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as u64)
+}
+
+/// Spawn the watch. Called once from main after the runtime is up.
+pub fn spawn() {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(PERIOD);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut prev = now_ms();
+        loop {
+            ticker.tick().await;
+            let Some(now) = now_ms() else {
+                // A clock before the epoch is its own absence of measurement; say so once.
+                crate::probe!(
+                    class = "boot.absent",
+                    from_ms = prev.unwrap_or(0),
+                    to_ms = 0u64,
+                    gap_s = 0u64,
+                    cause = "clock_unreadable",
+                    "the wall clock could not be read — absence cannot be measured this tick"
+                );
+                continue;
+            };
+            if let Some(gap_s) = prev.and_then(|p| absence_gap_s(p, now)) {
+                crate::probe!(
+                    class = "boot.absent",
+                    from_ms = prev.unwrap_or(0),
+                    to_ms = now,
+                    gap_s = gap_s,
+                    cause = "suspended",
+                    "the process did not run for this long — the machine slept or was paused; every lane, lease and turn in flight aged by this much"
+                );
+                tracing::warn!(
+                    gap_s,
+                    "⏸ ABSENT for {gap_s} s — the node was suspended (sleep/pause); check `pmset -g log` for the cause"
+                );
+            }
+            prev = Some(now);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the threshold drifting so that a real sleep (the M5's shortest
+    // dark-wake cycle was ~4 min) reads as a tick, or a scheduler hiccup reads as sleep.
+    #[test]
+    fn a_four_minute_hole_is_an_absence_and_a_late_tick_is_not() {
+        let t0 = 1_788_800_000_000u64;
+        assert_eq!(absence_gap_s(t0, t0 + 240_000), Some(240));
+        assert_eq!(absence_gap_s(t0, t0 + 91_000), Some(91), "just over three periods");
+        assert_eq!(absence_gap_s(t0, t0 + 89_000), None, "under three periods is a late tick");
+        assert_eq!(absence_gap_s(t0, t0 + 30_000), None);
+        assert_eq!(absence_gap_s(t0 + 10, t0), None, "a clock stepping backwards is not an absence");
+    }
+}

--- a/core/continuum-core/src/system_resources/absence_watch.rs
+++ b/core/continuum-core/src/system_resources/absence_watch.rs
@@ -53,7 +53,7 @@ pub fn spawn() {
                 // A clock before the epoch is its own absence of measurement; say so once.
                 crate::probe!(
                     class = "boot.absent",
-                    from_ms = prev.unwrap_or(0),
+                    from_ms = prev.unwrap_or(0), // unwrap_or: 0 = no previous reading, a legible absence in the row
                     to_ms = 0u64,
                     gap_s = 0u64,
                     cause = "clock_unreadable",
@@ -64,7 +64,7 @@ pub fn spawn() {
             if let Some(gap_s) = prev.and_then(|p| absence_gap_s(p, now)) {
                 crate::probe!(
                     class = "boot.absent",
-                    from_ms = prev.unwrap_or(0),
+                    from_ms = prev.unwrap_or(0), // unwrap_or: unreachable here (gap needs prev) — 0 stays legible
                     to_ms = now,
                     gap_s = gap_s,
                     cause = "suspended",

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -11,6 +11,7 @@
 //!
 //! Uses the `sysinfo` crate for cross-platform (macOS/Linux/Windows) monitoring.
 
+pub mod absence_watch;
 pub mod bounded_command;
 pub mod concurrency;
 pub mod disk_eviction;

--- a/tools/scripts/start-server.sh
+++ b/tools/scripts/start-server.sh
@@ -1129,4 +1129,15 @@ if [ -f "$REPO_ROOT/apps/web/package.json" ] && command -v npm >/dev/null 2>&1; 
     || echo "  ⚠ background desktop build failed — run npm run build -w @continuum/web to diagnose" >&2) &
 fi
 
+# A HOSTING NODE DOES NOT SLEEP (card 94a95a98). On 2026-09-07 the M5 idle-slept on
+# battery and then cycled Maintenance Sleep on AC for three hours while hosting five
+# citizens: the core ran only inside 180 s dark-wake windows, and every hourly number
+# read that evening was taken on a suspended machine. caffeinate holds the system-sleep
+# and idle-sleep assertions for exactly the core's lifetime (it wraps the exec), so the
+# assertion can never outlive the core or be forgotten by a later launcher. On battery
+# macOS may still sleep; the core says so itself (boot.absent, absence_watch.rs).
+if [ "$(uname -s)" = "Darwin" ] && command -v caffeinate >/dev/null 2>&1; then
+  echo "  power: holding the system-sleep assertion for the core's lifetime (caffeinate -s -i)"
+  exec caffeinate -s -i "$CORE_BIN" "$CONTINUUM_SOCKET"
+fi
 exec "$CORE_BIN" "$CONTINUUM_SOCKET"


### PR DESCRIPTION
fix(power): a hosting node holds a sleep assertion for the core's lifetime and says when it was suspended (card 94a95a98)

On 2026-09-07 the M5 idle-slept on battery from 20:36Z and cycled Maintenance
Sleep on AC afterwards while hosting five citizens: the core ran only inside
180 s dark-wake windows for three hours, and every hourly read that evening was
taken on a suspended machine. The only evidence was a 15-minute hole in the
probe ledger and `pmset -g log` the next day.

- start-server.sh (macOS): the core is exec'd under `caffeinate -s -i`, so the
  system-sleep and idle-sleep assertions live exactly as long as the core and
  cannot be forgotten by a later launcher.
- system_resources/absence_watch.rs: one interval task; a wall-clock jump of more
  than three periods between ticks emits boot.absent {from_ms, to_ms, gap_s,
  cause: suspended} and a warn line. The hole is said, never inferred.
- Pure decision absence_gap_s() with a test (a 4-minute hole is an absence, a
  late tick is not, a backwards clock is not).

Battery idle sleep and thermal-emergency sleep are outside what an assertion can
prevent; the card keeps the follow-ups (say 'on battery, sleeping in N min',
thermal as a governor input).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo