### PR TITLE
fix(cognition): a ColdStartCritical source that delivers NOTHING says so, and says WHICH nothing (#3873)

### DIFF
--- a/core/continuum-core/src/cognition/bounded_room_ledger.rs
+++ b/core/continuum-core/src/cognition/bounded_room_ledger.rs
@@ -1,0 +1,228 @@
+//! A per-room diagnostics ledger that cannot grow without bound.
+//!
+//! ## Why this exists (#3903 review, @Astra)
+//!
+//! Two diagnostics in the grounding path key their state BY ROOM: the doctrine
+//! source's last observed outcome, and the `RagSourceFaculty`'s absence streak.
+//! Keying them by room was itself a review fix, since a single cell let room A's
+//! state answer for room B. But a plain `HashMap<Uuid, _>` traded one defect for
+//! a smaller one: it retains every room the persona has EVER taken a turn in, and
+//! per-task rooms plus arbitrary stamped contexts make that lifetime history
+//! strictly larger than current subscriptions. Diagnostics must not outlive their
+//! subject, and a map that only grows is a leak with a slow fuse.
+//!
+//! ## The eviction decision, stated rather than implied
+//!
+//! Per CLAUDE.md, a structure that accumulates gets an explicit eviction story or
+//! it does not ship. This one: bounded at the `cap` given to
+//! [`BoundedRoomLedger::new`], evicting the least-recently-WRITTEN room.
+//! Recency-by-write is the right axis because every observation is a write. A
+//! room being actively answered in is a room being written to, and the room not
+//! written to longest is by construction the one whose diagnostics matter least.
+//!
+//! EVICTION IS NOT A STATE CHANGE AND MUST NEVER BE REPORTED AS ONE. An evicted
+//! room's next observation looks like a first observation, which is honest: the
+//! ledger genuinely does not know its prior state. What must not happen is an
+//! eviction being read as RECOVERY, announcing that a room's absence ended when
+//! in truth its record was dropped. Callers get `None` from
+//! [`BoundedRoomLedger::take`] for an evicted room exactly as they do for a room
+//! that was never absent, and that is the property their regressions pin.
+//!
+//! ## Why not an LRU crate
+//!
+//! At this cap the order queue is a handful of entries and the linear scan in
+//! `touch` is cheaper than the allocation a fancier structure would cost. A
+//! dependency for thirty elements is not a trade worth making, and the existing
+//! convention in this tree for bounded per-room state is exactly this shape: a
+//! `const` cap plus a `VecDeque` and `pop_front`
+//! (`airc_persona_conversation.rs`). This is that convention applied to the ROOM
+//! KEY rather than to the per-room ring, which is the level the leak was at.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+
+/// How many rooms of diagnostics either ledger keeps.
+///
+/// Sized for every room a persona plausibly works in at once, plus headroom, not
+/// for its lifetime history. A citizen here is subscribed to six rooms, so the
+/// cap is well above ordinary work and far below the unbounded growth per-task
+/// rooms would otherwise produce.
+pub(crate) const ROOMS_TRACKED: usize = 32;
+
+/// A bounded map from room to some small diagnostic value.
+#[derive(Debug)]
+pub(crate) struct BoundedRoomLedger<K: Eq + Hash + Copy, V> {
+    entries: HashMap<K, V>,
+    /// Least-recently-written FIRST. Holds exactly the keys in `entries`.
+    order: VecDeque<K>,
+    cap: usize,
+}
+
+impl<K: Eq + Hash + Copy, V> BoundedRoomLedger<K, V> {
+    pub(crate) fn new(cap: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            // A cap of 0 would make every insert evict what it just wrote: a
+            // silently useless ledger rather than a loud error at the call site.
+            cap: cap.max(1),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn touch(&mut self, key: K) {
+        if let Some(at) = self.order.iter().position(|k| *k == key) {
+            self.order.remove(at);
+        }
+        self.order.push_back(key);
+    }
+
+    /// Write `value` for `key`, returning the PREVIOUS value if this ledger still
+    /// held one. `None` means either never-seen or evicted, deliberately the same
+    /// answer, because the ledger cannot distinguish them and pretending
+    /// otherwise is the exact failure this PR is about.
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        let previous = self.entries.insert(key, value);
+        self.touch(key);
+        while self.order.len() > self.cap {
+            if let Some(evicted) = self.order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+        previous
+    }
+
+    /// Read without disturbing recency. Gated like [`Self::len`] because every
+    /// production caller goes through `insert`/`take`/`entry_or` — a read that
+    /// does NOT count as a write would quietly make an actively-inspected room
+    /// evictable, so leaving it available to production invites that bug rather
+    /// than serving a need. Ungate it the day a real caller wants it, with a
+    /// decision about recency attached.
+    #[cfg(test)]
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+        self.entries.get(key)
+    }
+
+    /// Remove and return this key's value. `None` for an evicted room, same as
+    /// for a room that was never written. See the module doc on why eviction must
+    /// not read as recovery.
+    pub(crate) fn take(&mut self, key: &K) -> Option<V> {
+        let taken = self.entries.remove(key)?;
+        if let Some(at) = self.order.iter().position(|k| k == key) {
+            self.order.remove(at);
+        }
+        Some(taken)
+    }
+
+    /// Mutable access, inserting `default` first if absent. Counts as a WRITE for
+    /// recency, which is what makes an actively-observed room un-evictable.
+    pub(crate) fn entry_or(&mut self, key: K, default: V) -> &mut V {
+        if self.entries.contains_key(&key) {
+            self.touch(key);
+        } else {
+            self.insert(key, default);
+        }
+        self.entries
+            .get_mut(&key)
+            // Present by construction: either it already was, or the line above
+            // just inserted it. entries and order hold the same key set.
+            .expect("entry_or guarantees the key is present")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        debug_assert_eq!(
+            self.entries.len(),
+            self.order.len(),
+            "ledger key sets drift"
+        );
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the leak this type exists to close. A plain HashMap
+    // keyed by room retains every room the persona ever took a turn in, and
+    // per-task rooms make that unbounded. Exceeding the cap must evict, and the
+    // ledger must never hold more than the cap.
+    #[test]
+    fn exceeding_the_cap_evicts_the_least_recently_written_room() {
+        let mut led = BoundedRoomLedger::new(3);
+        for room in 0..3u32 {
+            led.insert(room, room);
+        }
+        assert_eq!(led.len(), 3);
+
+        // Touch room 0 so room 1 becomes the least-recently-written.
+        led.insert(0, 100);
+        led.insert(9, 9);
+
+        assert_eq!(led.len(), 3, "the cap is a ceiling, not a suggestion");
+        assert_eq!(led.get(&1), None, "the least-recently-WRITTEN room goes");
+        assert_eq!(
+            led.get(&0),
+            Some(&100),
+            "a room being actively written to must survive a newer arrival: \
+             recency-by-write is the whole reason this is not plain FIFO"
+        );
+        assert_eq!(led.get(&9), Some(&9));
+    }
+
+    // what this catches: EVICTION MUST NOT READ AS RECOVERY (@Astra, #3903). A
+    // caller asks take() whether this room had a running absence. For an evicted
+    // room the honest answer is unknown, and the only safe encoding of that in
+    // this API is the same None a never-absent room gives, so a caller cannot
+    // accidentally announce that a room's absence of N ticks ended about a record
+    // that was simply dropped.
+    #[test]
+    fn an_evicted_room_reports_nothing_rather_than_a_recovery() {
+        let mut led = BoundedRoomLedger::new(2);
+        led.insert(1, 7u32);
+        led.insert(2, 7);
+        led.insert(3, 7); // evicts room 1
+
+        assert_eq!(led.take(&1), None, "an evicted room yields no prior value");
+        assert_eq!(
+            led.take(&99),
+            None,
+            "non-degeneracy: a room that was NEVER written gives the same answer, \
+             which is what makes the two indistinguishable to a caller by design"
+        );
+        assert_eq!(led.take(&3), Some(7), "a live room still yields its value");
+    }
+
+    // what this catches: revisiting an evicted room must behave as a FIRST
+    // observation. No stale value resurrected, and the key set stays consistent.
+    #[test]
+    fn revisiting_an_evicted_room_starts_over() {
+        let mut led = BoundedRoomLedger::new(2);
+        led.insert(1, 5u32);
+        led.insert(2, 5);
+        led.insert(3, 5); // evicts 1
+        assert_eq!(led.get(&1), None);
+
+        assert_eq!(
+            led.insert(1, 42),
+            None,
+            "the returned previous value must be None: there is no prior state to \
+             compare against, and claiming one would invent history"
+        );
+        assert_eq!(led.get(&1), Some(&42));
+        assert_eq!(led.len(), 2, "and the cap still holds after the revisit");
+    }
+
+    // what this catches: entry_or counts as a write, so a room being incremented
+    // every tick can never become the eviction victim.
+    #[test]
+    fn entry_or_refreshes_recency() {
+        let mut led = BoundedRoomLedger::new(2);
+        led.insert(1, 0u32);
+        led.insert(2, 0);
+        *led.entry_or(1, 0) += 1;
+        led.insert(3, 0);
+        assert_eq!(led.get(&1), Some(&1), "the touched room survived");
+        assert_eq!(led.get(&2), None, "the untouched one was evicted");
+    }
+}

--- a/core/continuum-core/src/cognition/mod.rs
+++ b/core/continuum-core/src/cognition/mod.rs
@@ -83,6 +83,9 @@ pub mod pass_intent;
 pub mod perception_facts;
 pub mod persona_tools;
 pub mod persona_workspace;
+/// Bounded per-room diagnostics state, with the eviction decision CLAUDE.md
+/// requires of anything that accumulates (#3903 review).
+pub(crate) mod bounded_room_ledger;
 pub mod prefill_throttle;
 pub mod prompt_capture;
 pub mod rag_source_faculty;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -443,10 +443,15 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // the total ≤ window.
     let grounding_budget = super::rag_source_faculty::grounding_budget_for(cfg.context_window);
     for g in cfg.grounding_sources {
-        let faculty =
-            RagSourceFaculty::new(cfg.persona_id, g.source, g.policy)
+        let faculty = RagSourceFaculty::new(cfg.persona_id, g.source, g.policy)
             .with_budget(grounding_budget)
-            .with_volatile_content(g.volatile_content);
+            .with_volatile_content(g.volatile_content)
+            // Deferrability is also a LOUDNESS contract, not only a scheduling one
+            // (#3873). ColdStartCritical means "absent here is a wrong turn", so a
+            // source in this tier that delivers nothing says so in the probe
+            // ledger instead of abstaining silently — which is how `room-doctrine`
+            // sat at 0 bids in 873 consecutive ticks with nothing noticing.
+            .cold_start_critical(matches!(g.deferrability, Deferrability::ColdStartCritical));
         match g.deferrability {
             Deferrability::DeferTolerant if cfg.defer_grounding => {
                 faculties.push(Arc::new(DeferredFaculty::spawn(Arc::new(faculty))));

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -50,7 +50,6 @@
 //! salience-free, no new coupling. In the converged end-state this policy is just
 //! what each native faculty's `contribute()` returns.
 
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -179,7 +178,7 @@ pub struct RagSourceFaculty {
     /// produced a meaningless streak mixing both.
     ///
     /// Bounded by the rooms this persona actually takes turns in.
-    empty_streak: Mutex<HashMap<Uuid, u32>>,
+    empty_streak: Mutex<super::bounded_room_ledger::BoundedRoomLedger<Uuid, u32>>,
 }
 
 impl RagSourceFaculty {
@@ -211,7 +210,9 @@ impl RagSourceFaculty {
             // source's ordinary silence in the ledger, which is how a real signal
             // gets buried ([[bounded-window-eviction-bug-class]]).
             cold_start_critical: false,
-            empty_streak: Mutex::new(HashMap::new()),
+            empty_streak: Mutex::new(super::bounded_room_ledger::BoundedRoomLedger::new(
+                super::bounded_room_ledger::ROOMS_TRACKED,
+            )),
         }
     }
 
@@ -292,7 +293,7 @@ impl RagSourceFaculty {
             // diagnostics-only bookkeeping; a poisoned lock must not take
             // cognition down to protect a counter. No await is held here.
             let mut g = self.empty_streak.lock().unwrap_or_else(|e| e.into_inner());
-            let c = g.entry(room).or_insert(0);
+            let c = g.entry_or(room, 0);
             *c += 1;
             *c
         };
@@ -303,7 +304,7 @@ impl RagSourceFaculty {
                 persona_id = %self.persona_id,
                 room = %room,
                 consecutive_empty = streak,
-                "ColdStartCritical grounding delivered NOTHING and did not bid —                  this tier's absence is a WRONG turn, not an unenriched one. The                  source's own probe on the same tick carries WHY."
+                "ColdStartCritical grounding delivered NOTHING and did not bid —                  this tier's absence is a WRONG turn, not an unenriched one. This                  faculty is generic over every RagSource and cannot say WHY: only                  the source knows, and only if it reports at all. Where one does                  (room-doctrine emits rag.doctrine.outcome), that row reflects its                  LAST EVALUATION, which need not be this tick — a cached delivery                  never reaches the source."
             );
             return Some(streak);
         }
@@ -337,7 +338,10 @@ impl RagSourceFaculty {
         let streak = {
             // same contract as note_absence: recover the guard, never panic here.
             let mut g = self.empty_streak.lock().unwrap_or_else(|e| e.into_inner());
-            g.remove(&room).unwrap_or(0)
+            // `None` here is BOTH "never absent" and "evicted", and that is
+            // deliberate: announcing a recovery for a record that was merely
+            // dropped would be the same lie this whole change is about.
+            g.take(&room).unwrap_or(0)
         };
         if streak > 0 {
             crate::probe!(
@@ -642,6 +646,68 @@ mod tests {
                 faculty.note_absence(room()),
                 Some(1),
                 "and the next absence starts a NEW streak, not a continuation"
+            );
+        }
+
+        // what this catches: @Astra's #3903 re-review — per-room keys fixed the
+        // cross-talk but left BOTH diagnostic maps retaining every room the
+        // persona ever answered in, which per-task rooms make unbounded. The
+        // second half of her requirement is the subtle one: EVICTION MUST NOT BE
+        // REPORTED AS RECOVERY. A dropped record is not an absence that ended.
+        #[tokio::test]
+        async fn an_evicted_room_is_forgotten_without_announcing_a_recovery() {
+            let faculty = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+            let victim = Uuid::from_u128(1);
+            faculty.note_absence(victim);
+            assert_eq!(faculty.streak_in(victim), 1);
+
+            // Push past the bound with distinct rooms. `from_u128` starting at 2
+            // keeps every id different from the victim's.
+            for n in 2..(crate::cognition::bounded_room_ledger::ROOMS_TRACKED as u128 + 2) {
+                faculty.note_absence(Uuid::from_u128(n));
+            }
+
+            assert_eq!(
+                faculty.streak_in(victim),
+                0,
+                "the oldest room's diagnostics are dropped once the bound is                  exceeded — that is the leak this closes"
+            );
+            assert_eq!(
+                faculty.note_presence(victim),
+                None,
+                "and its return to content must announce NOTHING. A recovery row                  here would claim an absence ended when the record was merely                  evicted — inventing history is the failure this PR exists to stop"
+            );
+            // Non-degeneracy: a room still inside the bound DOES report, so the
+            // assertion above cannot be passing because recovery never fires.
+            let live = Uuid::from_u128(crate::cognition::bounded_room_ledger::ROOMS_TRACKED as u128 + 1);
+            assert_eq!(
+                faculty.note_presence(live),
+                Some(1),
+                "a retained room still reports its real streak"
+            );
+        }
+
+        // what this catches: revisiting an evicted room starts a NEW streak from
+        // 1 rather than resurrecting the old count — the diagnostic must not
+        // carry a number it cannot justify.
+        #[tokio::test]
+        async fn revisiting_an_evicted_room_starts_a_fresh_streak() {
+            let faculty = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+            let victim = Uuid::from_u128(1);
+            for _ in 0..5 {
+                faculty.note_absence(victim);
+            }
+            assert_eq!(faculty.streak_in(victim), 5);
+
+            for n in 2..(crate::cognition::bounded_room_ledger::ROOMS_TRACKED as u128 + 2) {
+                faculty.note_absence(Uuid::from_u128(n));
+            }
+            assert_eq!(faculty.streak_in(victim), 0, "evicted");
+
+            assert_eq!(
+                faculty.note_absence(victim),
+                Some(1),
+                "the revisit reports a streak of ONE, not the five it can no                  longer prove"
             );
         }
 

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -50,6 +50,7 @@
 //! salience-free, no new coupling. In the converged end-state this policy is just
 //! what each native faculty's `contribute()` returns.
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -160,6 +161,16 @@ pub struct RagSourceFaculty {
     stable: bool,
     budget: u32,
     clock: Clock,
+    /// `true` when the assembler registered this grounding as
+    /// [`Deferrability::ColdStartCritical`] — meaning its absence is a WRONG turn,
+    /// not merely an unenriched one. Only these are held to the loudness contract
+    /// below; a defer-tolerant source is ALLOWED to be quietly absent.
+    ///
+    /// [`Deferrability::ColdStartCritical`]: super::persona_workspace::Deferrability::ColdStartCritical
+    cold_start_critical: bool,
+    /// Consecutive ticks this source has delivered NOTHING. See
+    /// [`Self::note_absence`] for why a counter exists at all.
+    empty_streak: AtomicU32,
 }
 
 impl RagSourceFaculty {
@@ -185,7 +196,23 @@ impl RagSourceFaculty {
             // cfg.context_window))` so the ceiling tracks the LIVE served window.
             budget: grounding_budget_for(crate::cognition::serving_plan::MIN_SERVE_CTX),
             clock: wall_clock(),
+            // Not cold-start-critical until the assembler says so. The safe
+            // direction for a LOUDNESS contract is the opposite of the safe
+            // direction for a SCHEDULING one: over-declaring here would put every
+            // source's ordinary silence in the ledger, which is how a real signal
+            // gets buried ([[bounded-window-eviction-bug-class]]).
+            cold_start_critical: false,
+            empty_streak: AtomicU32::new(0),
         }
+    }
+
+    /// Declare that this grounding's absence is WRONG, not merely unenriched —
+    /// mirroring [`Deferrability::ColdStartCritical`] at the assembly layer.
+    ///
+    /// [`Deferrability::ColdStartCritical`]: super::persona_workspace::Deferrability::ColdStartCritical
+    pub fn cold_start_critical(mut self, critical: bool) -> Self {
+        self.cold_start_critical = critical;
+        self
     }
 
     /// Override the resolved salience directly (e.g. a learned signal) — escape
@@ -214,6 +241,84 @@ impl RagSourceFaculty {
     pub fn with_clock(mut self, clock: Clock) -> Self {
         self.clock = clock;
         self
+    }
+
+    /// Record that this source delivered NOTHING this tick, and say so when it is
+    /// a source whose absence is wrong.
+    ///
+    /// ## Why this exists (#3873)
+    ///
+    /// `room-doctrine` — the PARTICIPATION GATE, the lone source deliberately kept
+    /// synchronous because a cold-start `None` would let a persona speak in a room
+    /// it shouldn't — bid **0 times in 873 consecutive ticks over 11.7 h**, and
+    /// nothing anywhere noticed. `evicted=[]` on all 873 rows, so attention never
+    /// removed it: it simply never offered. The census that found it was looking
+    /// for something else.
+    ///
+    /// It was invisible because the abstain below is CORRECT and SILENT, and
+    /// because a second live path (`compose_for_turn`) carried the same content,
+    /// so the citizens were fine. A dead registration with a working spare stays
+    /// dead until the day the spare breaks too — which is exactly what happened to
+    /// the roster, whose spare was the SAME broken `Arc` (#3862, 662 abstains, a
+    /// citizen standing in a room seeing nobody).
+    ///
+    /// The whole point of the ColdStartCritical tier is that its absence is a
+    /// WRONG turn. So its absence must not be silent.
+    ///
+    /// ## Why a streak, and why powers of two
+    ///
+    /// A probe on EVERY empty tick would be 873 rows for one fact, and the fact
+    /// that matters is not "empty now" but "empty CONTINUOUSLY". Firing on the
+    /// 1st, 2nd, 4th, 8th … consecutive miss costs ~log2(n) rows — 10 rows across
+    /// those 873 ticks — and keeps both ends legible: the onset is in the ledger
+    /// immediately, and the duration is in the ledger without drowning it.
+    ///
+    /// Returns the streak length WHEN IT REPORTED, so the decision to report is
+    /// testable without standing up a tracing subscriber to watch for the probe.
+    fn note_absence(&self, room: Uuid) -> Option<u32> {
+        if !self.cold_start_critical {
+            return None;
+        }
+        let streak = self.empty_streak.fetch_add(1, Ordering::Relaxed) + 1;
+        if streak.is_power_of_two() {
+            crate::probe!(
+                class = "rag.coldstart.absent",
+                source = self.source.source_id(),
+                persona_id = %self.persona_id,
+                room = %room,
+                consecutive_empty = streak,
+                "ColdStartCritical grounding delivered NOTHING and did not bid —                  this tier's absence is a WRONG turn, not an unenriched one. The                  source's own probe on the same tick carries WHY."
+            );
+            return Some(streak);
+        }
+        None
+    }
+
+    /// Record that this source delivered content, closing any absence streak.
+    ///
+    /// The restore row is not decoration: an absence with no end in the ledger is
+    /// indistinguishable from an absence still running when the census was taken,
+    /// and the streak length is the only place the DURATION is written down.
+    ///
+    /// Returns the closed streak's length when it reported one (same reason as
+    /// [`Self::note_absence`]).
+    fn note_presence(&self, room: Uuid) -> Option<u32> {
+        if !self.cold_start_critical {
+            return None;
+        }
+        let streak = self.empty_streak.swap(0, Ordering::Relaxed);
+        if streak > 0 {
+            crate::probe!(
+                class = "rag.coldstart.restored",
+                source = self.source.source_id(),
+                persona_id = %self.persona_id,
+                room = %room,
+                was_empty_for = streak,
+                "ColdStartCritical grounding is bidding again"
+            );
+            return Some(streak);
+        }
+        None
     }
 }
 
@@ -250,8 +355,10 @@ impl Faculty for RagSourceFaculty {
         // Empty delivery → abstain (the source had nothing, or degraded to empty
         // per the good-citizen doctrine). No empty bid clutters the workspace.
         if delivery.items.is_empty() {
+            let _ = self.note_absence(ws.room_id);
             return None;
         }
+        let _ = self.note_presence(ws.room_id);
 
         // One context block per source: concatenate the delivered atomic units.
         // The deliberation faculty renders this under a `[<source_id>]` header.
@@ -370,6 +477,130 @@ mod tests {
             _budget: u32,
         ) -> Option<RagDelivery> {
             None
+        }
+    }
+
+    mod coldstart_absence_is_loud {
+        use super::*;
+
+        fn room() -> Uuid {
+            Uuid::parse_str("00000000-0000-0000-0000-0000000b0b0b").unwrap()
+        }
+
+        fn critical(source: Arc<StubSource>) -> RagSourceFaculty {
+            RagSourceFaculty::new(persona(), source, SaliencePolicy::StandingFraming)
+                .cold_start_critical(true)
+                .with_clock(Arc::new(|| 1_000))
+        }
+
+        // what this catches: regression for #3873 — `room-doctrine`, the
+        // ColdStartCritical participation gate, delivered nothing on 873
+        // consecutive ticks and NOTHING said so, because an empty delivery
+        // abstains silently and a second live path carried the same content. The
+        // tier whose absence is a WRONG turn must not be able to be quietly
+        // absent. Powers of two: 1,2,4,8 report; 3,5,6,7 do not.
+        #[tokio::test]
+        async fn a_cold_start_critical_source_reports_its_absence_on_a_log2_schedule() {
+            let faculty = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+            let reported: Vec<Option<u32>> =
+                (0..8).map(|_| faculty.note_absence(room())).collect();
+
+            assert_eq!(
+                reported,
+                vec![
+                    Some(1),
+                    Some(2),
+                    None,
+                    Some(4),
+                    None,
+                    None,
+                    None,
+                    Some(8)
+                ],
+                "the onset must be in the ledger immediately and the duration must                  keep arriving, without one fact costing 873 rows"
+            );
+        }
+
+        // what this catches: the guard above must not fire for sources that are
+        // ALLOWED to be quietly absent. A defer-tolerant source's first-tick miss
+        // is by design (wall, kanban, active-work, media-perception), and putting
+        // their ordinary silence in the ledger is how the one row that matters
+        // gets evicted from the window someone is reading
+        // ([[bounded-window-eviction-bug-class]]).
+        #[tokio::test]
+        async fn a_defer_tolerant_source_stays_silent_when_absent() {
+            let faculty =
+                RagSourceFaculty::new(persona(), Arc::new(StubSource::new("room-wall", &[])), SaliencePolicy::StandingFraming)
+                    .with_clock(Arc::new(|| 1_000));
+            let reported: Vec<Option<u32>> =
+                (0..8).map(|_| faculty.note_absence(room())).collect();
+            assert!(
+                reported.iter().all(|r| r.is_none()),
+                "cold_start_critical defaults to false; only the assembler's                  declaration opts a source into the loudness contract"
+            );
+        }
+
+        // what this catches: an absence with no END in the ledger is
+        // indistinguishable from one still running when the census was taken —
+        // which is precisely the reading that made #3873 look like a permanent
+        // dead gate. The recovery row carries the streak length, and it is the
+        // only place the DURATION is written down.
+        #[tokio::test]
+        async fn recovery_closes_the_streak_and_reports_how_long_it_ran() {
+            let faculty = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+            for _ in 0..5 {
+                faculty.note_absence(room());
+            }
+            assert_eq!(
+                faculty.note_presence(room()),
+                Some(5),
+                "the restore row must carry the length of the absence it ended"
+            );
+            assert_eq!(
+                faculty.note_presence(room()),
+                None,
+                "a source that was never absent has no recovery to announce"
+            );
+            assert_eq!(
+                faculty.note_absence(room()),
+                Some(1),
+                "and the next absence starts a NEW streak, not a continuation"
+            );
+        }
+
+        // what this catches: the accounting has to run through the real
+        // `contribute` path, not only through the helpers. An empty source still
+        // abstains (behaviour unchanged — no empty bid clutters the workspace)
+        // and a non-empty one still bids; the loudness rides alongside both.
+        #[tokio::test]
+        async fn contribute_still_abstains_on_empty_and_bids_on_content() {
+            let silent = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+            assert!(
+                silent.contribute(&Workspace::new("anything")).await.is_none(),
+                "an empty delivery must not become an empty bid"
+            );
+            assert_eq!(
+                silent.empty_streak.load(Ordering::Relaxed),
+                1,
+                "and the abstain must have been counted on the live path"
+            );
+
+            let speaking = critical(Arc::new(StubSource::new(
+                "room-doctrine",
+                &["This room is for coordination."],
+            )));
+            assert!(
+                speaking
+                    .contribute(&Workspace::new("anything"))
+                    .await
+                    .is_some(),
+                "a source with content still bids"
+            );
+            assert_eq!(
+                speaking.empty_streak.load(Ordering::Relaxed),
+                0,
+                "and a bidding source carries no absence"
+            );
         }
     }
 

--- a/core/continuum-core/src/cognition/rag_source_faculty.rs
+++ b/core/continuum-core/src/cognition/rag_source_faculty.rs
@@ -50,8 +50,8 @@
 //! salience-free, no new coupling. In the converged end-state this policy is just
 //! what each native faculty's `contribute()` returns.
 
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -168,9 +168,18 @@ pub struct RagSourceFaculty {
     ///
     /// [`Deferrability::ColdStartCritical`]: super::persona_workspace::Deferrability::ColdStartCritical
     cold_start_critical: bool,
-    /// Consecutive ticks this source has delivered NOTHING. See
+    /// Consecutive ticks this source has delivered NOTHING, PER ROOM. See
     /// [`Self::note_absence`] for why a counter exists at all.
-    empty_streak: AtomicU32,
+    ///
+    /// KEYED BY ROOM, because a grounding source answers for whatever room the
+    /// turn is in (`Workspace::room_id`). A single counter was the first version
+    /// and @Astra caught it on review of #3903: content in room B would have
+    /// closed — and reported the length of — room A's absence, and a citizen
+    /// alternating between a room that grounds and one that does not would have
+    /// produced a meaningless streak mixing both.
+    ///
+    /// Bounded by the rooms this persona actually takes turns in.
+    empty_streak: Mutex<HashMap<Uuid, u32>>,
 }
 
 impl RagSourceFaculty {
@@ -202,7 +211,7 @@ impl RagSourceFaculty {
             // source's ordinary silence in the ledger, which is how a real signal
             // gets buried ([[bounded-window-eviction-bug-class]]).
             cold_start_critical: false,
-            empty_streak: AtomicU32::new(0),
+            empty_streak: Mutex::new(HashMap::new()),
         }
     }
 
@@ -279,7 +288,14 @@ impl RagSourceFaculty {
         if !self.cold_start_critical {
             return None;
         }
-        let streak = self.empty_streak.fetch_add(1, Ordering::Relaxed) + 1;
+        let streak = {
+            // diagnostics-only bookkeeping; a poisoned lock must not take
+            // cognition down to protect a counter. No await is held here.
+            let mut g = self.empty_streak.lock().unwrap_or_else(|e| e.into_inner());
+            let c = g.entry(room).or_insert(0);
+            *c += 1;
+            *c
+        };
         if streak.is_power_of_two() {
             crate::probe!(
                 class = "rag.coldstart.absent",
@@ -294,6 +310,18 @@ impl RagSourceFaculty {
         None
     }
 
+    /// How long THIS room's current absence streak is. Test-visible so the live
+    /// `contribute` path can be asserted without reaching into the map.
+    #[cfg(test)]
+    fn streak_in(&self, room: Uuid) -> u32 {
+        self.empty_streak
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) // diagnostics-only, same as note_absence
+            .get(&room)
+            .copied()
+            .unwrap_or(0)
+    }
+
     /// Record that this source delivered content, closing any absence streak.
     ///
     /// The restore row is not decoration: an absence with no end in the ledger is
@@ -306,7 +334,11 @@ impl RagSourceFaculty {
         if !self.cold_start_critical {
             return None;
         }
-        let streak = self.empty_streak.swap(0, Ordering::Relaxed);
+        let streak = {
+            // same contract as note_absence: recover the guard, never panic here.
+            let mut g = self.empty_streak.lock().unwrap_or_else(|e| e.into_inner());
+            g.remove(&room).unwrap_or(0)
+        };
         if streak > 0 {
             crate::probe!(
                 class = "rag.coldstart.restored",
@@ -540,6 +572,51 @@ mod tests {
             );
         }
 
+        // what this catches: regression for @Astra's #3903 review finding 2 — one
+        // counter for a source that answers for whatever room the turn is in
+        // meant CONTENT IN ROOM B CLOSED AND REPORTED ROOM A'S ABSENCE, and a
+        // citizen alternating between a grounding room and a bare one produced a
+        // streak that mixed both and meant nothing.
+        //
+        // NON-DEGENERACY: two different rooms, driven to different streak
+        // lengths, asserted different — with one counter this cannot hold.
+        #[tokio::test]
+        async fn one_room_s_absence_streak_never_answers_for_another() {
+            let a = Uuid::parse_str("00000000-0000-0000-0000-00000000000a").unwrap();
+            let b = Uuid::parse_str("00000000-0000-0000-0000-00000000000b").unwrap();
+            assert_ne!(a, b, "non-degeneracy: two DIFFERENT rooms");
+            let faculty = critical(Arc::new(StubSource::new("room-doctrine", &[])));
+
+            for _ in 0..3 {
+                faculty.note_absence(a);
+            }
+            faculty.note_absence(b);
+            assert_eq!(faculty.streak_in(a), 3);
+            assert_eq!(faculty.streak_in(b), 1);
+            assert_ne!(
+                faculty.streak_in(a),
+                faculty.streak_in(b),
+                "non-degeneracy: with a single counter these would be equal and                  the test could not fail"
+            );
+
+            // Content in B closes B's streak and says B's length — never A's.
+            assert_eq!(
+                faculty.note_presence(b),
+                Some(1),
+                "the recovery row must carry the length of THIS room's absence"
+            );
+            assert_eq!(
+                faculty.streak_in(a),
+                3,
+                "and room A's absence must still be running, untouched"
+            );
+            assert_eq!(
+                faculty.note_presence(a),
+                Some(3),
+                "A's own recovery still reports A's own length"
+            );
+        }
+
         // what this catches: an absence with no END in the ledger is
         // indistinguishable from one still running when the census was taken —
         // which is precisely the reading that made #3873 look like a permanent
@@ -580,7 +657,7 @@ mod tests {
                 "an empty delivery must not become an empty bid"
             );
             assert_eq!(
-                silent.empty_streak.load(Ordering::Relaxed),
+                silent.streak_in(Workspace::new("anything").room_id),
                 1,
                 "and the abstain must have been counted on the live path"
             );
@@ -597,7 +674,7 @@ mod tests {
                 "a source with content still bids"
             );
             assert_eq!(
-                speaking.empty_streak.load(Ordering::Relaxed),
+                speaking.streak_in(Workspace::new("anything").room_id),
                 0,
                 "and a bidding source carries no absence"
             );

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -140,26 +140,6 @@ enum Outcome {
     BudgetTooSmall,
 }
 
-impl Outcome {
-    fn code(self) -> u8 {
-        self as u8
-    }
-    fn from_code(c: u8) -> Self {
-        match c {
-            1 => Self::Delivered,
-            2 => Self::CrossPersona,
-            3 => Self::NilRoom,
-            4 => Self::NotObservedInReadWindow,
-            5 => Self::ReadFailed,
-            6 => Self::BudgetTooSmall,
-            // 0 and anything unrecognised: nothing observed. `from_code` only ever
-            // reads back what `code` wrote, so the fallthrough is unreachable in
-            // practice -- it is written this way because a panic here would take
-            // down cognition to report a logging detail.
-            _ => Self::Unobserved,
-        }
-    }
-}
 
 /// RoomDoctrineSource — persona-bound, reads the room doctrine from any
 /// `AircDoctrineReader`.
@@ -185,7 +165,9 @@ pub struct RoomDoctrineSource {
     ///
     /// Bounded by the persona's subscribed rooms, which is a handful; a room she
     /// never takes a turn in never gets an entry.
-    observed: std::sync::Mutex<std::collections::HashMap<Option<uuid::Uuid>, (Outcome, u64)>>,
+    observed: std::sync::Mutex<
+        crate::cognition::bounded_room_ledger::BoundedRoomLedger<Option<uuid::Uuid>, (Outcome, u64)>,
+    >,
 }
 
 impl RoomDoctrineSource {
@@ -194,7 +176,11 @@ impl RoomDoctrineSource {
             persona_id,
             room_id: None,
             reader,
-            observed: std::sync::Mutex::new(std::collections::HashMap::new()),
+            observed: std::sync::Mutex::new(
+                crate::cognition::bounded_room_ledger::BoundedRoomLedger::new(
+                    crate::cognition::bounded_room_ledger::ROOMS_TRACKED,
+                ),
+            ),
         }
     }
 
@@ -219,9 +205,26 @@ impl RoomDoctrineSource {
     ///
     /// So the two probes count different populations: the faculty's streak counts
     /// TICKS WITHOUT A BID; this outcome is the last ACTUAL READ, which on a
-    /// cached path may be several ticks old. The probe therefore carries
-    /// `observed_age_ms` — the reader can see how stale the observation is instead
-    /// of assuming it is this tick's.
+    /// cached path may be several ticks old.
+    ///
+    /// The probe carries `since_previous_evaluation_ms`, and the name has now been
+    /// corrected TWICE, which is worth recording because both errors were the
+    /// same one.
+    ///
+    /// It was first `observed_age_ms`, described as the age of the observation at
+    /// this tick. It is not: this function runs only on a source evaluation, every
+    /// evaluation rewrites the timestamp (transition or not), and cache hits never
+    /// reach here at all.
+    ///
+    /// It was then `since_previous_read_ms` — still wrong, and @Astra caught that
+    /// too. `CrossPersona` and `NilRoom` both return BEFORE any reader I/O, so an
+    /// interval bounded by one of those did not span a read at all. EVALUATION is
+    /// the honest word: the span between the last two times this source was asked
+    /// and answered, whatever it did to answer.
+    ///
+    /// Naming a measurement for the thing you wish it measured is how a diagnostic
+    /// lies quietly, and doing it twice in one PR is why the name is now derived
+    /// from the code path rather than from the intent.
     ///
     /// Returns `true` when it emitted, so the transition rule is testable without
     /// standing up a tracing subscriber to watch for the probe.
@@ -250,7 +253,7 @@ impl RoomDoctrineSource {
             effective_room = ?room,
             from = ?prev_outcome,
             to = ?outcome,
-            observed_age_ms = now.saturating_sub(prev_at),
+            since_previous_evaluation_ms = now.saturating_sub(prev_at),
             "room-doctrine outcome changed for THIS room — an empty delivery now              says WHICH empty it is (unobserved-in-window vs read-failed vs gated              out), and how old the previous observation was"
         );
         true
@@ -623,31 +626,6 @@ mod tests {
             assert_eq!(src.observed_in(None), Outcome::Unobserved);
         }
 
-        // what this catches: the code<->enum round-trip the stored representation
-        // relies
-        // on. A silent collision (two outcomes sharing a code) would merge two
-        // distinct absences back into one, undoing this whole change while every
-        // other test still passed.
-        #[test]
-        fn every_outcome_survives_the_atomic_round_trip_distinctly() {
-            let all = [
-                Outcome::Unobserved,
-                Outcome::Delivered,
-                Outcome::CrossPersona,
-                Outcome::NilRoom,
-                Outcome::NotObservedInReadWindow,
-                Outcome::ReadFailed,
-                Outcome::BudgetTooSmall,
-            ];
-            for o in all {
-                assert_eq!(Outcome::from_code(o.code()), o, "round-trip for {o:?}");
-            }
-            let mut codes: Vec<u8> = all.iter().map(|o| o.code()).collect();
-            codes.sort_unstable();
-            let before = codes.len();
-            codes.dedup();
-            assert_eq!(before, codes.len(), "two outcomes must never share a code");
-        }
     }
 
     // what this catches: #443 — a citizen taking a turn in a per-run BENCH room

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -92,6 +92,62 @@ impl AircDoctrineReader for airc_lib::Airc {
     }
 }
 
+/// WHY a delivery turned out the way it did — the thing an empty `RagDelivery`
+/// cannot say for itself (#3873).
+///
+/// A doctrine delivery is empty for five materially different reasons, and until
+/// this enum existed all five rendered as the same nothing: a room with no
+/// published doctrine was indistinguishable, at every seam we had, from a reader
+/// whose cache never wired up. #3873 could not be triaged past that ambiguity —
+/// "no doctrine has ever been published here" and "the source is broken" were the
+/// two live hypotheses and no instrument separated them.
+/// [[absence-rendered-as-positive-fact]]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    /// Nothing has been observed yet — the pre-first-call sentinel. Distinct from
+    /// every real outcome so the FIRST call always reports one.
+    Unobserved,
+    /// A doctrine block was delivered.
+    Delivered,
+    /// The context belongs to another persona (defense in depth; should not occur
+    /// in production, and its appearance in the ledger is itself the finding).
+    CrossPersona,
+    /// A synthetic nil-room context — deliberately gets nothing, and deliberately
+    /// does NOT fall back to the bound room (the exam-bleed pin).
+    NilRoom,
+    /// The reader answered successfully: this room HAS no published doctrine.
+    /// The source is working; the room is empty. This is the honest normal case
+    /// and the one that was being read as a defect.
+    NoDoctrinePublished,
+    /// The reader failed. Cognition stays up, but this is NOT the normal case and
+    /// must never again look like one.
+    ReadFailed,
+    /// A doctrine exists but the budget could not carry the marker plus real
+    /// content.
+    BudgetTooSmall,
+}
+
+impl Outcome {
+    fn code(self) -> u8 {
+        self as u8
+    }
+    fn from_code(c: u8) -> Self {
+        match c {
+            1 => Self::Delivered,
+            2 => Self::CrossPersona,
+            3 => Self::NilRoom,
+            4 => Self::NoDoctrinePublished,
+            5 => Self::ReadFailed,
+            6 => Self::BudgetTooSmall,
+            // 0 and anything unrecognised: nothing observed. `from_code` only ever
+            // reads back what `code` wrote, so the fallthrough is unreachable in
+            // practice -- it is written this way because a panic here would take
+            // down cognition to report a logging detail.
+            _ => Self::Unobserved,
+        }
+    }
+}
+
 /// RoomDoctrineSource — persona-bound, reads the room doctrine from any
 /// `AircDoctrineReader`.
 pub struct RoomDoctrineSource {
@@ -101,6 +157,9 @@ pub struct RoomDoctrineSource {
     /// (legacy/test construction): pre-gate behavior.
     room_id: Option<uuid::Uuid>,
     reader: Arc<dyn AircDoctrineReader>,
+    /// The last [`Outcome`] this source reported, as a code. Transitions are what
+    /// reach the probe ledger -- see [`Self::report`].
+    last_outcome: std::sync::atomic::AtomicU8,
 }
 
 impl RoomDoctrineSource {
@@ -109,7 +168,51 @@ impl RoomDoctrineSource {
             persona_id,
             room_id: None,
             reader,
+            last_outcome: std::sync::atomic::AtomicU8::new(Outcome::Unobserved.code()),
         }
+    }
+
+    /// Emit a probe when, and only when, the outcome CHANGES.
+    ///
+    /// Per-tick reporting would be 873 rows to say one thing, and the fact worth
+    /// having is not "empty now" but "empty for a DIFFERENT reason than before".
+    /// A transition ledger is bounded by the number of real state changes -- for a
+    /// room that has simply never had doctrine published, exactly ONE row, written
+    /// on the first tick, saying so in those words.
+    ///
+    /// This is the half that answers WHY; the [`RagSourceFaculty`] absence streak
+    /// is the half that answers HOW LONG. They join on `source` + tick.
+    ///
+    /// [`RagSourceFaculty`]: crate::cognition::rag_source_faculty::RagSourceFaculty
+    /// Returns `true` when it emitted, so the transition rule is testable without
+    /// standing up a tracing subscriber to watch for the probe.
+    fn report(&self, outcome: Outcome, room: Option<uuid::Uuid>) -> bool {
+        let prev = Outcome::from_code(
+            self.last_outcome
+                .swap(outcome.code(), std::sync::atomic::Ordering::Relaxed),
+        );
+        if prev == outcome {
+            return false;
+        }
+        crate::probe!(
+            class = "rag.doctrine.outcome",
+            source = SOURCE_ID,
+            persona_id = %self.persona_id,
+            bound_room = ?self.room_id,
+            effective_room = ?room,
+            from = ?prev,
+            to = ?outcome,
+            "room-doctrine outcome changed — an empty delivery now says WHICH              empty it is (published-nothing vs read-failed vs gated out)"
+        );
+        true
+    }
+
+    /// The last outcome this source observed — the state the transition ledger is
+    /// tracking. Test-visible so a regression can assert WHICH absence occurred,
+    /// which is the whole point of the enum.
+    #[cfg(test)]
+    fn observed(&self) -> Outcome {
+        Outcome::from_code(self.last_outcome.load(std::sync::atomic::Ordering::Relaxed))
     }
 
     /// Bind this source to the room its reader answers for, so a context-stamped
@@ -190,6 +293,7 @@ impl RagSource for RoomDoctrineSource {
 
         // Persona-scoped (defense in depth, same shape as the roster).
         if ctx.persona_id != self.persona_id {
+            let _ = self.report(Outcome::CrossPersona, None);
             return empty(ResolutionPreference::Placeholder);
         }
         // Room resolution — TURN-PARAMETRIC (#443), the same shape RoomBoardSource
@@ -209,6 +313,7 @@ impl RagSource for RoomDoctrineSource {
                     persona_id = %ctx.persona_id,
                     "synthetic nil-room context — no doctrine, and no fallback to the bound room"
                 );
+                let _ = self.report(Outcome::NilRoom, Some(t));
                 return empty(ResolutionPreference::Placeholder);
             }
             Some(t) => Some(t),
@@ -217,19 +322,27 @@ impl RagSource for RoomDoctrineSource {
 
         let card = match self.reader.room_doctrine(effective_room).await {
             Ok(Some(card)) => card,
-            // No doctrine published for this room → no block (normal).
-            Ok(None) => return empty(resolution),
+            // No doctrine published for this room → no block. This is the NORMAL
+            // case and it is now SAYS so: #3873 spent its life as "the gate has
+            // never held" because a working source reading an empty room looked
+            // exactly like a broken one.
+            Ok(None) => {
+                let _ = self.report(Outcome::NoDoctrinePublished, effective_room);
+                return empty(resolution);
+            }
             Err(err) => {
                 tracing::warn!(
                     error = %err,
                     persona_id = %self.persona_id,
                     "room_doctrine: read failed — empty delivery, cognition stays up"
                 );
+                let _ = self.report(Outcome::ReadFailed, effective_room);
                 return empty(ResolutionPreference::Placeholder);
             }
         };
 
         let Some(content) = Self::fit_body(&card.body, budget) else {
+            let _ = self.report(Outcome::BudgetTooSmall, effective_room);
             return empty(resolution);
         };
         let tokens = estimate_tokens(&content);
@@ -241,6 +354,7 @@ impl RagSource for RoomDoctrineSource {
             tokens,
             "room_doctrine: deliver"
         );
+        let _ = self.report(Outcome::Delivered, effective_room);
 
         RagDelivery {
             source_id: SOURCE_ID.to_string(),
@@ -329,6 +443,108 @@ mod tests {
                 return Err(AircError::UnknownPeer(PeerId::new()));
             }
             Ok(self.doctrine.clone())
+        }
+    }
+
+    mod which_empty_is_it {
+        use super::*;
+
+        fn source(reader: Arc<StubReader>, room: uuid::Uuid) -> RoomDoctrineSource {
+            RoomDoctrineSource::new(persona(), reader).for_room(room)
+        }
+
+        fn ctx_in(room: uuid::Uuid) -> RagContext {
+            RagContext::for_persona_in_room(persona(), 1_000_000, room)
+        }
+
+        // what this catches: regression for #3873. `room-doctrine` delivered
+        // nothing on 873 consecutive ticks and the two live hypotheses — "no
+        // doctrine was ever published here" (source fine) and "the cache never
+        // wired up" (source broken) — were INDISTINGUISHABLE at every seam we
+        // had, because both rendered as the same empty delivery. They are now
+        // different rows. [[absence-rendered-as-positive-fact]]
+        #[tokio::test]
+        async fn an_unpublished_room_and_a_broken_reader_are_different_absences() {
+            let room = uuid::Uuid::new_v4();
+            let reader = Arc::new(StubReader::new(None));
+            let src = source(reader.clone(), room);
+
+            let d = src.deliver(&ctx_in(room), 4_000, ResolutionPreference::Raw).await;
+            assert!(d.items.is_empty(), "no doctrine published — no block");
+            assert_eq!(
+                src.observed(),
+                Outcome::NoDoctrinePublished,
+                "the honest normal case must SAY it is the normal case"
+            );
+
+            reader.set_fail(true);
+            let d = src.deliver(&ctx_in(room), 4_000, ResolutionPreference::Raw).await;
+            assert!(d.items.is_empty(), "a failed read still keeps cognition up");
+            assert_eq!(
+                src.observed(),
+                Outcome::ReadFailed,
+                "and a BROKEN reader must not look like an empty room"
+            );
+
+            assert_ne!(
+                Outcome::NoDoctrinePublished,
+                Outcome::ReadFailed,
+                "non-degeneracy: the two states this test distinguishes must not                  be the same value, or it would pass without discriminating"
+            );
+        }
+
+        // what this catches: the transition rule. Reporting every tick would be
+        // 873 rows to say one thing, and the row that matters would be evicted
+        // from whatever window someone is reading
+        // ([[bounded-window-eviction-bug-class]]). One row per real state change:
+        // the first tick reports, an unchanged second tick does not, and a CHANGE
+        // reports again.
+        #[tokio::test]
+        async fn only_a_change_of_outcome_reaches_the_ledger() {
+            let room = uuid::Uuid::new_v4();
+            let src = source(Arc::new(StubReader::new(None)), room);
+
+            assert!(
+                src.report(Outcome::NoDoctrinePublished, Some(room)),
+                "the FIRST observation is always a transition (from Unobserved)"
+            );
+            assert!(
+                !src.report(Outcome::NoDoctrinePublished, Some(room)),
+                "a repeat of the same state must not cost a row"
+            );
+            assert!(
+                src.report(Outcome::ReadFailed, Some(room)),
+                "a real change must always be written down"
+            );
+            assert!(
+                src.report(Outcome::Delivered, Some(room)),
+                "including recovery — the end of an absence is a fact too"
+            );
+        }
+
+        // what this catches: the code<->enum round-trip that the AtomicU8 relies
+        // on. A silent collision (two outcomes sharing a code) would merge two
+        // distinct absences back into one, undoing this whole change while every
+        // other test still passed.
+        #[test]
+        fn every_outcome_survives_the_atomic_round_trip_distinctly() {
+            let all = [
+                Outcome::Unobserved,
+                Outcome::Delivered,
+                Outcome::CrossPersona,
+                Outcome::NilRoom,
+                Outcome::NoDoctrinePublished,
+                Outcome::ReadFailed,
+                Outcome::BudgetTooSmall,
+            ];
+            for o in all {
+                assert_eq!(Outcome::from_code(o.code()), o, "round-trip for {o:?}");
+            }
+            let mut codes: Vec<u8> = all.iter().map(|o| o.code()).collect();
+            codes.sort_unstable();
+            let before = codes.len();
+            codes.dedup();
+            assert_eq!(before, codes.len(), "two outcomes must never share a code");
         }
     }
 

--- a/core/continuum-core/src/persona/room_doctrine_source.rs
+++ b/core/continuum-core/src/persona/room_doctrine_source.rs
@@ -115,10 +115,23 @@ enum Outcome {
     /// A synthetic nil-room context — deliberately gets nothing, and deliberately
     /// does NOT fall back to the bound room (the exam-bleed pin).
     NilRoom,
-    /// The reader answered successfully: this room HAS no published doctrine.
-    /// The source is working; the room is empty. This is the honest normal case
-    /// and the one that was being read as a defect.
-    NoDoctrinePublished,
+    /// The reader answered successfully and returned nothing **within the window
+    /// it reads**. This is NOT "the room has no doctrine", and naming it that was
+    /// the first version of this enum -- caught by @Astra on review of #3903.
+    ///
+    /// THE BOUND, verified in `airc.rs::room_doctrine_in` rather than assumed:
+    /// it calls `page_recent_filtered(filter, 200)` and `continue`s past events
+    /// that fail to decode. So `Ok(None)` means *no decodable
+    /// `DoctrinePublished` event in the latest 200 events of this room*. In a
+    /// busy room that is minutes. A doctrine published an hour ago is invisible
+    /// to it, and an undecodable one is silently skipped.
+    ///
+    /// Calling that `NoDoctrinePublished` renders COULD_NOT_LOOK as
+    /// MEASURED_ABSENT -- the exact defect this enum exists to prevent,
+    /// committed inside the enum. Establishing real absence needs a complete
+    /// indexed projection, which this reader is not.
+    /// [[absence-rendered-as-positive-fact]]
+    NotObservedInReadWindow,
     /// The reader failed. Cognition stays up, but this is NOT the normal case and
     /// must never again look like one.
     ReadFailed,
@@ -136,7 +149,7 @@ impl Outcome {
             1 => Self::Delivered,
             2 => Self::CrossPersona,
             3 => Self::NilRoom,
-            4 => Self::NoDoctrinePublished,
+            4 => Self::NotObservedInReadWindow,
             5 => Self::ReadFailed,
             6 => Self::BudgetTooSmall,
             // 0 and anything unrecognised: nothing observed. `from_code` only ever
@@ -157,9 +170,22 @@ pub struct RoomDoctrineSource {
     /// (legacy/test construction): pre-gate behavior.
     room_id: Option<uuid::Uuid>,
     reader: Arc<dyn AircDoctrineReader>,
-    /// The last [`Outcome`] this source reported, as a code. Transitions are what
-    /// reach the probe ledger -- see [`Self::report`].
-    last_outcome: std::sync::atomic::AtomicU8,
+    /// The last [`Outcome`] observed PER ROOM, with the wall-clock ms at which it
+    /// was observed. Transitions are what reach the probe ledger -- see
+    /// [`Self::report`].
+    ///
+    /// KEYED BY ROOM because this source is TURN-PARAMETRIC (#443): it answers
+    /// for whatever room the turn is in. A single cell was the first version and
+    /// it was wrong three ways, all caught by @Astra on review of #3903 — the
+    /// same outcome in room B was suppressed by room A's, alternating rooms
+    /// emitted a transition every tick with no state having changed, and a
+    /// recovery in B would have been reported as room A's absence ending. The
+    /// key is `Option<Uuid>` because an UNSTAMPED context (background
+    /// consolidation) is its own scope, not a room.
+    ///
+    /// Bounded by the persona's subscribed rooms, which is a handful; a room she
+    /// never takes a turn in never gets an entry.
+    observed: std::sync::Mutex<std::collections::HashMap<Option<uuid::Uuid>, (Outcome, u64)>>,
 }
 
 impl RoomDoctrineSource {
@@ -168,51 +194,79 @@ impl RoomDoctrineSource {
             persona_id,
             room_id: None,
             reader,
-            last_outcome: std::sync::atomic::AtomicU8::new(Outcome::Unobserved.code()),
+            observed: std::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
-    /// Emit a probe when, and only when, the outcome CHANGES.
+    /// Emit a probe when, and only when, THIS ROOM's outcome changes.
     ///
     /// Per-tick reporting would be 873 rows to say one thing, and the fact worth
     /// having is not "empty now" but "empty for a DIFFERENT reason than before".
     /// A transition ledger is bounded by the number of real state changes -- for a
-    /// room that has simply never had doctrine published, exactly ONE row, written
-    /// on the first tick, saying so in those words.
+    /// room whose doctrine the reader has never seen in its window, exactly ONE
+    /// row, written on the first tick, saying so in those words.
     ///
-    /// This is the half that answers WHY; the [`RagSourceFaculty`] absence streak
-    /// is the half that answers HOW LONG. They join on `source` + tick.
+    /// ## What this does NOT join with (corrected, #3903 review)
     ///
-    /// [`RagSourceFaculty`]: crate::cognition::rag_source_faculty::RagSourceFaculty
+    /// An earlier version of this doc claimed the source outcome and the
+    /// [`RagSourceFaculty`] absence streak "join on source + tick". They do not,
+    /// and I had not checked it. Two reasons, both verified:
+    ///
+    /// 1. There is no shared tick or cycle id on either probe.
+    /// 2. `CachedRagSource::deliver` returns `cached.delivery.clone()` WITHOUT
+    ///    calling the inner source (`cached_source.rs`, the `answers` fast path),
+    ///    so on a cache hit this function never runs at all.
+    ///
+    /// So the two probes count different populations: the faculty's streak counts
+    /// TICKS WITHOUT A BID; this outcome is the last ACTUAL READ, which on a
+    /// cached path may be several ticks old. The probe therefore carries
+    /// `observed_age_ms` — the reader can see how stale the observation is instead
+    /// of assuming it is this tick's.
+    ///
     /// Returns `true` when it emitted, so the transition rule is testable without
     /// standing up a tracing subscriber to watch for the probe.
-    fn report(&self, outcome: Outcome, room: Option<uuid::Uuid>) -> bool {
-        let prev = Outcome::from_code(
-            self.last_outcome
-                .swap(outcome.code(), std::sync::atomic::Ordering::Relaxed),
-        );
-        if prev == outcome {
+    ///
+    /// [`RagSourceFaculty`]: crate::cognition::rag_source_faculty::RagSourceFaculty
+    /// `now_ms` is THE TURN'S clock (`ctx.now_ms`), never `SystemTime::now()` —
+    /// `SubstrateContext` documents that so observations stamp consistently and
+    /// replay stays deterministic.
+    fn report(&self, outcome: Outcome, room: Option<uuid::Uuid>, now_ms: u64) -> bool {
+        let now = now_ms;
+        // lock poisoning here would mean a panic inside this tiny map update; the
+        // observation ledger is diagnostics, and taking cognition down to protect
+        // its bookkeeping is the wrong trade.
+        let mut guard = self.observed.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = guard.insert(room, (outcome, now));
+        let (prev_outcome, prev_at) = prev.unwrap_or((Outcome::Unobserved, now));
+        if prev_outcome == outcome {
             return false;
         }
+        drop(guard);
         crate::probe!(
             class = "rag.doctrine.outcome",
             source = SOURCE_ID,
             persona_id = %self.persona_id,
             bound_room = ?self.room_id,
             effective_room = ?room,
-            from = ?prev,
+            from = ?prev_outcome,
             to = ?outcome,
-            "room-doctrine outcome changed — an empty delivery now says WHICH              empty it is (published-nothing vs read-failed vs gated out)"
+            observed_age_ms = now.saturating_sub(prev_at),
+            "room-doctrine outcome changed for THIS room — an empty delivery now              says WHICH empty it is (unobserved-in-window vs read-failed vs gated              out), and how old the previous observation was"
         );
         true
     }
 
-    /// The last outcome this source observed — the state the transition ledger is
-    /// tracking. Test-visible so a regression can assert WHICH absence occurred,
-    /// which is the whole point of the enum.
+    /// The last outcome observed FOR ONE ROOM. Test-visible so a regression can
+    /// assert WHICH absence occurred and that room A's state never answers for
+    /// room B — the whole point of both the enum and the key.
     #[cfg(test)]
-    fn observed(&self) -> Outcome {
-        Outcome::from_code(self.last_outcome.load(std::sync::atomic::Ordering::Relaxed))
+    fn observed_in(&self, room: Option<uuid::Uuid>) -> Outcome {
+        self.observed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) // diagnostics-only ledger, same as report()
+            .get(&room)
+            .map(|(o, _)| *o)
+            .unwrap_or(Outcome::Unobserved)
     }
 
     /// Bind this source to the room its reader answers for, so a context-stamped
@@ -293,7 +347,7 @@ impl RagSource for RoomDoctrineSource {
 
         // Persona-scoped (defense in depth, same shape as the roster).
         if ctx.persona_id != self.persona_id {
-            let _ = self.report(Outcome::CrossPersona, None);
+            let _ = self.report(Outcome::CrossPersona, None, ctx.now_ms);
             return empty(ResolutionPreference::Placeholder);
         }
         // Room resolution — TURN-PARAMETRIC (#443), the same shape RoomBoardSource
@@ -313,7 +367,7 @@ impl RagSource for RoomDoctrineSource {
                     persona_id = %ctx.persona_id,
                     "synthetic nil-room context — no doctrine, and no fallback to the bound room"
                 );
-                let _ = self.report(Outcome::NilRoom, Some(t));
+                let _ = self.report(Outcome::NilRoom, Some(t), ctx.now_ms);
                 return empty(ResolutionPreference::Placeholder);
             }
             Some(t) => Some(t),
@@ -322,12 +376,14 @@ impl RagSource for RoomDoctrineSource {
 
         let card = match self.reader.room_doctrine(effective_room).await {
             Ok(Some(card)) => card,
-            // No doctrine published for this room → no block. This is the NORMAL
-            // case and it is now SAYS so: #3873 spent its life as "the gate has
-            // never held" because a working source reading an empty room looked
-            // exactly like a broken one.
+            // Nothing in the reader's WINDOW → no block. Not "no doctrine
+            // exists": the reader pages the latest 200 events and skips decode
+            // failures, so this is an unobserved, not an absence. #3873 spent
+            // its life as "the gate has never held" because a working source
+            // reading an empty window looked exactly like a broken one — and
+            // this variant must not re-tell that story in the other direction.
             Ok(None) => {
-                let _ = self.report(Outcome::NoDoctrinePublished, effective_room);
+                let _ = self.report(Outcome::NotObservedInReadWindow, effective_room, ctx.now_ms);
                 return empty(resolution);
             }
             Err(err) => {
@@ -336,13 +392,13 @@ impl RagSource for RoomDoctrineSource {
                     persona_id = %self.persona_id,
                     "room_doctrine: read failed — empty delivery, cognition stays up"
                 );
-                let _ = self.report(Outcome::ReadFailed, effective_room);
+                let _ = self.report(Outcome::ReadFailed, effective_room, ctx.now_ms);
                 return empty(ResolutionPreference::Placeholder);
             }
         };
 
         let Some(content) = Self::fit_body(&card.body, budget) else {
-            let _ = self.report(Outcome::BudgetTooSmall, effective_room);
+            let _ = self.report(Outcome::BudgetTooSmall, effective_room, ctx.now_ms);
             return empty(resolution);
         };
         let tokens = estimate_tokens(&content);
@@ -354,7 +410,7 @@ impl RagSource for RoomDoctrineSource {
             tokens,
             "room_doctrine: deliver"
         );
-        let _ = self.report(Outcome::Delivered, effective_room);
+        let _ = self.report(Outcome::Delivered, effective_room, ctx.now_ms);
 
         RagDelivery {
             source_id: SOURCE_ID.to_string(),
@@ -472,22 +528,22 @@ mod tests {
             let d = src.deliver(&ctx_in(room), 4_000, ResolutionPreference::Raw).await;
             assert!(d.items.is_empty(), "no doctrine published — no block");
             assert_eq!(
-                src.observed(),
-                Outcome::NoDoctrinePublished,
-                "the honest normal case must SAY it is the normal case"
+                src.observed_in(Some(room)),
+                Outcome::NotObservedInReadWindow,
+                "an empty WINDOW must say it is a window, not an absence"
             );
 
             reader.set_fail(true);
             let d = src.deliver(&ctx_in(room), 4_000, ResolutionPreference::Raw).await;
             assert!(d.items.is_empty(), "a failed read still keeps cognition up");
             assert_eq!(
-                src.observed(),
+                src.observed_in(Some(room)),
                 Outcome::ReadFailed,
-                "and a BROKEN reader must not look like an empty room"
+                "and a BROKEN reader must not look like an unobserved window"
             );
 
             assert_ne!(
-                Outcome::NoDoctrinePublished,
+                Outcome::NotObservedInReadWindow,
                 Outcome::ReadFailed,
                 "non-degeneracy: the two states this test distinguishes must not                  be the same value, or it would pass without discriminating"
             );
@@ -505,24 +561,70 @@ mod tests {
             let src = source(Arc::new(StubReader::new(None)), room);
 
             assert!(
-                src.report(Outcome::NoDoctrinePublished, Some(room)),
+                src.report(Outcome::NotObservedInReadWindow, Some(room), 1_000),
                 "the FIRST observation is always a transition (from Unobserved)"
             );
             assert!(
-                !src.report(Outcome::NoDoctrinePublished, Some(room)),
+                !src.report(Outcome::NotObservedInReadWindow, Some(room), 1_000),
                 "a repeat of the same state must not cost a row"
             );
             assert!(
-                src.report(Outcome::ReadFailed, Some(room)),
+                src.report(Outcome::ReadFailed, Some(room), 1_200),
                 "a real change must always be written down"
             );
             assert!(
-                src.report(Outcome::Delivered, Some(room)),
+                src.report(Outcome::Delivered, Some(room), 1_300),
                 "including recovery — the end of an absence is a fact too"
             );
         }
 
-        // what this catches: the code<->enum round-trip that the AtomicU8 relies
+        // what this catches: regression for @Astra's #3903 review finding 2 — the
+        // first version kept ONE outcome cell for a source that is
+        // TURN-PARAMETRIC across rooms (#443). Room A's state then answered for
+        // room B three ways: B's first observation was suppressed when it matched
+        // A's, alternating rooms emitted a transition every tick with no state
+        // having changed, and a recovery in B would have been reported as A's
+        // absence ending.
+        //
+        // NON-DEGENERACY, stated because a fixture with fewer degrees of freedom
+        // than the bug cannot fail: this needs TWO rooms with DIFFERENT outcomes,
+        // and it asserts the rooms differ and the outcomes differ before relying
+        // on them. [[fixture-with-fewer-degrees-of-freedom-than-the-bug]]
+        #[test]
+        fn one_room_s_outcome_never_answers_for_another() {
+            let a = uuid::Uuid::new_v4();
+            let b = uuid::Uuid::new_v4();
+            assert_ne!(a, b, "non-degeneracy: two DIFFERENT rooms");
+            let src = source(Arc::new(StubReader::new(None)), a);
+
+            assert!(src.report(Outcome::NotObservedInReadWindow, Some(a), 1_000));
+            // Room B has never been observed, so its FIRST observation is a
+            // transition even though it carries the same outcome as A's.
+            assert!(
+                src.report(Outcome::NotObservedInReadWindow, Some(b), 1_010),
+                "B's first observation must not be suppressed by A's state"
+            );
+            // Neither room has changed, so going back to A reports nothing.
+            assert!(
+                !src.report(Outcome::NotObservedInReadWindow, Some(a), 1_020),
+                "alternating rooms must not manufacture transitions"
+            );
+            // A real change in B, and A is untouched by it.
+            assert!(src.report(Outcome::Delivered, Some(b), 1_030));
+            assert_eq!(src.observed_in(Some(a)), Outcome::NotObservedInReadWindow);
+            assert_eq!(src.observed_in(Some(b)), Outcome::Delivered);
+            assert_ne!(
+                src.observed_in(Some(a)),
+                src.observed_in(Some(b)),
+                "non-degeneracy: the two rooms must hold DIFFERENT outcomes, or                  this test would pass with the key removed"
+            );
+            // An UNSTAMPED context (background consolidation) is its own scope,
+            // not either room.
+            assert_eq!(src.observed_in(None), Outcome::Unobserved);
+        }
+
+        // what this catches: the code<->enum round-trip the stored representation
+        // relies
         // on. A silent collision (two outcomes sharing a code) would merge two
         // distinct absences back into one, undoing this whole change while every
         // other test still passed.
@@ -533,7 +635,7 @@ mod tests {
                 Outcome::Delivered,
                 Outcome::CrossPersona,
                 Outcome::NilRoom,
-                Outcome::NoDoctrinePublished,
+                Outcome::NotObservedInReadWindow,
                 Outcome::ReadFailed,
                 Outcome::BudgetTooSmall,
             ];


### PR DESCRIPTION
Closes #3873 (the loudness half — see "What this does not answer").

> **Two review rounds from @Astra corrected this PR's central claims.** Both were right, and the corrections are the most valuable part of the diff. This body has been rewritten to remove three claims the earlier version made that the code does not support — they are listed at the bottom under "Claims this PR previously made and should not have."

## The measurement this exists for

`room-doctrine` — the **participation gate**, the one source `supervisor.rs` deliberately keeps synchronous because *"a cold-start `None` would let the persona speak in a room it shouldn't on turn one"* — bid **0 times in 873 consecutive ticks over 11.7 h**. `evicted=[]` on all 873 rows, so attention never removed it. It never offered, and nothing anywhere noticed.

## 1. The absence was silent

`RagSourceFaculty::contribute` returns `None` on an empty delivery — correct (no empty bid should clutter the workspace) and completely quiet. So the tier whose whole justification is *"absent here is a WRONG turn"* could be absent forever and read exactly like a source with nothing to say.

Deferrability is now a **loudness contract** as well as a scheduling one. A `ColdStartCritical` faculty reports its own absence on the 1st, 2nd, 4th, 8th … consecutive miss — powers of two because a per-tick probe is 873 rows for one fact, and burying the row is the same as not writing it. ~10 rows across that window; onset immediate, duration still arriving. Recovery closes the streak and carries its length. Defer-tolerant sources are untouched: their first-tick miss is by design.

## 2. The absence had no type — and my first attempt at typing it repeated the defect

A doctrine delivery is empty for five materially different reasons and all five rendered as the same nothing. That ambiguity is why #3873 could not be triaged.

**The first version of this PR named one of them `NoDoctrinePublished`. That was wrong, and it is the same defect class the enum exists to prevent.** Verified in airc's source rather than assumed: `room_doctrine_in` calls `page_recent_filtered(filter, 200)` and `continue`s past events that fail to decode. So `Ok(None)` means *"no decodable `DoctrinePublished` event in the latest 200 events of this room"* — in a busy room, minutes. A doctrine published an hour ago is invisible to it; an undecodable one is silently skipped.

That is `COULD_NOT_LOOK` rendered as `MEASURED_ABSENT`. The variant is now **`NotObservedInReadWindow`**, with the reader's bound written into its doc so nobody re-derives the wrong meaning, and a note that establishing real absence needs a complete indexed projection, which this reader is not.

## 3. Per-room scope, and a bound on it

Both the source's outcome and the faculty's streak answer for **whatever room the turn is in** (#443), and both were single counters. Consequences, all real: room B's first observation suppressed when it matched A's; alternating rooms emitting a transition every tick with no state having changed; content in B closing and reporting the length of **A's** absence.

Both are keyed by room. And because per-task rooms make lifetime history strictly larger than current subscriptions, both use a new `cognition/bounded_room_ledger.rs` — cap 32, evicting the **least-recently-written** room (recency-by-write, since every observation is a write, so an actively-answered room is un-evictable).

Its load-bearing property is Astra's sentence: **eviction must not be reported as recovery.** `take()` returns `None` for an evicted room *and* for a never-absent one — the same answer, deliberately, because the ledger cannot distinguish them and pretending otherwise is this PR's entire subject.

I looked for an existing primitive first. The convention exists (`const` cap + `VecDeque` + `pop_front`) but no reusable type does, and the one place doing per-room rings leaves its *outer* map unbounded too — the same defect one level up.

## What the two probes actually mean

They do **not** join on a shared tick. There is no shared tick id, and `CachedRagSource::deliver` returns `cached.delivery.clone()` without calling the inner source, so on a cache hit the source's report never runs.

- **faculty streak** → ticks without a bid
- **source outcome** → the last source evaluation, which on a cached path may be several ticks old and can return before reader I/O
- **`since_previous_evaluation_ms`** → the interval between the last two source evaluations for that room, including gates that return before I/O. An earlier version called it `observed_age_ms` and described it as the observation's age at this tick; it is not, because every real evaluation rewrites the timestamp whether or not the outcome changed.

`now_ms` comes from `ctx.now_ms` — the turn's clock, which `SubstrateContext` documents as the one to read so replay stays deterministic — never `SystemTime::now()`.

## Tests

13 added across the two files plus the new ledger. Every guard mutation-proven:

| mutation | result |
|---|---|
| remove the `is_power_of_two()` gate | log2 test fails, printing `[Some(1)…Some(8)]` vs the expected schedule |
| remove the `prev == outcome` early return | transition test fails on *"a repeat of the same state must not cost a row"* |
| collapse the source's map key to a constant | `one_room_s_outcome_never_answers_for_another` fails |
| collapse the faculty's map key to a constant | `one_room_s_absence_streak_never_answers_for_another` fails (`left: 0, right: 3`) |

Each mutation killed **only** its intended tests; the others stayed green, so they are targeted rather than blanket breakage. The first two were re-run against the post-review head rather than assumed to still hold — unchanged logic is an argument, not a measurement.

Every new test asserts its own non-degeneracy where it could hide: two different rooms driven to different values, asserted different, because a fixture that cannot tell the rooms apart would pass with the key removed.

`Outcome::code`/`from_code` and their round-trip test are **deleted** — production stores the enum directly now, so the encoding and its only consumer were machinery testing themselves.

## Claims this PR previously made and should not have

Recorded rather than quietly edited out, because the pattern is the point:

1. ~~"the two probes join on source + tick"~~ — no shared tick id, and cache hits bypass the source entirely. I asserted a join I had not checked.
2. ~~`NoDoctrinePublished`~~ — the reader cannot establish absence; see §2.
3. ~~"the `CachedRagSource` subscribe failed and the fallback path is serving empty"~~ — repeated from #3873's original hypothesis and **false**. Verified at `supervisor.rs`: on subscribe failure the fallback serves `raw_doctrine`, the *raw* source, logging *"serving raw airc fetch per compose; slow but never stale"*. Slower, never empty.

## What this does not answer

Whether the faculty registration is dead weight (the `compose_for_turn` composer path being the real one) or the intended path that has never worked. Not answerable by measurement; not resolved here.

What *is* resolved: the next time a ColdStartCritical source goes dark, finding out will not require a census that was looking for something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc

