### PR TITLE
fix(memory): the anomaly scan names root-owned memory hogs through ps when sysinfo reads them as zero (card 5527936b, part 3)

### DIFF
--- a/core/continuum-core/src/system_resources/memory_pressure.rs
+++ b/core/continuum-core/src/system_resources/memory_pressure.rs
@@ -888,6 +888,7 @@ impl MemoryPressureMonitor {
                 if level.to_u8() >= PressureLevel::High.to_u8() {
                     st.sys.refresh_processes(sysinfo::ProcessesToUpdate::All, false);
                     let floor = total / 4;
+                    let mut named = 0u32;
                     for (pid, proc) in st.sys.processes() {
                         let mem = proc.memory();
                         if mem < floor || Some(*pid) == st.pid {
@@ -897,13 +898,36 @@ impl MemoryPressureMonitor {
                         if name.contains("llama-server") {
                             continue;
                         }
+                        named += 1;
                         crate::probe!(
                             class = "memory.pressure.anomaly",
                             process = %name,
                             pid = pid.as_u32(),
                             rss_gb = mem / (1024 * 1024 * 1024),
+                            source = "sysinfo",
                             "a process other than the model server holds over a quarter of physical memory — this is the fault to name, not the lane"
                         );
+                    }
+                    // sysinfo cannot read root-owned processes' memory on macOS (fseventsd
+                    // at 26.6 GB reported 0 on 2026-09-08) — `ps` can. Bounded to 2 s.
+                    if named == 0 {
+                        let self_pid = st.pid.map(|p| p.as_u32());
+                        for p in crate::system_resources::process_anomaly::residents_above(
+                            floor,
+                            std::time::Duration::from_secs(2),
+                        ) {
+                            if Some(p.pid) == self_pid || p.name.contains("llama-server") {
+                                continue;
+                            }
+                            crate::probe!(
+                                class = "memory.pressure.anomaly",
+                                process = %p.name,
+                                pid = p.pid,
+                                rss_gb = p.rss_bytes / (1024 * 1024 * 1024),
+                                source = "ps",
+                                "a process other than the model server holds over a quarter of physical memory — this is the fault to name, not the lane"
+                            );
+                        }
                     }
                 }
             }

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -12,6 +12,7 @@
 //! Uses the `sysinfo` crate for cross-platform (macOS/Linux/Windows) monitoring.
 
 pub mod absence_watch;
+pub mod process_anomaly;
 pub mod bounded_command;
 pub mod concurrency;
 pub mod disk_eviction;

--- a/core/continuum-core/src/system_resources/process_anomaly.rs
+++ b/core/continuum-core/src/system_resources/process_anomaly.rs
@@ -1,0 +1,91 @@
+//! WHO HOLDS THE MEMORY — a reader that can see processes the in-process scan cannot.
+//!
+//! `sysinfo`'s per-process `memory()` on macOS reads task info the calling user may not
+//! be allowed to see: on 2026-09-08 fseventsd (root) sat at 26.6 GB resident beside a
+//! 7 GB model server, `memory.pressure` read Critical every minute, and the anomaly scan
+//! named nothing — every root-owned process reported 0. `ps` sees them all. This module
+//! is the fallback: one bounded `ps` per anomaly window, parsed by a pure function.
+
+use std::process::Command;
+use std::time::Duration;
+
+/// A process holding memory, as `ps -axo rss=,pid=,comm=` reports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResidentProcess {
+    pub name: String,
+    pub pid: u32,
+    pub rss_bytes: u64,
+}
+
+/// Parse `ps -axo rss=,pid=,comm=` output (rss in KiB). Malformed rows are skipped.
+pub fn parse_ps_rss(out: &str) -> Vec<ResidentProcess> {
+    out.lines()
+        .filter_map(|line| {
+            let mut it = line.split_whitespace();
+            let rss_kib: u64 = it.next()?.parse().ok()?;
+            let pid: u32 = it.next()?.parse().ok()?;
+            let comm = it.collect::<Vec<_>>().join(" ");
+            if comm.is_empty() {
+                return None;
+            }
+            let name = comm.rsplit('/').next().unwrap_or(&comm).to_string(); // unwrap_or: rsplit always yields at least the whole string
+            Some(ResidentProcess { name, pid, rss_bytes: rss_kib * 1024 })
+        })
+        .collect()
+}
+
+/// Processes above `floor_bytes`, largest first. Bounded: `ps` is killed after
+/// `timeout`; a failed or slow read returns an EMPTY list, never a guess.
+pub fn residents_above(floor_bytes: u64, timeout: Duration) -> Vec<ResidentProcess> {
+    let Ok(mut child) = Command::new("ps")
+        .args(["-axo", "rss=,pid=,comm="])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    else {
+        return Vec::new();
+    };
+    let started = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if started.elapsed() < timeout => std::thread::sleep(Duration::from_millis(20)),
+            _ => {
+                let _ = child.kill();
+                return Vec::new();
+            }
+        }
+    }
+    let Some(mut stdout) = child.stdout.take() else { return Vec::new() };
+    let mut text = String::new();
+    if std::io::Read::read_to_string(&mut stdout, &mut text).is_err() {
+        return Vec::new();
+    }
+    let mut rows: Vec<ResidentProcess> = parse_ps_rss(&text)
+        .into_iter()
+        .filter(|p| p.rss_bytes >= floor_bytes)
+        .collect();
+    rows.sort_by(|a, b| b.rss_bytes.cmp(&a.rss_bytes));
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the parser losing the process that matters (a root daemon with a
+    // path-qualified comm) or reading KiB as bytes — the 26.6 GB fseventsd row of 2026-09-08.
+    #[test]
+    fn ps_rows_parse_with_paths_and_kib_and_skip_garbage() {
+        let out = "27893760 340 /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/Support/fseventsd\n\
+                   7549952 60469 /Users/joel/.continuum/bin/llama-server\n\
+                   garbage line\n\
+                   1024 1 launchd\n";
+        let rows = parse_ps_rss(out);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].name, "fseventsd");
+        assert_eq!(rows[0].pid, 340);
+        assert_eq!(rows[0].rss_bytes / (1024 * 1024 * 1024), 26, "KiB → bytes: 26 GB, not 26 TB");
+        assert_eq!(rows[1].name, "llama-server");
+    }
+}


### PR DESCRIPTION
fix(memory): the anomaly scan names root-owned memory hogs through ps when sysinfo reads them as zero (card 5527936b, part 3)

After batch12 the monitor wrote memory.pressure {critical, swap_pct 96–98} every minute
and NO anomaly row, while `ps` showed fseventsd at 26.6 GB resident: sysinfo's per-process
memory() on macOS reads task info the calling user cannot see for root-owned processes,
so every one of them reported 0 and the scan named nothing.

- system_resources/process_anomaly.rs: parse_ps_rss() (pure, tested: paths, KiB → bytes,
  garbage rows skipped) and residents_above(floor, timeout) — one bounded `ps -axo
  rss=,pid=,comm=` (2 s, killed on overrun; a failed read is an empty list, never a guess).
- The monitor's anomaly branch falls back to it when the sysinfo scan named nothing; rows
  carry source = sysinfo | ps.

Acceptance: on a box with a root-owned process above a quarter of physical memory,
memory.pressure.anomaly {process, pid, rss_gb, source: ps} appears within one
critical-level probe window (60 s).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo