### PR TITLE
fix(runtime): preserve native paths and release paging locks

### DIFF
--- a/core/continuum-core/src/bin/continuum.rs
+++ b/core/continuum-core/src/bin/continuum.rs
@@ -89,7 +89,9 @@ fn local_help_requested(command: &str, args: &[String]) -> bool {
                 | "orphans"
                 | "deploy-verify"
                 | "verify"
-        ) && args.iter().any(|arg| matches!(arg.as_str(), "-h" | "--help")))
+        ) && args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-h" | "--help")))
 }
 
 async fn run() -> Result<(), CliError> {
@@ -1060,11 +1062,54 @@ fn apply_runtime_library_path(cmd: &mut std::process::Command) {
     let Ok(root) = continuum_root() else {
         return;
     };
-    let dirs = runtime_library_dirs(&root);
+    apply_runtime_library_env_in(cmd, &root, std::env::consts::OS);
+}
+
+/// Read the child's effective environment, including config.env assignments and
+/// explicit removals. Looking only at our own environment loses launch overrides.
+fn command_env(cmd: &std::process::Command, key: &str) -> Option<std::ffi::OsString> {
+    match cmd.get_envs().find(|(name, _)| {
+        if cfg!(windows) {
+            name.as_encoded_bytes().eq_ignore_ascii_case(key.as_bytes())
+        } else {
+            *name == key
+        }
+    }) {
+        Some((_, value)) => value.map(std::ffi::OsStr::to_os_string),
+        None => std::env::var_os(key),
+    }
+}
+
+/// The installed-library contract also applies to binary-only launches. In
+/// particular, Windows otherwise finds System32's older ONNX Runtime and voice
+/// initialization panics while the rest of the core reports ready (card d2698cdc).
+/// Configure only the child, before spawn; never mutate a running process's env.
+fn apply_runtime_library_env_in(cmd: &mut std::process::Command, root: &Path, os: &str) {
+    if command_env(cmd, "ORT_DYLIB_PATH").is_none_or(|path| path.is_empty()) {
+        let library_name = match os {
+            "windows" => "onnxruntime.dll",
+            "macos" => "libonnxruntime.dylib",
+            _ => "libonnxruntime.so",
+        };
+        let installed = root.join("lib").join(library_name);
+        let homebrew = Path::new("/opt/homebrew/lib/libonnxruntime.dylib");
+        if installed.is_file() {
+            cmd.env("ORT_DYLIB_PATH", installed);
+        } else if os == "macos" && homebrew.is_file() {
+            cmd.env("ORT_DYLIB_PATH", homebrew);
+        } else if os == "windows" {
+            eprintln!(
+                "⚠ ONNX Runtime not provisioned at {}. Voice initialization may fail if Windows loads its system copy; install the onnxruntime module or set ORT_DYLIB_PATH.",
+                installed.display()
+            );
+        }
+    }
+
+    let dirs = runtime_library_dirs(root);
     if dirs.is_empty() {
         return;
     }
-    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let existing = command_env(cmd, "PATH").unwrap_or_default();
     let joined = std::env::join_paths(dirs.into_iter().chain(std::env::split_paths(&existing)));
     match joined {
         Ok(path) => {
@@ -2429,8 +2474,16 @@ mod tests {
     #[test]
     fn lifecycle_help_precedes_actions_and_remote_help_stays_remote() {
         for command in [
-            "start", "reboot", "restart", "boot", "stop", "desktop", "ui", "orphans",
-            "deploy-verify", "verify",
+            "start",
+            "reboot",
+            "restart",
+            "boot",
+            "stop",
+            "desktop",
+            "ui",
+            "orphans",
+            "deploy-verify",
+            "verify",
         ] {
             for flag in ["-h", "--help"] {
                 assert!(super::local_help_requested(
@@ -2488,6 +2541,76 @@ mod tests {
         assert!(
             !dirs.iter().any(|d| d.ends_with("models")),
             "unrelated continuum-root dirs are never runtime library paths: {dirs:?}"
+        );
+    }
+
+    // what this catches: card d2698cdc — ONNX selection must work without any
+    // CUDA/toolchain directory and must select the host platform's installed ABI.
+    #[test]
+    fn native_launch_selects_platform_ort_without_cuda() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir(root.join("lib")).expect("lib dir");
+        for (os, name) in [
+            ("windows", "onnxruntime.dll"),
+            ("linux", "libonnxruntime.so"),
+            ("macos", "libonnxruntime.dylib"),
+        ] {
+            let library = root.join("lib").join(name);
+            std::fs::write(&library, []).expect("installed library fixture");
+            let mut cmd = std::process::Command::new("unused");
+            cmd.env("ORT_DYLIB_PATH", "");
+            cmd.env("PATH", root.join("operator-bin"));
+            super::apply_runtime_library_env_in(&mut cmd, root, os);
+            assert_eq!(
+                super::command_env(&cmd, "ORT_DYLIB_PATH"),
+                Some(library.into_os_string())
+            );
+            assert_eq!(
+                super::command_env(&cmd, "PATH"),
+                Some(root.join("operator-bin").into_os_string()),
+                "ONNX discovery must not require or rewrite a toolchain PATH"
+            );
+        }
+    }
+
+    // what this catches: config.env overrides live on Command, not in the CLI's
+    // environment. Preserve both an explicit ORT selection and configured PATH.
+    #[test]
+    fn native_launch_preserves_runtime_overrides_and_configured_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let cuda = root.join("cuda-13.2/Library/bin");
+        std::fs::create_dir_all(&cuda).expect("cuda bin");
+        let explicit_ort = root.join("operator-ort.dll");
+        let explicit_path = root.join("operator-bin");
+        let mut cmd = std::process::Command::new("unused");
+        // Windows preserves spelling but compares environment keys without case.
+        // config.env may legally use either spelling; Unix remains case-sensitive.
+        let ort_key = if cfg!(windows) {
+            "ort_dylib_path"
+        } else {
+            "ORT_DYLIB_PATH"
+        };
+        let path_key = if cfg!(windows) { "Path" } else { "PATH" };
+        cmd.env(ort_key, &explicit_ort);
+        cmd.env(path_key, &explicit_path);
+        super::apply_runtime_library_env_in(&mut cmd, root, "windows");
+        assert_eq!(
+            super::command_env(&cmd, "ORT_DYLIB_PATH"),
+            Some(explicit_ort.into_os_string()),
+            "an explicit override remains authoritative even if the path is absent"
+        );
+        let actual = super::command_env(&cmd, "PATH").expect("child PATH");
+        assert_eq!(
+            std::env::split_paths(&actual).collect::<Vec<_>>(),
+            vec![cuda, explicit_path],
+            "prepend runtime dirs to the configured child PATH, not the parent's PATH"
+        );
+        cmd.env_remove(path_key);
+        assert!(
+            super::command_env(&cmd, "PATH").is_none(),
+            "an explicit removal must not fall through to the parent's environment"
         );
     }
 

--- a/core/continuum-core/src/genome/recall_select.rs
+++ b/core/continuum-core/src/genome/recall_select.rs
@@ -185,7 +185,8 @@ mod tests {
         let e = "test-embedder";
         // A BLENDED task (diagonal X+Y): different genes cover different halves of it,
         // so relevance and distinctness are separable (the realistic case).
-        let task = vec![0.7071, 0.7071, 0.0];
+        let diagonal = std::f32::consts::FRAC_1_SQRT_2;
+        let task = vec![diagonal, diagonal, 0.0];
         let x1 = sig(e, vec![1.0, 0.0, 0.0]); // covers the X half
         let x2 = sig(e, vec![1.0, 0.0, 0.0]); // exact duplicate of x1
         let y = sig(e, vec![0.0, 1.0, 0.0]); // covers the Y half — equally relevant, orthogonal

--- a/core/continuum-core/src/inference/backends/llamacpp.rs
+++ b/core/continuum-core/src/inference/backends/llamacpp.rs
@@ -642,24 +642,24 @@ impl LlamaCppBackend {
             .map_err(|e| format!("new_context failed: {e}"))?;
 
         // Eval text + media into the context, advancing n_past.
+        let eval_params = llama::MtmdEvalParams {
+            n_past: 0,
+            n_batch: self.config.n_batch as i32,
+            seq_id: 0,
+            logits_last: true,
+        };
         let eval_result = match kind {
             llama::MediaKind::Image => mtmd.eval_image(
                 &mut ctx,
                 prompt_with_marker,
                 media_bytes,
-                0,
-                self.config.n_batch as i32,
-                0,
-                true,
+                &eval_params,
             ),
             llama::MediaKind::Audio => mtmd.eval_audio(
                 &mut ctx,
                 prompt_with_marker,
                 media_bytes,
-                0,
-                self.config.n_batch as i32,
-                0,
-                true,
+                &eval_params,
             ),
         };
         let n_past = eval_result.map_err(|e| format!("mtmd eval ({:?}) failed: {e}", kind))?;

--- a/core/continuum-core/src/modules/data.rs
+++ b/core/continuum-core/src/modules/data.rs
@@ -4,8 +4,8 @@
 //! Also handles: vector/* commands (vector similarity search with in-memory caching)
 //! Uses the ORM module's StorageAdapter trait for database-agnostic operations.
 //!
-//! CRITICAL: Database paths are ALWAYS passed by the caller (TypeScript handle layer).
-//! NO defaults, NO environment variables, NO fallbacks. The caller owns the paths.
+//! Callers pass opaque database handles. This module resolves handles against
+//! the host's storage configuration; callers do not construct backend paths.
 
 use crate::orm::{
     adapter::{AdapterConfig, StorageAdapter},
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::any::Any;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Mutex, Semaphore};
 
@@ -228,16 +229,41 @@ impl DataState {
     ///
     /// This keeps the abstraction enforced at the caller boundary: SQL,
     /// URLs, and filenames simply do not exist in the caller's language.
+    /// `$HOME` remains the explicit home override; otherwise the native home
+    /// directory is used (including Windows launches without a shell's HOME).
     fn resolve_handle(&self, handle: &str) -> Result<String, String> {
+        Self::resolve_handle_with(handle, |key| std::env::var(key).ok(), dirs::home_dir)
+    }
+
+    /// Keep environment access at the resolution boundary so all local handle
+    /// families share one home policy, independently of the launching shell.
+    fn resolve_handle_with(
+        handle: &str,
+        env: impl Fn(&str) -> Option<String>,
+        native_home: impl FnOnce() -> Option<PathBuf>,
+    ) -> Result<String, String> {
+        // Lazy: configured backends and legacy paths do not need a home lookup.
+        let resolve_home = || {
+            if let Some(home) = env("HOME") {
+                return Ok(home);
+            }
+            native_home()
+                .ok_or_else(|| format!("resolve_handle('{handle}'): home directory unavailable"))?
+                .into_os_string()
+                .into_string()
+                .map_err(|_| {
+                    format!("resolve_handle('{handle}'): home directory is not valid UTF-8")
+                })
+        };
+
         // Main DB sentinel — honors DATABASE_URL env, falls back to SQLite.
         if handle == "main" {
-            if let Ok(url) = std::env::var("DATABASE_URL") {
+            if let Some(url) = env("DATABASE_URL") {
                 if !url.is_empty() {
                     return Ok(url);
                 }
             }
-            let home = std::env::var("HOME")
-                .map_err(|_| "resolve_handle('main'): HOME env not set".to_string())?;
+            let home = resolve_home()?;
             return Ok(format!("{}/.continuum/database/main.db", home));
         }
 
@@ -264,8 +290,7 @@ impl DataState {
                         "resolve_handle('{sentinel}{slug}'): slug must be a single path segment"
                     ));
                 }
-                let home = std::env::var("HOME")
-                    .map_err(|_| format!("resolve_handle('{sentinel}{slug}'): HOME env not set"))?;
+                let home = resolve_home()?;
                 return Ok(format!(
                     "{home}/.continuum/{bucket}/{slug}/data/longterm.db"
                 ));
@@ -274,16 +299,14 @@ impl DataState {
 
         // Telemetry SQLite sentinel.
         if handle == "@metrics" {
-            let home = std::env::var("HOME")
-                .map_err(|_| "resolve_handle('@metrics'): HOME env not set".to_string())?;
+            let home = resolve_home()?;
             return Ok(format!("{}/.continuum/metrics/metrics.sqlite", home));
         }
 
         // Per-persona UUID shape: 8-4-4-4-12 hex chars with hyphens (36 total).
         // Safe to check without crate parsing — the shape is unambiguous.
         if is_uuid_shape(handle) {
-            let home = std::env::var("HOME")
-                .map_err(|_| format!("resolve_handle('{}'): HOME env not set", handle))?;
+            let home = resolve_home()?;
             return Ok(format!(
                 "{}/.continuum/personas/{}/longterm.db",
                 home, handle
@@ -2350,35 +2373,92 @@ mod tests {
         ))
     }
 
-    /// what this catches: first-class citizenship (Joel 2026-07-25) — the
-    /// per-citizen store sentinels resolve to their OWN bucket, so an agent's
-    /// `/continuum:memory` writes land in `agents/<name>/…` (its durable
-    /// amnesia-fixing home), a human's in `humans/<name>/…`, a persona's in
-    /// `personas/<name>/…`. If the bucket mapping drifts, an agent's memory
-    /// collides with a persona of the same name or vanishes into the wrong dir.
+    /// what this catches: card d2698cdc — native Windows launches without HOME
+    /// lost chat and citizen memory. Every local handle must use the same native
+    /// home fallback while preserving explicit overrides and citizen isolation.
     #[test]
-    fn per_citizen_store_sentinels_resolve_to_their_own_bucket() {
-        // Set an isolated HOME so the resolved absolute path is deterministic.
-        let prior = std::env::var("HOME").ok();
-        std::env::set_var("HOME", "/tmp/continuum-citizen-test");
-        let state = DataState::new();
-        for (sentinel, bucket) in [
-            ("@persona:Asha", "personas/Asha"),
-            ("@agent:claude-code", "agents/claude-code"),
-            ("@human:operator", "humans/operator"),
+    fn database_handles_preserve_layout_with_native_home_and_overrides() {
+        let handles = [
+            ("main", "database/main.db"),
+            ("@persona:Asha", "personas/Asha/data/longterm.db"),
+            ("@agent:claude-code", "agents/claude-code/data/longterm.db"),
+            ("@human:operator", "humans/operator/data/longterm.db"),
+            ("@metrics", "metrics/metrics.sqlite"),
+            (
+                "e2f0e022-04ac-4f66-a26c-7146551745b4",
+                "personas/e2f0e022-04ac-4f66-a26c-7146551745b4/longterm.db",
+            ),
+        ];
+        for (home_override, native_home, expected_home) in [
+            (
+                Some("/tmp/explicit-home"),
+                "C:/Users/native",
+                "/tmp/explicit-home",
+            ),
+            (None, "C:/Users/native", "C:/Users/native"),
+            (None, "/Users/native", "/Users/native"),
         ] {
-            let resolved = state.resolve_handle(sentinel).expect("resolves");
+            for (handle, suffix) in handles {
+                let resolved = DataState::resolve_handle_with(
+                    handle,
+                    |key| match key {
+                        "HOME" => home_override.map(str::to_owned),
+                        // Empty DATABASE_URL must still select local SQLite.
+                        "DATABASE_URL" => Some(String::new()),
+                        _ => panic!("unexpected environment lookup: {key}"),
+                    },
+                    || {
+                        assert!(home_override.is_none(), "explicit HOME takes precedence");
+                        Some(PathBuf::from(native_home))
+                    },
+                )
+                .expect("local handle resolves");
+                assert_eq!(resolved, format!("{expected_home}/.continuum/{suffix}"));
+            }
+        }
+
+        let url = "postgres://localhost/continuum";
+        assert_eq!(
+            DataState::resolve_handle_with(
+                "main",
+                |key| {
+                    assert_eq!(key, "DATABASE_URL", "configured backend needs no HOME");
+                    Some(url.to_owned())
+                },
+                || panic!("configured backend needs no native home"),
+            )
+            .unwrap(),
+            url,
+        );
+        for (handle, _) in handles {
+            let error = DataState::resolve_handle_with(handle, |_| None, || None).unwrap_err();
             assert_eq!(
-                resolved,
-                format!("/tmp/continuum-citizen-test/.continuum/{bucket}/data/longterm.db"),
-                "sentinel {sentinel} → its own bucket"
+                error,
+                format!("resolve_handle('{handle}'): home directory unavailable")
             );
         }
-        // Path-escape defense holds for the new sentinels too.
-        assert!(state.resolve_handle("@agent:../evil").is_err());
-        match prior {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
+
+        // Invalid sentinels fail before resolving a home or touching storage.
+        for prefix in ["@persona:", "@agent:", "@human:"] {
+            for slug in ["", "../evil", "nested/evil", "nested\\evil"] {
+                assert!(DataState::resolve_handle_with(
+                    &format!("{prefix}{slug}"),
+                    |_| panic!("invalid slug needs no environment lookup"),
+                    || panic!("invalid slug needs no native home"),
+                )
+                .is_err());
+            }
+        }
+        for legacy in [url, "postgresql://localhost/continuum", "/tmp/legacy.db"] {
+            assert_eq!(
+                DataState::resolve_handle_with(
+                    legacy,
+                    |_| panic!("legacy connection needs no environment lookup"),
+                    || panic!("legacy connection needs no native home"),
+                )
+                .unwrap(),
+                legacy,
+            );
         }
     }
 

--- a/core/continuum-core/src/paging/pool.rs
+++ b/core/continuum-core/src/paging/pool.rs
@@ -730,34 +730,11 @@ where
 
     /// Snapshot stats for monitoring + PressureBroker queries.
     pub async fn stats(&self) -> PoolStats {
-        let entries = self.inner.entries.read();
-        let mut total_bytes: u64 = 0;
-        let mut pinned_count: usize = 0;
-        for entry in entries.values() {
-            total_bytes += entry.size_bytes;
-            if entry.pin_count.load(Ordering::Acquire) > 0 {
-                pinned_count += 1;
-            }
-        }
-        let max_bytes = self.inner.config.max_bytes;
-        let pressure = if max_bytes > 0 {
-            total_bytes as f64 / max_bytes as f64
-        } else {
-            0.0
-        };
-        let inflight_count = self.inner.inflight.lock().await.len();
-        PoolStats {
-            name: self.inner.config.name.clone(),
-            entry_count: entries.len(),
-            pinned_count,
-            total_bytes,
-            max_bytes,
-            pressure,
-            hit_count: self.inner.hits.load(Ordering::Relaxed),
-            miss_count: self.inner.misses.load(Ordering::Relaxed),
-            eviction_count: self.inner.evictions.load(Ordering::Relaxed),
-            inflight_count,
-        }
+        // The synchronous snapshot releases the entries guard before we wait
+        // for inflight loads. Monitoring must not stall entry writers/eviction.
+        let mut stats = self.stats_blocking();
+        stats.inflight_count = self.inner.inflight.lock().await.len();
+        stats
     }
 
     /// Reduce occupancy to 75% of max_bytes by evicting unpinned entries
@@ -1086,6 +1063,8 @@ mod tests {
         assert_eq!(r2.unwrap(), 123);
     }
 
+    // what this catches: card d2698cdc — stats waiting for the inflight map
+    // must release the entries lock while preserving its occupancy snapshot.
     #[tokio::test]
     async fn stats_pressure_tracks_occupancy() {
         let pool: PagedResourcePool<String, Vec<u8>> = PagedResourcePool::new(PoolConfig {
@@ -1095,9 +1074,23 @@ mod tests {
             eviction_priority: lru_priority(),
         });
         pool.insert("k".to_string(), vec![0; 25]);
-        let stats = pool.stats().await;
+        let inflight_guard = pool.inner.inflight.lock().await;
+        let mut pending_stats = std::pin::pin!(pool.stats());
+        assert!(futures::poll!(pending_stats.as_mut()).is_pending());
+        assert!(
+            pool.inner.entries.try_write().is_some(),
+            "a stats wait must not retain the synchronous entries guard"
+        );
+        pool.insert("later".to_string(), vec![0; 10]);
+        drop(inflight_guard);
+        let stats = pending_stats.await;
+        assert_eq!(stats.entry_count, 1, "occupancy is the pre-wait snapshot");
         assert_eq!(stats.total_bytes, 25);
+        assert_eq!(stats.inflight_count, 0);
         assert!((stats.pressure - 0.25).abs() < 0.001);
+        let current = pool.stats().await;
+        assert_eq!(current.entry_count, 2);
+        assert_eq!(current.total_bytes, 35);
     }
 
     #[tokio::test]

--- a/core/continuum-core/src/source_hygiene/identity_discipline.rs
+++ b/core/continuum-core/src/source_hygiene/identity_discipline.rs
@@ -137,7 +137,7 @@ mod tests {
     fn string_composite_id_keys_never_rise() {
         let violations = scan(&[&NoStringCompositeIdKeys]);
         assert!(
-            violations.len() <= BASELINE_STRING_COMPOSITE_KEYS,
+            violations.is_empty(),
             "string-composite id keys rose to {} (baseline {BASELINE_STRING_COMPOSITE_KEYS}).\n\
              Key on a typed struct of UUIDs, never a formatted string.\nOffenders:\n{}",
             violations.len(),

--- a/core/continuum-orm-derive/src/lib.rs
+++ b/core/continuum-orm-derive/src/lib.rs
@@ -334,18 +334,13 @@ struct ForeignKeyAttr {
     on_update: CascadeRuleAttr,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 enum CascadeRuleAttr {
+    #[default]
     Restrict,
     Cascade,
     SetNull,
     NoAction,
-}
-
-impl Default for CascadeRuleAttr {
-    fn default() -> Self {
-        CascadeRuleAttr::Restrict
-    }
 }
 
 fn parse_cascade_rule(s: &str) -> Option<CascadeRuleAttr> {

--- a/core/continuum-positron/src/scoping.rs
+++ b/core/continuum-positron/src/scoping.rs
@@ -78,7 +78,7 @@ impl PerUserSubstrates {
             .lock()
             .unwrap_or_else(|e| e.into_inner()) // poisoning = a PRIOR holder panicked; values are Arc handles and no invariant spans this lock, so recover the guard rather than fail a read for someone else's panic
             .entry(citizen)
-            .or_insert_with(Substrate::new)
+            .or_default()
             .clone()
     }
 
@@ -134,7 +134,7 @@ impl PerRoomSubstrates {
             .lock()
             .unwrap_or_else(|e| e.into_inner()) // poisoning = a PRIOR holder panicked; values are Arc handles, no invariant spans this lock, so recover rather than take grounding down for someone else's panic
             .entry(room)
-            .or_insert_with(Substrate::new)
+            .or_default()
             .clone()
     }
 

--- a/core/continuum-positron/src/session_task.rs
+++ b/core/continuum-positron/src/session_task.rs
@@ -34,16 +34,14 @@
 //! messages not realtime") — realtime is the default path, not a
 //! best-effort add-on.
 //!
-//! ## Rate: subscription is unlimited, observers are budgeted
+//! ## Rate: latest-state frames coalesce to the connection's budget
 //!
-//! A subscribed kind (a human renderer) forwards every change. An
-//! observed-only kind (AI perception) forwards at most its
-//! `budget_hz`. When a kind is both, the subscription wins (unlimited).
-//! When several observers name the same kind on one connection, the
-//! highest budget wins — one socket carries one stream per kind, and
-//! the most-demanding watcher sets its cadence. `budget_hz == 0` means
-//! snapshot-only: the observer got its snapshot from `handle`, but no
-//! live forwarder is attached.
+//! A subscribed kind has a `RENDERER_HZ` frame budget; observers request
+//! their own `budget_hz`. The highest budget naming a kind wins — one
+//! connection carries one stream per kind, and the most-demanding watcher
+//! sets its cadence. `budget_hz == 0` means snapshot-only: the observer got
+//! its snapshot from `handle`, but requests no live forwarder. Token streams
+//! use a separate rail and are unaffected by state-frame coalescing.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -61,22 +59,17 @@ use crate::scoping::SessionSubstrate;
 /// How fast a kind's live `State` frames are forwarded on this
 /// connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ForwardRate {
-    /// Every change — a subscribed human renderer wants all of them.
-    Unlimited,
-    /// At most `hz` frames per second — an observer's perception
+struct ForwardRate {
+    /// At most `hz` frames per second, from the subscription or observer
     /// budget. `hz` is always `>= 1` (0-budget observers get no
-    /// forwarder at all, so they never reach this variant).
-    Hz(u32),
+    /// forwarder at all, so they never construct a rate).
+    hz: u32,
 }
 
 impl ForwardRate {
-    /// Minimum spacing between forwarded frames. `Unlimited` → zero.
+    /// Minimum spacing between forwarded frames.
     fn min_interval(self) -> Duration {
-        match self {
-            ForwardRate::Unlimited => Duration::ZERO,
-            ForwardRate::Hz(hz) => Duration::from_secs_f64(1.0 / hz as f64),
-        }
+        Duration::from_secs_f64(1.0 / self.hz as f64)
     }
 }
 
@@ -106,7 +99,7 @@ fn frame_kinds(msg: &ClientMessage) -> Vec<String> {
     }
 }
 
-/// A subscribed renderer's frame budget. NOT `Unlimited`: state kinds are
+/// A subscribed renderer's frame budget. State kinds are
 /// latest-wins snapshots riding a `watch` channel, so intermediate revisions
 /// are legally skippable — and a boot-replay/burst that folds thousands of
 /// messages must NOT become thousands of socket frames (the 2026-07-30 "load
@@ -124,7 +117,7 @@ const RENDERER_HZ: u32 = 10;
 fn desired_rates(conn: &Connection) -> HashMap<String, ForwardRate> {
     let mut rates: HashMap<String, ForwardRate> = HashMap::new();
     for kind in &conn.subscription.kinds {
-        rates.insert(kind.clone(), ForwardRate::Hz(RENDERER_HZ));
+        rates.insert(kind.clone(), ForwardRate { hz: RENDERER_HZ });
     }
     for obs in conn.observers.values() {
         if obs.budget_hz == 0 {
@@ -134,11 +127,9 @@ fn desired_rates(conn: &Connection) -> HashMap<String, ForwardRate> {
         }
         for kind in &obs.kinds {
             match rates.get(kind) {
-                // A subscription on this kind outranks any observer.
-                Some(ForwardRate::Unlimited) => {}
-                Some(ForwardRate::Hz(existing)) if *existing >= obs.budget_hz => {}
+                Some(existing) if existing.hz >= obs.budget_hz => {}
                 _ => {
-                    rates.insert(kind.clone(), ForwardRate::Hz(obs.budget_hz));
+                    rates.insert(kind.clone(), ForwardRate { hz: obs.budget_hz });
                 }
             }
         }

--- a/core/expert-pager-policy/src/division.rs
+++ b/core/expert-pager-policy/src/division.rs
@@ -143,7 +143,7 @@ pub fn feasible_divisions(
     let mut out = Vec::new();
     for (i, t) in tiers.iter().enumerate() {
         let budget = hw.expert_cache_bytes(t.resident_bytes);
-        let slots = if shape.expert_bytes > 0 { budget / shape.expert_bytes } else { 0 };
+        let slots = budget.checked_div(shape.expert_bytes).unwrap_or(0);
         if budget == 0 || slots == 0 {
             continue; // this tier leaves no room for a cache — not a useful division
         }

--- a/core/llama/src/lib.rs
+++ b/core/llama/src/lib.rs
@@ -62,5 +62,5 @@ pub mod sys {
 
 mod mtmd;
 mod safe;
-pub use mtmd::{MediaKind, MtmdContext};
+pub use mtmd::{MediaKind, MtmdContext, MtmdEvalParams};
 pub use safe::*;

--- a/core/llama/src/mtmd.rs
+++ b/core/llama/src/mtmd.rs
@@ -16,7 +16,8 @@
 //! let model = Model::load("qwen2-vl-7b.gguf", ModelParams::default())?;
 //! let mut lctx = model.new_context(ContextParams::default())?;
 //! let mtmd = MtmdContext::from_file("mmproj-qwen2-vl.gguf", &model)?;
-//! let n_past = mtmd.eval_image(&mut lctx, "<__media__>What's in this picture?", &png_bytes, 0, 512, 0)?;
+//! let eval = MtmdEvalParams { n_past: 0, n_batch: 512, seq_id: 0, logits_last: true };
+//! let n_past = mtmd.eval_image(&mut lctx, "<__media__>What's in this picture?", &png_bytes, &eval)?;
 //! // ... continue with normal sampler.sample(&lctx, ...) loop, starting from n_past
 //! ```
 //!
@@ -38,6 +39,20 @@ use std::ptr::NonNull;
 pub enum MediaKind {
     Image,
     Audio,
+}
+
+/// Where and how to evaluate a media prompt in an existing llama context.
+/// Shared by image and audio evaluation; media bytes remain borrowed separately.
+#[derive(Debug, Clone, Copy)]
+pub struct MtmdEvalParams {
+    /// Starting position in the context; evaluation returns the advanced position.
+    pub n_past: sys::llama_pos,
+    /// Maximum number of tokens per evaluation batch.
+    pub n_batch: i32,
+    /// Sequence in the shared context that receives the tokens.
+    pub seq_id: sys::llama_seq_id,
+    /// Compute final-token logits when sampling follows this evaluation.
+    pub logits_last: bool,
 }
 
 /// Multimodal projector context. Loaded once per (mmproj, model) pair and
@@ -96,13 +111,13 @@ impl MtmdContext {
 
     /// Tokenize `text` (which must contain the media marker, see
     /// `default_marker()`) together with `image_bytes`, then evaluate the
-    /// resulting interleaved chunks through `lctx` starting at `n_past`.
+    /// resulting interleaved chunks through `lctx` starting at `params.n_past`.
     ///
     /// Returns the new `n_past` after evaluation — the caller continues
-    /// the normal sampler-loop from this position. `seq_id` selects which
+    /// the normal sampler-loop from this position. `params.seq_id` selects which
     /// sequence in the shared context receives the tokens.
     ///
-    /// `logits_last` controls whether logits for the very last token are
+    /// `params.logits_last` controls whether logits for the very last token are
     /// computed (true if the next step is sampling, false if more eval
     /// calls follow).
     ///
@@ -115,12 +130,9 @@ impl MtmdContext {
         lctx: &mut Context,
         text: &str,
         image_bytes: &[u8],
-        n_past: i32,
-        n_batch: i32,
-        seq_id: i32,
-        logits_last: bool,
+        params: &MtmdEvalParams,
     ) -> Result<i32, String> {
-        self.eval_media(lctx, text, image_bytes, n_past, n_batch, seq_id, logits_last, MediaKind::Image)
+        self.eval_media(lctx, text, image_bytes, params, MediaKind::Image)
     }
 
     /// Audio analogue of `eval_image`. The underlying mtmd helper
@@ -140,12 +152,9 @@ impl MtmdContext {
         lctx: &mut Context,
         text: &str,
         audio_bytes: &[u8],
-        n_past: i32,
-        n_batch: i32,
-        seq_id: i32,
-        logits_last: bool,
+        params: &MtmdEvalParams,
     ) -> Result<i32, String> {
-        self.eval_media(lctx, text, audio_bytes, n_past, n_batch, seq_id, logits_last, MediaKind::Audio)
+        self.eval_media(lctx, text, audio_bytes, params, MediaKind::Audio)
     }
 
     /// Internal workhorse — single-bitmap eval (image OR audio, whichever
@@ -157,10 +166,7 @@ impl MtmdContext {
         lctx: &mut Context,
         text: &str,
         media_bytes: &[u8],
-        n_past: i32,
-        n_batch: i32,
-        seq_id: i32,
-        logits_last: bool,
+        params: &MtmdEvalParams,
         kind: MediaKind,
     ) -> Result<i32, String> {
         // Step 1: load bitmap from raw bytes — the helper auto-detects
@@ -260,16 +266,16 @@ impl MtmdContext {
         }
 
         // Step 4: evaluate the chunks through llama_context, advancing n_past.
-        let mut new_n_past: sys::llama_pos = n_past;
+        let mut new_n_past = params.n_past;
         let eval_rc = unsafe {
             sys::mtmd_helper_eval_chunks(
                 self.ptr.as_ptr(),
                 lctx.as_ptr(),
                 chunks.as_ptr(),
-                n_past,
-                seq_id,
-                n_batch,
-                logits_last,
+                params.n_past,
+                params.seq_id,
+                params.n_batch,
+                params.logits_last,
                 &mut new_n_past,
             )
         };


### PR DESCRIPTION
Native Windows launches can select the system ONNX DLL instead of the installed runtime, and data handles depend on a Unix-style HOME being present. Resolve every data-handle family through the same HOME/native-home policy, preserve the existing database layout and explicit overrides, and configure the platform ONNX library before launch even when no CUDA paths exist. Child PATH and ORT overrides retain Windows case-insensitive environment semantics.

The same runtime batch releases the paging entries lock before awaiting inflight stats, reuses the existing synchronous snapshot, and groups borrowed image/audio evaluation parameters without changing FFI ownership or argument order. Dependency cleanup removes a retired unlimited-frame variant while preserving the renderer/observer cadence, derives the existing default, and keeps zero-sized expert division safe.

Validation: native-launch regressions passed (2/2); combined data/paging/learning regressions passed (27/27); a final receipt, recall, and identity regression run passed (14/14, overlapping the first run). Positron subscription/scoping tests passed (14/14), and expert-pager-policy passed (25/25). The exact diagonal fixture and zero-violation assertion also fix three default-denied Clippy errors. Final `cargo clippy -p continuum-core --bin continuum --lib --tests --offline -- -D clippy::await_holding_lock` completed successfully against this batch plus #3897. Strict `-D warnings` remains failed against the existing warning backlog, now tracked in card 3cbbcae5; no suppressions were introduced. Live deployment verification remains separate from source/test validation.

The public Rust image/audio evaluation methods now accept `MtmdEvalParams`; all repository callers are updated. External callers of this internal wrapper must adopt the options struct.

Tracks AIRC card d2698cdc-5c82-46bc-bb6c-998f684dd731.
