### PR TITLE
Close Chromium when perception surface initialization fails

### DIFF
--- a/packages/perception/domSurface.spec.ts
+++ b/packages/perception/domSurface.spec.ts
@@ -9,7 +9,8 @@
  * generous timeout. It needs a Chromium browser present; that's our stated expectation.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { chromium, type Browser } from 'playwright';
 import { DomSurface } from './domSurface';
 import type { ProbeNode } from './surface';
 
@@ -44,6 +45,50 @@ describe('DomSurface — the web Surface (Percept · Probe · Actuator · diff)'
   afterEach(async () => {
     await surface?.close();
     surface = undefined;
+  });
+
+  // Regression: failed open never returns a session for the caller's finally
+  // to close. Exercise real Chromium, and clean up even if the assertion fails.
+  it.each(['navigation', 'newPage'] as const)('closes Chromium after failed %s during open', { timeout: 45_000 }, async (stage) => {
+    const launch = chromium.launch.bind(chromium);
+    let browser: Browser | undefined;
+    const setupError = new Error('injected page creation failure');
+    const launchSpy = vi.spyOn(chromium, 'launch').mockImplementation(async (options) => {
+      browser = await launch(options);
+      if (stage === 'newPage') vi.spyOn(browser, 'newPage').mockRejectedValueOnce(setupError);
+      return browser;
+    });
+    try {
+      const opening = DomSurface.open({ url: stage === 'navigation' ? 'invalid://failed-open' : FIXTURE });
+      if (stage === 'newPage') await expect(opening).rejects.toBe(setupError);
+      else await expect(opening).rejects.toThrow();
+      expect(browser).toBeDefined();
+      expect(browser!.isConnected()).toBe(false);
+    } finally {
+      launchSpy.mockRestore();
+      await browser?.close();
+    }
+  });
+
+  it('preserves both initialization and cleanup errors', { timeout: 45_000 }, async () => {
+    const launch = chromium.launch.bind(chromium);
+    let browser: Browser | undefined;
+    const setupError = new Error('page creation failed');
+    const closeError = new Error('browser close failed');
+    const launchSpy = vi.spyOn(chromium, 'launch').mockImplementation(async (options) => {
+      browser = await launch(options);
+      vi.spyOn(browser, 'newPage').mockRejectedValueOnce(setupError);
+      vi.spyOn(browser, 'close').mockRejectedValueOnce(closeError);
+      return browser;
+    });
+    try {
+      await expect(DomSurface.open({ url: FIXTURE })).rejects.toMatchObject({
+        errors: [setupError, closeError], cause: setupError,
+      });
+    } finally {
+      launchSpy.mockRestore();
+      await browser?.close();
+    }
   });
 
   // what this catches: the whole Surface contract for the DOM in one flow — a regression

--- a/packages/perception/domSurface.ts
+++ b/packages/perception/domSurface.ts
@@ -161,6 +161,21 @@ export class DomSurface implements Surface<DomViewSpec, DomAction> {
       ...resolveLaunch(opts),
       ...(extraArgs.length > 0 ? { args: extraArgs } : {}),
     });
+    // Until initialization returns a surface, no caller owns this browser.
+    // In particular, observe/hotEdit cannot close a session that never returned.
+    try {
+      return await DomSurface.initialize(browser, opts);
+    } catch (error) {
+      try {
+        await browser.close();
+      } catch (closeError) {
+        throw new AggregateError([error, closeError], 'Browser initialization and cleanup failed', { cause: error });
+      }
+      throw error;
+    }
+  }
+
+  private static async initialize(browser: Browser, opts: DomSurfaceOptions): Promise<DomSurface> {
     // PERCEPTION_GRANT_MEDIA=1 pre-grants microphone + camera to the page so the
     // fake device publishes without a permission prompt nobody can click.
     const grantMedia = process.env.PERCEPTION_GRANT_MEDIA === '1';


### PR DESCRIPTION
When Chromium launches but page creation, script setup, navigation, or settling fails, DomSurface.open rejects before observe/hotEdit receive a session. Their finally blocks therefore have nothing to close, leaving the browser alive. Keep ownership inside open until initialization succeeds and close the browser on any initialization error. If cleanup also fails, preserve both errors and the original cause.

Validation: all six existing/extended DomSurface real-Chromium integration tests pass on Windows, including navigation rejection, injected newPage failure, browser disconnection before rejection, and combined setup/cleanup errors. Perception package typecheck passes. Independent adversarial reviewer Parfit approved source scope. Tests clean up their own browsers even on assertion failure.

This closes the failed-initialization leak path. It does not claim recovery of already-orphaned browsers/profile directories or hard-parent-exit cleanup. No live service or daemon changes.

Card: 519dafdb-1ee4-4506-b408-cc96d66e3cb5 (bounded slice of de9b8876).
