### PR TITLE
fix(memory): the ps reader drains stdout while it waits — the anomaly row fires on a real machine (card 5527936b)

### DIFF
--- a/core/continuum-core/src/system_resources/memory_pressure.rs
+++ b/core/continuum-core/src/system_resources/memory_pressure.rs
@@ -912,21 +912,32 @@ impl MemoryPressureMonitor {
                     // at 26.6 GB reported 0 on 2026-09-08) — `ps` can. Bounded to 2 s.
                     if named == 0 {
                         let self_pid = st.pid.map(|p| p.as_u32());
-                        for p in crate::system_resources::process_anomaly::residents_above(
+                        match crate::system_resources::process_anomaly::residents_above(
                             floor,
                             std::time::Duration::from_secs(2),
                         ) {
-                            if Some(p.pid) == self_pid || p.name.contains("llama-server") {
-                                continue;
+                            Ok(rows) => {
+                                for p in rows {
+                                    if Some(p.pid) == self_pid || p.name.contains("llama-server") {
+                                        continue;
+                                    }
+                                    crate::probe!(
+                                        class = "memory.pressure.anomaly",
+                                        process = %p.name,
+                                        pid = p.pid,
+                                        rss_gb = p.rss_bytes / (1024 * 1024 * 1024),
+                                        source = "ps",
+                                        "a process other than the model server holds over a quarter of physical memory — this is the fault to name, not the lane"
+                                    );
+                                }
                             }
-                            crate::probe!(
-                                class = "memory.pressure.anomaly",
-                                process = %p.name,
-                                pid = p.pid,
-                                rss_gb = p.rss_bytes / (1024 * 1024 * 1024),
-                                source = "ps",
-                                "a process other than the model server holds over a quarter of physical memory — this is the fault to name, not the lane"
-                            );
+                            // A read that could not complete is said, never an empty list
+                            // (card c7ae34b2) — the anomaly is UNKNOWN this window, not absent.
+                            Err(why) => crate::probe!(
+                                class = "memory.pressure.anomaly_unreadable",
+                                why = %why,
+                                "the process table could not be read this window — no anomaly claim either way"
+                            ),
                         }
                     }
                 }

--- a/core/continuum-core/src/system_resources/process_anomaly.rs
+++ b/core/continuum-core/src/system_resources/process_anomaly.rs
@@ -34,16 +34,36 @@ pub fn parse_ps_rss(out: &str) -> Vec<ResidentProcess> {
         .collect()
 }
 
+/// Why a `ps` read produced no rows — a failed read is never an empty list (card
+/// c7ae34b2: a read that could not complete must not return the empty value of its
+/// success type; five instances on 2026-09-08).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsReadFailed {
+    /// `ps` could not be spawned or exited with an error.
+    Spawn,
+    /// `ps` did not finish inside the bound; the reader thread was abandoned.
+    Timeout,
+}
+
+impl std::fmt::Display for PsReadFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn => f.write_str("ps could not be run"),
+            Self::Timeout => f.write_str("ps did not finish inside the bound"),
+        }
+    }
+}
+
 /// Processes above `floor_bytes`, largest first. Bounded: the read runs on its own
-/// thread and is abandoned after `timeout`; a failed or slow read returns an EMPTY list,
-/// never a guess.
+/// thread and is abandoned after `timeout`. A failed or slow read is an `Err` naming
+/// why — never an empty list that reads as "nothing to name".
 ///
 /// The first cut polled `try_wait` and read stdout only after exit. `ps -axo` on a
 /// developer Mac prints more than the 64 KB pipe buffer (700 processes with full comm
 /// paths), so ps blocked on a full pipe, never exited, the 2 s bound killed it, and the
 /// monitor named nothing while fseventsd sat at 21 GB (2026-09-08 03:3xZ, batch13).
 /// `output()` drains stdout while waiting; the timeout wraps the whole call.
-pub fn residents_above(floor_bytes: u64, timeout: Duration) -> Vec<ResidentProcess> {
+pub fn residents_above(floor_bytes: u64, timeout: Duration) -> Result<Vec<ResidentProcess>, PsReadFailed> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let out = Command::new("ps")
@@ -53,15 +73,16 @@ pub fn residents_above(floor_bytes: u64, timeout: Duration) -> Vec<ResidentProce
         let _ = tx.send(out);
     });
     let text = match rx.recv_timeout(timeout) {
-        Ok(Ok(out)) => String::from_utf8_lossy(&out.stdout).to_string(),
-        _ => return Vec::new(),
+        Ok(Ok(out)) if out.status.success() => String::from_utf8_lossy(&out.stdout).to_string(),
+        Ok(_) => return Err(PsReadFailed::Spawn),
+        Err(_) => return Err(PsReadFailed::Timeout),
     };
     let mut rows: Vec<ResidentProcess> = parse_ps_rss(&text)
         .into_iter()
         .filter(|p| p.rss_bytes >= floor_bytes)
         .collect();
     rows.sort_by(|a, b| b.rss_bytes.cmp(&a.rss_bytes));
-    rows
+    Ok(rows)
 }
 
 #[cfg(test)]
@@ -90,7 +111,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn the_real_ps_read_names_this_process() {
-        let rows = residents_above(0, Duration::from_secs(5));
+        let rows = residents_above(0, Duration::from_secs(5)).expect("ps must run on this box"); // expect: the test's premise
         let me = std::process::id();
         assert!(rows.iter().any(|r| r.pid == me), "ps read returned {} rows, none is pid {me}", rows.len());
     }

--- a/core/continuum-core/src/system_resources/process_anomaly.rs
+++ b/core/continuum-core/src/system_resources/process_anomaly.rs
@@ -34,33 +34,28 @@ pub fn parse_ps_rss(out: &str) -> Vec<ResidentProcess> {
         .collect()
 }
 
-/// Processes above `floor_bytes`, largest first. Bounded: `ps` is killed after
-/// `timeout`; a failed or slow read returns an EMPTY list, never a guess.
+/// Processes above `floor_bytes`, largest first. Bounded: the read runs on its own
+/// thread and is abandoned after `timeout`; a failed or slow read returns an EMPTY list,
+/// never a guess.
+///
+/// The first cut polled `try_wait` and read stdout only after exit. `ps -axo` on a
+/// developer Mac prints more than the 64 KB pipe buffer (700 processes with full comm
+/// paths), so ps blocked on a full pipe, never exited, the 2 s bound killed it, and the
+/// monitor named nothing while fseventsd sat at 21 GB (2026-09-08 03:3xZ, batch13).
+/// `output()` drains stdout while waiting; the timeout wraps the whole call.
 pub fn residents_above(floor_bytes: u64, timeout: Duration) -> Vec<ResidentProcess> {
-    let Ok(mut child) = Command::new("ps")
-        .args(["-axo", "rss=,pid=,comm="])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    else {
-        return Vec::new();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let out = Command::new("ps")
+            .args(["-axo", "rss=,pid=,comm="])
+            .stderr(std::process::Stdio::null())
+            .output();
+        let _ = tx.send(out);
+    });
+    let text = match rx.recv_timeout(timeout) {
+        Ok(Ok(out)) => String::from_utf8_lossy(&out.stdout).to_string(),
+        _ => return Vec::new(),
     };
-    let started = std::time::Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) if started.elapsed() < timeout => std::thread::sleep(Duration::from_millis(20)),
-            _ => {
-                let _ = child.kill();
-                return Vec::new();
-            }
-        }
-    }
-    let Some(mut stdout) = child.stdout.take() else { return Vec::new() };
-    let mut text = String::new();
-    if std::io::Read::read_to_string(&mut stdout, &mut text).is_err() {
-        return Vec::new();
-    }
     let mut rows: Vec<ResidentProcess> = parse_ps_rss(&text)
         .into_iter()
         .filter(|p| p.rss_bytes >= floor_bytes)
@@ -88,4 +83,16 @@ mod tests {
         assert_eq!(rows[0].rss_bytes / (1024 * 1024 * 1024), 26, "KiB → bytes: 26 GB, not 26 TB");
         assert_eq!(rows[1].name, "llama-server");
     }
+
+    // what this catches: the reader returning empty on a real machine (the 64 KB pipe
+    // deadlock of batch13) — with floor 0 and a generous bound, ps must name at least
+    // this test process.
+    #[cfg(unix)]
+    #[test]
+    fn the_real_ps_read_names_this_process() {
+        let rows = residents_above(0, Duration::from_secs(5));
+        let me = std::process::id();
+        assert!(rows.iter().any(|r| r.pid == me), "ps read returned {} rows, none is pid {me}", rows.len());
+    }
+
 }


### PR DESCRIPTION
fix(memory): the ps reader drains stdout while it waits (card 5527936b)

Batch13 deployed the ps fallback and the anomaly row still never fired while ps
showed fseventsd at 21 GB. The first cut polled try_wait and read stdout only after
exit; `ps -axo rss=,pid=,comm=` on a developer Mac prints more than the 64 KB pipe
buffer, so ps blocked on a full pipe, never exited, the 2 s bound killed it, and the
reader returned an empty list — a bounded probe converting a full pipe into a silent
"nothing to name".

- residents_above runs Command::output() on its own thread (stdout drained while
  waiting) and abandons it after the timeout via recv_timeout.
- Test: the real ps read must name this test's own pid (unix).

Acceptance: memory.pressure.anomaly {process: fseventsd, source: ps} within one
critical-level probe window on the M5.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo