### PR TITLE
fix(rag): make the #3862 binding unstatable in the TYPE SYSTEM, not in a doc comment (#3881)

### DIFF
--- a/.github/workflows/continuum-rust-tests.yml
+++ b/.github/workflows/continuum-rust-tests.yml
@@ -170,6 +170,33 @@ jobs:
             --skip 'modules::persona_allocator::' \
             --skip 'persona::allocator::tests::test_allocate'
 
+      # Compile-fail guards (#3881). `--lib` above CANNOT run these: proving a
+      # wrong construction does not compile requires a compile step, and the
+      # only in-toolchain way to assert that is a ```compile_fail doctest,
+      # which lives behind `--doc`. Without this step the guard would have been
+      # written, merged, and never executed once in CI — built-but-never-wired,
+      # which is the same class of defect #3881 exists to prevent.
+      #
+      # Filtered rather than the whole doctest surface deliberately: no doctest
+      # has ever run on a Linux runner here, so an unfiltered `--doc` could go
+      # red for reasons that predate this PR. Turning the rest on is its own
+      # card, not a side effect of this one.
+      #
+      # The `2 passed` assertion is load-bearing. A filter that matches NOTHING
+      # exits 0 — so if the struct is renamed, the step would go green while
+      # testing nothing at all. The count turns that silent zero into a failure.
+      - name: cargo test -p continuum-core --doc (compile-fail guards)
+        if: github.event_name != 'pull_request' || steps.gate.outputs.relevant == 'true'
+        run: |
+          set -o pipefail
+          cargo test -p continuum-core --doc BindingIsUnstatable 2>&1 | tee doc-guard.log
+          if ! grep -q 'test result: ok. 2 passed' doc-guard.log; then
+            echo "::error::expected exactly 2 BindingIsUnstatable doctests to pass."
+            echo "A zero-match filter exits 0, so this is how a renamed or deleted"
+            echo "guard is caught. Check core/continuum-core/src/persona/viewstate_rag.rs."
+            exit 1
+          fi
+
       # ts-rs binding-drift gate (was its own workflow until 2026-08-16).
       #
       # Rust types carry `#[derive(TS)]` + `#[ts(export_to = "…/protocol/typescript/…")]`.

--- a/core/continuum-core/src/persona/viewstate_rag.rs
+++ b/core/continuum-core/src/persona/viewstate_rag.rs
@@ -215,29 +215,63 @@ enum SubstrateBinding {
     PerRoom(std::sync::Arc<continuum_positron::scoping::PerRoomSubstrates>),
 }
 
+/// A kind that describes THE NODE, not a room: the bench board, serving, metrics.
+/// Its [`RagRenderable::room`] answers `None`, and it is the only shape
+/// [`ViewStateRagSource::new`] accepts.
+///
+/// This marker exists because a doc comment was carrying the rule. #3879 claimed
+/// "the two constructors make the wrong binding unstatable"; they did not --
+/// `new` was generic over every `RagRenderable`, so
+/// `ViewStateRagSource::<RosterViewState>::new(substrate)` (which IS the #3862
+/// defect) compiled fine and only this paragraph refused it. A comment asserting
+/// a guarantee the compiler does not enforce is the exact shape that cost 662
+/// abstains, so the guarantee moved into the type system (#3881).
+pub trait NodeScopedView: RagRenderable {}
+
+/// A kind that describes ONE ROOM: the roster, and every per-room view after it.
+/// Its [`RagRenderable::room`] answers `Some`, and it can ONLY be constructed
+/// through [`ViewStateRagSource::per_room`], which takes the registry and
+/// resolves the turn's room per delivery.
+///
+/// The invariant, in @IntelMac's words and credited to them: ANY SOURCE HOLDING A
+/// BOUND `room_id` MUST CONSULT THE TURN'S ROOM BEFORE READING IT. A room-scoped
+/// kind cannot be handed a single `Substrate`, so it cannot hold a bound room at
+/// all -- the invariant holds by construction rather than by review.
+pub trait RoomScopedView: RagRenderable {}
+
+/// THE ACCEPTANCE FOR #3881, as a compile-fail proof rather than a claim.
+///
+/// This is the #3862 defect written out: handing a ROOM-scoped kind a single
+/// `Substrate`, so it reads one room forever while citizens work in others. It
+/// compiled before this change, and the only thing refusing it was a paragraph.
+///
+/// ```compile_fail
+/// use continuum_core::persona::viewstate_rag::ViewStateRagSource;
+/// use continuum_positron::{RosterViewState, Substrate};
+/// // `new` is bound on NodeScopedView; the roster is RoomScopedView.
+/// let _ = ViewStateRagSource::<RosterViewState>::new(Substrate::new());
+/// ```
+///
+/// And the mirror, which MUST still build -- a guard that refuses everything is
+/// not a guard, and this is the half that catches an over-tight bound:
+///
+/// ```
+/// use continuum_core::persona::viewstate_rag::ViewStateRagSource;
+/// use continuum_positron::bench::BenchViewState;
+/// use continuum_positron::Substrate;
+/// let _ = ViewStateRagSource::<BenchViewState>::new(Substrate::new());
+/// ```
+///
+/// A doctest is used deliberately: `trybuild` would be a new dev-dependency for
+/// one assertion, and `compile_fail` is in the toolchain already. The cost is
+/// that it runs only under `cargo test --doc`, and CI ran `--lib` only -- so
+/// this guard would have merged and never executed once. `.github/workflows/
+/// continuum-rust-tests.yml` gained a step that runs it by name and asserts
+/// `2 passed`, because a filter matching NOTHING exits 0 and a renamed struct
+/// would otherwise leave a green step testing nothing.
+pub struct BindingIsUnstatable;
+
 impl<V: RagRenderable> ViewStateRagSource<V> {
-    /// A NODE-scoped source: one substrate, every turn. Use only for a kind whose
-    /// [`RagRenderable::room`] returns `None`.
-    pub fn new(substrate: Substrate) -> Self {
-        Self {
-            binding: SubstrateBinding::Node(substrate),
-            _kind: std::marker::PhantomData,
-        }
-    }
-
-    /// A ROOM-scoped source: reads the store of whatever room the turn is in.
-    ///
-    /// This is the constructor a room-scoped kind must use. It takes the REGISTRY,
-    /// not a room, precisely so no caller can bind a room at construction time.
-    pub fn per_room(
-        rooms: std::sync::Arc<continuum_positron::scoping::PerRoomSubstrates>,
-    ) -> Self {
-        Self {
-            binding: SubstrateBinding::PerRoom(rooms),
-            _kind: std::marker::PhantomData,
-        }
-    }
-
     /// Read + deserialize the current view, or `None` when the kind has never been
     /// stored (a cold boot before the first projection) or the payload does not
     /// match this build's shape. Both are honest absences: no block is rendered.
@@ -313,6 +347,32 @@ impl<V: RagRenderable> ViewStateRagSource<V> {
             });
         }
         (items, used, next)
+    }
+}
+
+impl<V: RagRenderable + NodeScopedView> ViewStateRagSource<V> {
+    /// A NODE-scoped source: one substrate, every turn. Use only for a kind whose
+    /// [`RagRenderable::room`] returns `None`.
+    pub fn new(substrate: Substrate) -> Self {
+        Self {
+            binding: SubstrateBinding::Node(substrate),
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<V: RagRenderable + RoomScopedView> ViewStateRagSource<V> {
+    /// A ROOM-scoped source: reads the store of whatever room the turn is in.
+    ///
+    /// This is the constructor a room-scoped kind must use. It takes the REGISTRY,
+    /// not a room, precisely so no caller can bind a room at construction time.
+    pub fn per_room(
+        rooms: std::sync::Arc<continuum_positron::scoping::PerRoomSubstrates>,
+    ) -> Self {
+        Self {
+            binding: SubstrateBinding::PerRoom(rooms),
+            _kind: std::marker::PhantomData,
+        }
     }
 }
 
@@ -434,6 +494,10 @@ impl<V: RagRenderable> RagSource for ViewStateRagSource<V> {
 
 // ─────────────────────── OUTLIER A: the roster (people) ───────────────────────
 
+/// The roster describes ONE room, so it is room-scoped and can only be built
+/// through `per_room`. See [`RoomScopedView`].
+impl RoomScopedView for continuum_positron::RosterViewState {}
+
 /// Who is present, rendered for a mind from the SAME `RosterViewState` the web
 /// roster renders.
 ///
@@ -516,6 +580,10 @@ impl RagRenderable for continuum_positron::RosterViewState {
 }
 
 // ──────────────── OUTLIER B: the benchmark board (numbers, no identity) ────────
+
+/// The bench board is ONE global fold describing the NODE, so it is node-scoped
+/// and keeps the single-substrate constructor. See [`NodeScopedView`].
+impl NodeScopedView for continuum_positron::bench::BenchViewState {}
 
 /// A benchmark run's live rows, rendered for a mind from the SAME `BenchViewState`
 /// the academy rail renders.


### PR DESCRIPTION
Closes #3881.

## What #3879 claimed, and what was actually true

#3879 landed the fix for #3862 and said its two constructors "make the wrong binding unstatable." They did not. `new` was generic over every `RagRenderable`, so this still compiled:

```rust
ViewStateRagSource::<RosterViewState>::new(substrate)
```

That line **is** the #3862 defect — one room's store read forever while citizens work in other rooms — and the only thing refusing it was a paragraph of prose above the constructor. A comment asserting a guarantee the compiler does not enforce is exactly how the defect reached production the first time, at a cost of 662 roster abstains and 74.1% of turns rendering `received=0`.

## The change

Two marker traits carry what the prose was carrying:

| trait | means | constructor |
|---|---|---|
| `NodeScopedView` | describes the NODE — bench board, serving, metrics. `room()` is `None`. | `new(Substrate)` |
| `RoomScopedView` | describes ONE room — roster, and every per-room view after it. | `per_room(registry)` |

`per_room` takes the **registry**, not a room, so a room-scoped kind cannot hold a bound `room_id` at all. @IntelMac's invariant, credited in the source: *any source holding a bound `room_id` must consult the turn's room before reading it.* It now holds by construction rather than by review.

## Acceptance — and the proof it is load-bearing

A ```compile_fail``` doctest pins the roster-plus-`Substrate` call as non-compiling, with a **mirror doctest that must build** (`BenchViewState`) — a guard that refuses everything is not a guard, and that half catches an over-tight bound.

`compile_fail` passes on *any* compile error, including a typo or a wrong import path, so I mutation-tested it. With `+ NodeScopedView` removed from the impl:

```
---- persona::viewstate_rag::BindingIsUnstatable (line 248) stdout ----
Test compiled successfully, but it's marked `compile_fail`.
test result: FAILED. 1 passed; 1 failed
```

The trait bound is what makes it fail. Restored, both pass.

`trybuild` was considered and not added: a new dev-dependency for one assertion, when `compile_fail` is already in the toolchain.

## The part that was nearly built-but-never-wired

**This guard could not have run in CI.** The workflow runs `cargo test -p continuum-core --lib`; a compile-fail assertion requires a compile step, which lives behind `--doc`. It would have merged and never executed once — the same silently-unwired shape this PR exists to prevent.

So `.github/workflows/continuum-rust-tests.yml` gains a `--doc` step:

- **filtered** to `BindingIsUnstatable` rather than the whole doctest surface, because no doctest has ever run on that Linux runner and an unfiltered `--doc` could go red for reasons predating this PR. Turning the rest on is its own card, not a side effect of this one.
- **asserting `2 passed`**, which is load-bearing: a filter matching nothing exits 0, so a renamed or deleted struct would otherwise leave a green step testing nothing at all.

Verified locally with the exact CI invocation: `test result: ok. 2 passed; 0 failed`.

## Also in this diff

The marker impls were first written between the `RagRenderable` doc blocks and their impls, which silently reattached the roster's and the bench board's documentation to an empty marker impl. Caught by reading the diff, not by a test. Both doc comments are restored to the items they describe.

No behaviour change. Type-level constraint, one acceptance test, one CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc
