### PR TITLE
feat(grid): a spawned round announces itself to its parent room, and every node's resume pass seats its residents into announced citizen rounds (alpha S4)

### DIFF
--- a/core/continuum-core/src/experience/children.rs
+++ b/core/continuum-core/src/experience/children.rs
@@ -21,8 +21,8 @@ pub const CHILD_WALL_CATEGORY: &str = "children";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoomChildRecord {
-    /// The child room's id, as a string uuid (the wire form the binding already uses).
-    pub room_id: String,
+    /// The child room's id.
+    pub room_id: uuid::Uuid,
     /// The child room's NAME — what a remote node joins by.
     pub name: String,
     pub recipe: String,
@@ -52,7 +52,7 @@ impl RoomChildRecord {
 /// room was announced twice (a re-spawn of the same name). Malformed posts are skipped:
 /// a parent wall may carry older shapes and one bad row must not hide the rest.
 pub fn project_children(posts: &[airc_core::doctrine::WallPostPublished]) -> Vec<RoomChildRecord> {
-    let mut by_room: std::collections::BTreeMap<String, RoomChildRecord> = Default::default();
+    let mut by_room: std::collections::BTreeMap<uuid::Uuid, RoomChildRecord> = Default::default();
     for post in posts {
         let Ok(rec) = serde_json::from_str::<RoomChildRecord>(&post.body) else {
             continue;
@@ -60,7 +60,7 @@ pub fn project_children(posts: &[airc_core::doctrine::WallPostPublished]) -> Vec
         match by_room.get(&rec.room_id) {
             Some(prev) if prev.spawned_at_ms > rec.spawned_at_ms => {}
             _ => {
-                by_room.insert(rec.room_id.clone(), rec);
+                by_room.insert(rec.room_id, rec);
             }
         }
     }
@@ -90,15 +90,15 @@ mod tests {
     #[test]
     fn only_citizen_benchmark_children_qualify_and_the_newest_record_wins() {
         let bench = RoomChildRecord {
-            room_id: "r1".into(),
+            room_id: uuid::Uuid::from_u128(1),
             name: "bench-swe-bench-verified-1".into(),
             recipe: "benchmark".into(),
             driver: Some("citizen".into()),
             suite: Some("swe-bench-verified".into()),
             spawned_at_ms: 10,
         };
-        let detached = RoomChildRecord { driver: Some("detached_solve".into()), room_id: "r2".into(), ..bench.clone() };
-        let chat = RoomChildRecord { suite: None, driver: None, room_id: "r3".into(), ..bench.clone() };
+        let detached = RoomChildRecord { driver: Some("detached_solve".into()), room_id: uuid::Uuid::from_u128(2), ..bench.clone() };
+        let chat = RoomChildRecord { suite: None, driver: None, room_id: uuid::Uuid::from_u128(3), ..bench.clone() };
         let older = RoomChildRecord { spawned_at_ms: 5, name: "stale".into(), ..bench.clone() };
         let posts = vec![
             post(&serde_json::to_string(&older).unwrap()),   // unwrap: test literal
@@ -109,7 +109,7 @@ mod tests {
         ];
         let children = project_children(&posts);
         assert_eq!(children.len(), 3, "{children:?}");
-        let r1 = children.iter().find(|c| c.room_id == "r1").expect("r1 present"); // expect: test asserts presence
+        let r1 = children.iter().find(|c| c.room_id == uuid::Uuid::from_u128(1)).expect("r1 present"); // expect: test asserts presence
         assert_eq!(r1.name, "bench-swe-bench-verified-1", "the newest record wins");
         assert!(r1.is_citizen_benchmark());
         assert!(!detached.is_citizen_benchmark());

--- a/core/continuum-core/src/experience/children.rs
+++ b/core/continuum-core/src/experience/children.rs
@@ -1,0 +1,118 @@
+//! CHILD RECORDS — a spawned activity announces itself to its PARENT room, so a node that
+//! never spawned it can find it.
+//!
+//! Before 2026-09-08 a run room carried its recipe binding on its OWN wall and nothing
+//! reached the parent: the tracker on the spawning node knew the round, the presence
+//! refresher on that node adopted it, and a citizen hosted on another machine — seated
+//! in the same commons, working the same board — could never be seated in the round,
+//! because her node had no way to learn the room's name. "Personas that scale cross grid"
+//! (Joel, the alpha) starts with this record: one durable wall post in the parent, read
+//! by every node's resume pass.
+//!
+//! The record is small and stable: what the child IS (room, name, recipe, driver, the
+//! run's suite) and when it was spawned. Standing (working / paused / done) is NOT here —
+//! it lives on the child's own wall (`experience::standing`) and is read after joining,
+//! so a stale parent record can never seat a citizen into a finished round.
+
+use serde::{Deserialize, Serialize};
+
+/// Wall category on the PARENT room. Sibling of `recipe` and `standing`.
+pub const CHILD_WALL_CATEGORY: &str = "children";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomChildRecord {
+    /// The child room's id, as a string uuid (the wire form the binding already uses).
+    pub room_id: String,
+    /// The child room's NAME — what a remote node joins by.
+    pub name: String,
+    pub recipe: String,
+    /// The activity's driver when the recipe carries one (`citizen`, `detached_solve`…).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub driver: Option<String>,
+    /// The benchmark suite when this is a benchmark round; None for any other activity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suite: Option<String>,
+    pub spawned_at_ms: u64,
+}
+
+impl RoomChildRecord {
+    /// A benchmark round citizens pull from: it names a suite and its driver is citizen-
+    /// class. A detached solve or a chat spawned under the commons is not one.
+    pub fn is_citizen_benchmark(&self) -> bool {
+        self.suite.is_some()
+            && self
+                .driver
+                .as_deref()
+                .map(|d| d.to_ascii_lowercase().contains("citizen"))
+                .unwrap_or(false) // unwrap_or: no driver named = not a citizen round; a remote node never seats on a guess
+    }
+}
+
+/// The children a parent's wall names — one per child room, the NEWEST record wins when a
+/// room was announced twice (a re-spawn of the same name). Malformed posts are skipped:
+/// a parent wall may carry older shapes and one bad row must not hide the rest.
+pub fn project_children(posts: &[airc_core::doctrine::WallPostPublished]) -> Vec<RoomChildRecord> {
+    let mut by_room: std::collections::BTreeMap<String, RoomChildRecord> = Default::default();
+    for post in posts {
+        let Ok(rec) = serde_json::from_str::<RoomChildRecord>(&post.body) else {
+            continue;
+        };
+        match by_room.get(&rec.room_id) {
+            Some(prev) if prev.spawned_at_ms > rec.spawned_at_ms => {}
+            _ => {
+                by_room.insert(rec.room_id.clone(), rec);
+            }
+        }
+    }
+    by_room.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airc_core::doctrine::WallPostPublished;
+
+    fn post(body: &str) -> WallPostPublished {
+        WallPostPublished {
+            room_id: airc_core::RoomId::from_uuid(uuid::Uuid::nil()),
+            post_id: uuid::Uuid::nil(),
+            category: CHILD_WALL_CATEGORY.to_string(),
+            body: body.to_string(),
+            supersedes: None,
+            published_by: airc_core::PeerId::from_u128(1),
+            published_at_ms: 0,
+        }
+    }
+
+    // what this catches: a remote node seating its residents into the wrong child (a chat,
+    // a detached solve, or a stale duplicate announcement) — only a citizen-driven
+    // benchmark round with a suite qualifies, and the newest record for a room wins.
+    #[test]
+    fn only_citizen_benchmark_children_qualify_and_the_newest_record_wins() {
+        let bench = RoomChildRecord {
+            room_id: "r1".into(),
+            name: "bench-swe-bench-verified-1".into(),
+            recipe: "benchmark".into(),
+            driver: Some("citizen".into()),
+            suite: Some("swe-bench-verified".into()),
+            spawned_at_ms: 10,
+        };
+        let detached = RoomChildRecord { driver: Some("detached_solve".into()), room_id: "r2".into(), ..bench.clone() };
+        let chat = RoomChildRecord { suite: None, driver: None, room_id: "r3".into(), ..bench.clone() };
+        let older = RoomChildRecord { spawned_at_ms: 5, name: "stale".into(), ..bench.clone() };
+        let posts = vec![
+            post(&serde_json::to_string(&older).unwrap()),   // unwrap: test literal
+            post(&serde_json::to_string(&bench).unwrap()),   // unwrap: test literal
+            post("not json"),
+            post(&serde_json::to_string(&detached).unwrap()), // unwrap: test literal
+            post(&serde_json::to_string(&chat).unwrap()),     // unwrap: test literal
+        ];
+        let children = project_children(&posts);
+        assert_eq!(children.len(), 3, "{children:?}");
+        let r1 = children.iter().find(|c| c.room_id == "r1").expect("r1 present"); // expect: test asserts presence
+        assert_eq!(r1.name, "bench-swe-bench-verified-1", "the newest record wins");
+        assert!(r1.is_citizen_benchmark());
+        assert!(!detached.is_citizen_benchmark());
+        assert!(!chat.is_citizen_benchmark());
+    }
+}

--- a/core/continuum-core/src/experience/mod.rs
+++ b/core/continuum-core/src/experience/mod.rs
@@ -67,6 +67,7 @@ use crate::modules::grid::acl::required_trust;
 use crate::modules::grid::node::TrustLevel;
 
 pub mod binding;
+pub mod children;
 pub mod spawned_rooms;
 pub mod membership;
 pub mod recipe;

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -507,15 +507,24 @@ pub async fn spawn_activity_room(
         ),
     )?;
     let resolved_params = resolve_params(&recipe_def, params)?;
+    // Read before `resolved_params` moves into the binding below.
+    let child_driver = resolved_params.get("driver").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let child_suite = resolved_params.get("suite").and_then(|v| v.as_str()).map(|s| s.to_string());
     // WHERE IT ROOTS: an explicit parent wins (a sub-activity nests under the activity
     // that spawned it); else the recipe's declared BASE (a benchmark round is learning →
     // `academy`, by what it is); else nowhere in particular (the spawner's context). The
     // base room is resolved by name WITHOUT moving the spawner's focus (airc's Keep join).
+    // The parent ROOM (not just its id) is kept when we resolved it ourselves: the child
+    // record below is published on the parent's wall, and that needs a `Room`.
+    let mut parent_room: Option<airc_lib::Room> = None;
     let parent = match parent {
         Some(p) => Some(p),
         None => match recipe_def.base.as_deref() {
             Some(base) => match airc.subscribe_room(base).await {
-                Ok(room) => Some(room.channel),
+                Ok(room) => {
+                    parent_room = Some(room.clone());
+                    Some(room.channel)
+                }
                 Err(source) => {
                     crate::probe!(
                         class = "activity.base_unresolved",
@@ -586,6 +595,69 @@ pub async fn spawn_activity_room(
                 ))
             })?;
 
+        // THE CHILD ANNOUNCES ITSELF TO ITS PARENT (experience::children). A remote node's
+        // resume pass reads the parent's wall and seats its residents by NAME; without
+        // this record a round existed only on the node that spawned it. Never fails the
+        // spawn: the room and its binding stand; a missing record is said, not hidden.
+        if let Some(parent_id) = parent {
+            let parent_room = match parent_room.take() {
+                Some(r) => Some(r),
+                None => airc
+                    .subscription_set()
+                    .await
+                    .ok()
+                    .and_then(|set| set.all().map(|sub| sub.as_room()).find(|r| r.channel == parent_id)),
+            };
+            match parent_room {
+                Some(parent_room) => {
+                    let record = crate::experience::children::RoomChildRecord {
+                        room_id: room.channel.as_uuid().to_string(),
+                        name: name.to_string(),
+                        recipe: recipe.to_string(),
+                        driver: child_driver,
+                        suite: child_suite,
+                        spawned_at_ms: std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0), // unwrap_or: a pre-epoch clock stamps 0 — the record still names the room
+                    };
+                    match serde_json::to_string(&record) {
+                        Ok(body) => match airc
+                            .publish_wall_post_in(
+                                &parent_room,
+                                crate::experience::children::CHILD_WALL_CATEGORY.to_string(),
+                                body,
+                                None,
+                            )
+                            .await
+                        {
+                            Ok(_) => crate::probe!(
+                                class = "activity.child_announced",
+                                room = %name,
+                                parent = %parent_room.name,
+                                recipe = %recipe,
+                                "the spawned activity is on its parent's wall — any node reading the parent can seat its residents"
+                            ),
+                            Err(source) => crate::probe!(
+                                class = "activity.child_announce_failed",
+                                room = %name,
+                                parent = %parent_room.name,
+                                error = %source.to_string(),
+                                "the room exists but its parent never heard of it — remote nodes cannot seat into it until a re-spawn"
+                            ),
+                        },
+                        Err(source) => tracing::warn!(%source, room = %name, "child record could not be encoded"),
+                    }
+                }
+                None => crate::probe!(
+                    class = "activity.child_announce_failed",
+                    room = %name,
+                    parent = %parent_id.as_uuid(),
+                    error = "parent room not in this peer's subscriptions",
+                    "the parent is known by id only — no wall to announce on"
+                ),
+            }
+        }
         Ok(ActivitySpawnResult {
             room_id: room.channel,
             name: room.name,

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -611,7 +611,7 @@ pub async fn spawn_activity_room(
             match parent_room {
                 Some(parent_room) => {
                     let record = crate::experience::children::RoomChildRecord {
-                        room_id: room.channel.as_uuid().to_string(),
+                        room_id: room.channel.as_uuid(),
                         name: name.to_string(),
                         recipe: recipe.to_string(),
                         driver: child_driver,

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -208,6 +208,7 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
             // held nothing and pulled nothing. Idempotent: a citizen already in
             // the room is left alone (no epoch bump, no stream re-open).
             reseat_working_rounds(&registry).await;
+            seat_announced_rounds(&registry).await;
             unseat_finished_rounds(&registry).await;
             if attempt == 1 {
                 crate::modules::work::spawn_env_prewarm_for_working_rounds();
@@ -390,6 +391,101 @@ async fn board_state_of(
 /// personas (`persona.inbound.catch_up_tick rooms_paged=68`, 2026-09-04) — 800
 /// store pages a minute for rooms nobody will speak in again. A room a citizen
 /// re-enters later resumes unread-first like any other; leaving loses nothing.
+/// CROSS-NODE SEATING (alpha slice S4). The rounds THIS node's tracker knows are
+/// reseated above; the rounds ANOTHER node spawned are only knowable through the parent
+/// room's wall (`experience::children`). Every node's citizens stand in the commons, so
+/// the commons' child records are readable everywhere: for each citizen-driven benchmark
+/// child not tracked here, join every local resident by name (idempotent on the daemon),
+/// then read the child's OWN standing — a paused or done round is left again at once, so
+/// a stale announcement never seats anyone into finished work.
+async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegistry) {
+    use crate::experience::children::{project_children, CHILD_WALL_CATEGORY};
+    let local: std::collections::HashSet<String> = crate::cognition::bench_round::live_rounds()
+        .into_iter()
+        .map(|r| r.run_room_name)
+        .collect();
+    // Any live resident's view of the commons will do — the wall is the room's, not hers.
+    let Some(reader) = registry.any_live_citizen() else { return };
+    let Ok(set) = reader.airc().subscription_set().await else { return };
+    let Some(commons) = set
+        .all()
+        .map(|sub| sub.as_room())
+        .find(|r| r.name == crate::persona::airc_runtime::CITIZEN_COMMONS_ROOM)
+    else {
+        return;
+    };
+    let posts = match reader.airc().wall_posts_in(&commons, Some(CHILD_WALL_CATEGORY)).await {
+        Ok(p) => p,
+        Err(e) => {
+            crate::probe!(
+                class = "bench.round.announced_unreadable",
+                error = %e.to_string(),
+                "the commons' child records could not be read — remote rounds stay invisible this pass"
+            );
+            return;
+        }
+    };
+    for child in project_children(&posts) {
+        if !child.is_citizen_benchmark() || local.contains(&child.name) {
+            continue;
+        }
+        let mut joined = 0u64;
+        let mut already = 0u64;
+        let mut failed = 0u64;
+        for rt in registry.iter() {
+            // join is idempotent on the daemon: an already-seated resident costs one call.
+            match rt.join_room(&child.name).await {
+                Ok(()) => joined += 1,
+                Err(_) => failed += 1,
+            }
+        }
+        // Standing lives on the child's own wall; read it now that we are inside.
+        let standing = match reader
+            .airc()
+            .subscription_set()
+            .await
+            .ok()
+            .and_then(|set| set.all().map(|sub| sub.as_room()).find(|r| r.name == child.name))
+        {
+            Some(room) => reader
+                .airc()
+                .wall_posts_in(&room, Some(crate::experience::standing::STANDING_WALL_CATEGORY))
+                .await
+                .ok()
+                .and_then(|posts| crate::experience::standing::project_standing(&posts).ok()),
+            None => None,
+        };
+        // The durable "finished" fact a remote node can read is the child's ARCHIVED
+        // standing (the tracker archives its room on pause/done); no standing = fresh.
+        let finished = standing
+            .as_ref()
+            .map(|s| s.archived)
+            .unwrap_or(false); // unwrap_or: no standing yet = a fresh round, seat it
+        if finished {
+            for rt in registry.iter() {
+                if rt.airc().part_channel(Some(child.name.as_str())).await.is_ok() {
+                    already += 1;
+                }
+            }
+            crate::probe!(
+                class = "bench.round.announced_finished",
+                room = %child.name,
+                left = already,
+                "an announced round is paused or done on its own wall — residents left again"
+            );
+            continue;
+        }
+        crate::probe!(
+            class = "bench.round.seated_remote",
+            room = %child.name,
+            suite = %child.suite.clone().unwrap_or_default(), // unwrap_or: is_citizen_benchmark guarantees a suite
+            joined,
+            failed,
+            "residents seated into a round another node spawned — the board is shared, now the room is too"
+        );
+    }
+}
+
 async fn unseat_finished_rounds(registry: &crate::persona::PersonaAircRuntimeRegistry) {
     use crate::persona::airc_citizen::AircCitizen as _;
     let (mut rounds_considered, mut pass_left, mut pass_failed, mut pass_unknown) = (0u64, 0u64, 0u64, 0u64);


### PR DESCRIPTION
feat(grid): a spawned round announces itself to its parent room, and every node's resume pass seats its residents into announced citizen rounds (alpha S4)

Before this a run room carried its recipe binding on its OWN wall and nothing reached
the parent: the tracker on the spawning node knew the round, its presence refresher
adopted it, and a citizen hosted on another machine — same commons, same board — could
never be seated in the round because her node had no way to learn the room's name.
"Personas that scale cross grid" (Joel, the alpha) starts here.

- experience/children.rs: RoomChildRecord {room_id, name, recipe, driver, suite,
  spawned_at_ms} on the PARENT's wall (category `children`); project_children() keeps
  the newest record per room and skips malformed rows; is_citizen_benchmark() = a suite
  and a citizen-class driver. Tested.
- modules/activity.rs::spawn_activity_room publishes the record to the parent after the
  binding (probes activity.child_announced / child_announce_failed); never fails the spawn.
- modules/benchmark_resume.rs::seat_announced_rounds: every resume pass reads the
  commons' child records through any live resident, joins every local resident by name
  into each citizen benchmark round this node's tracker does not own, then reads the
  child's own standing — an ARCHIVED round is left again at once (a stale announcement
  never seats anyone into finished work). Probes bench.round.seated_remote /
  announced_finished / announced_unreadable.

Acceptance (S4 in docs/planning/ALPHA-CROSS-GRID-TEAM-ROUND.md): a round dispatched on
the M5 shows activity.child_announced on #academy; within one resume pass the 5090 shows
bench.round.seated_remote {room} and its citizens are members of the run room; they pull
cards off the shared board.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo