### PR TITLE
fix(cognition): preserve attention without falsely claiming a message names a citizen

### DIFF
--- a/core/continuum-core/src/cognition/deferred_faculty.rs
+++ b/core/continuum-core/src/cognition/deferred_faculty.rs
@@ -221,7 +221,7 @@ impl Faculty for DeferredFaculty {
 
     /// AMBIENT turns: non-blocking — kick the worker with the current world and
     /// return the last-good finding, never awaiting the inner faculty (the whole
-    /// point of the lane). DIRECTED turns: the ORIENTING RESPONSE — run the inner
+    /// point of the lane). Priority turns (addressed or human opportunity): run the inner
     /// faculty synchronously on THIS burst, because the deferred lane
     /// structurally serves the PREVIOUS turn's finding and an addressed question
     /// must benefit from its OWN recall (the eval fork already runs perception
@@ -229,7 +229,7 @@ impl Faculty for DeferredFaculty {
     /// parity). Cost: one fresh perception pass on turns that were already going
     /// to run full deliberation — negligible next to decode.
     async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
-        if ws.directed_at_self {
+        if ws.attention.requires_priority() {
             // Orienting response: fresh inner perception on this burst. Probe the
             // outcome — glass-boxed 2026-07-10: a directed silver-harbor question
             // 30s after boot produced NO recall bid and the seam was dark; whether
@@ -461,14 +461,16 @@ mod tests {
         fn id(&self) -> FacultyId {
             FacultyId::Recall
         }
-        async fn contribute(&self, _ws: &Workspace) -> Option<Contribution> {
+        async fn contribute(&self, ws: &Workspace) -> Option<Contribution> {
             tokio::time::sleep(std::time::Duration::from_millis(40)).await;
-            Some(Contribution::context(
+            let mut finding = Contribution::context(
                 FacultyId::Recall,
                 "a slow, late recall finding",
                 0.8,
                 "deep analyzer, off the hot path",
-            ))
+            );
+            finding.cycle = ws.cycle;
+            Some(finding)
         }
     }
 
@@ -553,10 +555,25 @@ mod tests {
             "the finding must be the inner faculty's own output"
         );
 
+        // Regression for card157c095d: separating literal addressing must not
+        // demote an unmentioned human question to the previous turn's recall.
+        let human = Workspace::in_room("which port is the new gateway on?", Uuid::nil())
+            .with_cycle(CycleId(2))
+            .with_attention(crate::cognition::workspace::TurnAttention::HumanOpportunity);
+        let human_finding = deferred
+            .contribute(&human)
+            .await
+            .expect("fresh human recall");
+        assert_eq!(
+            human_finding.cycle,
+            CycleId(2),
+            "human opportunity must perceive this burst"
+        );
+
         // The same tick UNDIRECTED still behaves as the deferred lane (fast —
         // the directed run warm-published, so this serves last-good) — ambience
         // never pays the synchronous cost.
-        let ws_ambient = Workspace::in_room("idle chatter", Uuid::nil()).with_cycle(CycleId(2));
+        let ws_ambient = Workspace::in_room("idle chatter", Uuid::nil()).with_cycle(CycleId(3));
         let t = tokio::time::Instant::now();
         let _ = deferred.contribute(&ws_ambient).await;
         assert!(

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -37,12 +37,27 @@ use super::deliberation_budget::{est_tokens, turn_message_line_addressed, GUARD_
 use super::deliberation_parse::decision_from_response;
 use super::deliberation_prompt;
 use super::persona_tools;
-use super::workspace::{Contribution, Decision, Faculty, FacultyId, TurnVoice, Workspace};
+use super::workspace::{
+    Contribution, Decision, Faculty, FacultyId, TurnAttention, TurnVoice, Workspace,
+};
 use crate::ai::adapter::AIProviderAdapter;
 use crate::ai::types::{
     ActiveAdapterRequest, ChatMessage, FinishReason, NativeToolSpec, TextGenerationRequest,
     TextGenerationResponse,
 };
+
+/// Ambient deliberation yields to measured foreground work. Human opportunity
+/// keeps its existing turn class even when the message did not name the persona.
+fn deliberation_slot_class(
+    purpose: Option<&str>,
+    attention: TurnAttention,
+) -> crate::inference::slots::SlotClass {
+    use crate::inference::slots::{class_for, SlotClass};
+    match class_for(purpose) {
+        SlotClass::Turn if !attention.requires_priority() => SlotClass::Background,
+        class => class,
+    }
+}
 
 /// The persona's paged-in genome: the LoRA layers active for this faculty's next
 /// generation. Shared (the [`WorkspaceCycle`](super::workspace::WorkspaceCycle)
@@ -1584,7 +1599,7 @@ impl LlmDeliberationFaculty {
                 .compose_system_split(
                     "",
                     &expanded,
-                    ws.directed_at_self,
+                    ws.directed_at_self(),
                     ws.self_initiated,
                     ws.now_ms,
                     holds_live_work,
@@ -1654,7 +1669,7 @@ impl LlmDeliberationFaculty {
         let trailing_framing = deliberation_prompt::compose_trailing(
             ws.now_ms,
             ws.self_initiated,
-            ws.directed_at_self,
+            ws.directed_at_self(),
             holds_live_work,
         );
         let all_messages = self.messages_unfitted(
@@ -1811,7 +1826,7 @@ impl LlmDeliberationFaculty {
             .compose_system_split(
                 &context,
                 &expanded,
-                ws.directed_at_self,
+                ws.directed_at_self(),
                 ws.self_initiated,
                 ws.now_ms,
                 holds_live_work,
@@ -2775,24 +2790,12 @@ impl Faculty for LlmDeliberationFaculty {
         crate::probe!(
             class = "delib.defer.entered",
             persona = %self.persona_name,
-            directed = ws.directed_at_self,
+            directed = ws.directed_at_self(),
+            attention = ?ws.attention,
             "at the pre-gate hold defer"
         );
         {
-            let mut class = crate::inference::slots::class_for(request.purpose.as_deref());
-            // DIRECTEDNESS REFINES THE CLASS (2026-08-29, the convoy). `class_for`
-            // maps purpose "cognition/deliberation" to Turn — but an UNDIRECTED
-            // self-tick is ambient work wearing a turn's purpose string. During a
-            // measured hold those ambient deliberations sailed past every defer,
-            // took the faculty lane permits, and convoyed single-file into the
-            // adapter's one-permit FIFO at slow-model speed — the solve starved
-            // behind idle chatter (avail=0 at every tick-2 lane_wait, glass-boxed).
-            // An undirected deliberation yields to a hold like any Background gen;
-            // the holder's own ticks are directed and never wait. No hold active →
-            // zero change (should_defer is a no-op on a released cell).
-            if matches!(class, crate::inference::slots::SlotClass::Turn) && !ws.directed_at_self {
-                class = crate::inference::slots::SlotClass::Background;
-            }
+            let class = deliberation_slot_class(request.purpose.as_deref(), ws.attention);
             crate::inference::measured_hold::defer_while_held(
                 class,
                 Some(self.persona_id),
@@ -2805,16 +2808,17 @@ impl Faculty for LlmDeliberationFaculty {
             persona = %self.persona_name,
             "past the pre-gate defer — admission gates next"
         );
-        if ws.directed_at_self {
-            // #2561: a directed engagement marks the organism ACTIVE (with linger)
-            // — the one seam that knows directedness feeds the activity gate.
+        if ws.attention.requires_priority() {
+            // #2561: foreground engagement marks the organism ACTIVE (with linger).
+            // Human opportunity remains active without asserting a literal address.
             crate::cognition::activity_gate::note_directed();
         }
         let gen_result = {
             crate::probe!(
                 class = "delib.gate.lane_wait",
                 persona = %self.persona_name,
-                directed = ws.directed_at_self,
+                directed = ws.directed_at_self(),
+                attention = ?ws.attention,
                 lanes_available = crate::cognition::resource_admission::serving_lane_permits_available() as u64,
                 "at the serving-lane admission gate"
             );
@@ -2822,7 +2826,7 @@ impl Faculty for LlmDeliberationFaculty {
             // the park held no lane, so abandoning it costs nothing, and the loop
             // head drains the line next (`cognition::directed_pending`). A `None`
             // here is her CHOICE to answer first, named by the probe — not a fault.
-            let _lane = if ws.directed_at_self {
+            let _lane = if ws.attention.requires_priority() {
                 crate::cognition::resource_admission::acquire_serving_lane(true).await
             } else {
                 tokio::select! {
@@ -4587,7 +4591,7 @@ mod tests {
                     )
                     .session_stable(),
                 );
-                ws.directed_at_self = directed;
+                ws.attention = TurnAttention::for_message(directed, false);
                 ws
             };
             let undirected = faculty.prompt_view(&with_grounding(false));
@@ -6107,12 +6111,17 @@ mod tests {
         // " If you have nothing worth adding, stay silent." nudge is gone, so neither turn
         // carries it. This is a FRAMING decision over a structural addressing fact — her
         // output is never filtered.
-        #[test]
-        fn directed_turn_withholds_the_silence_escape() {
+        #[tokio::test]
+        async fn directed_turn_withholds_the_silence_escape() {
             use crate::ai::types::MessageContent;
+            use crate::cognition::workspace::{
+                SalienceArbiter, Situation, TurnFraming, WorkspaceCycle,
+            };
+            use crate::inference::slots::SlotClass;
+            use crate::persona::persona_identity::PersonaIdentity;
             let adapter = Arc::new(ScriptedAdapter::new(vec![]));
             let faculty =
-                LlmDeliberationFaculty::new(Uuid::new_v4(), "Asha", "You are Asha.", adapter);
+                LlmDeliberationFaculty::new(Uuid::new_v4(), "Kimi", "You are Kimi.", adapter);
             // 2026-09-01: presence framing rides the conversation tail (the KV
             // split applied for real), so these assertions read the WHOLE
             // delivered prompt — system + turns — not the system string alone.
@@ -6153,6 +6162,70 @@ mod tests {
                 !directed.contains("stay silent"),
                 "and carries no 'stay silent' nudge on a directed turn either"
             );
+
+            // Regression for card157c095d: a human's opportunity (including a
+            // stale peer-kind classification) became the false instruction
+            // "This message names you". Exercise the real framing -> cycle ->
+            // prompt seam on both admission and act-result re-perception.
+            let identity = PersonaIdentity::new(faculty.persona_id, "Kimi");
+            let cycle = WorkspaceCycle::new(vec![], Arc::new(SalienceArbiter), 4);
+            for (text, human, expected_attention, expected_class) in [
+                (
+                    "Joel here — which card do you hold?",
+                    true,
+                    TurnAttention::HumanOpportunity,
+                    SlotClass::Turn,
+                ),
+                (
+                    "Astra / Codex -> IntelMac: thanks for the 3898 review.",
+                    false,
+                    TurnAttention::Ambient,
+                    SlotClass::Background,
+                ),
+                (
+                    "Astra / Codex -> IntelMac: thanks for the 3898 review.",
+                    true,
+                    TurnAttention::HumanOpportunity,
+                    SlotClass::Turn,
+                ),
+                (
+                    "Kimi, please review the patch.",
+                    false,
+                    TurnAttention::Addressed,
+                    SlotClass::Turn,
+                ),
+                (
+                    "Kimi, please review the patch.",
+                    true,
+                    TurnAttention::Addressed,
+                    SlotClass::Turn,
+                ),
+            ] {
+                let framing = TurnFraming::message(TurnAttention::for_message(
+                    identity.mentions(text),
+                    human,
+                ));
+                for situation in [Situation::FreshContext, Situation::PostAction] {
+                    let ws = cycle.run_situated(text.into(), framing, situation).await;
+                    assert_eq!(ws.attention, expected_attention, "{text}");
+                    assert_eq!(
+                        deliberation_slot_class(Some("cognition/deliberation"), ws.attention),
+                        expected_class,
+                        "human opportunity retains the foreground lane: {text}",
+                    );
+                    let delivered = whole(&faculty.prompt_view(&ws));
+                    assert_eq!(
+                        delivered.contains("This message names you"),
+                        expected_attention == TurnAttention::Addressed,
+                        "the actual prompt must not turn admission priority into addressing: {text}",
+                    );
+                    assert_eq!(
+                        delivered.contains("do not need to be addressed by name"),
+                        expected_attention != TurnAttention::Addressed,
+                        "unmentioned messages keep ordinary participation: {text}",
+                    );
+                }
+            }
         }
 
         // what this catches: the tools gate. With NO tools authorized, a tool-call

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -807,7 +807,42 @@ impl From<&String> for Burst {
     }
 }
 
-/// How THIS turn is framed for the persona — the two structural facts the system
+/// Why a turn receives attention. Human participation retains foreground
+/// scheduling without claiming the speaker literally addressed this persona.
+/// Addressing comes from the raw message's identity-aware mention check (or an
+/// explicitly targeted command/eval), never from the speaker's kind alone.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TurnAttention {
+    #[default]
+    Ambient,
+    HumanOpportunity,
+    Addressed,
+}
+
+impl TurnAttention {
+    pub fn for_message(mentioned: bool, sender_is_human: bool) -> Self {
+        if mentioned {
+            Self::Addressed
+        } else if sender_is_human {
+            Self::HumanOpportunity
+        } else {
+            Self::Ambient
+        }
+    }
+
+    /// A literal addressing fact, used only to frame the prompt.
+    pub fn is_addressed(self) -> bool {
+        matches!(self, Self::Addressed)
+    }
+
+    /// Admission, fresh perception and foreground lanes preserve the existing
+    /// opportunity for a human to speak without having to name each citizen.
+    pub fn requires_priority(self) -> bool {
+        !matches!(self, Self::Ambient)
+    }
+}
+
+/// How THIS turn is framed for the persona — the structural facts the system
 /// prompt reflects: is it DIRECTED at her (suppress the silence escape) and is it
 /// SELF-INITIATED (the heartbeat pursuing her own thread, vs a message/eval
 /// driving it). Replaces the lone `directed: bool` that used to thread through
@@ -817,9 +852,8 @@ impl From<&String> for Burst {
 /// ([[no-hardcoded-heuristics-to-steer-cognition]]).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TurnFraming {
-    /// Directed AT the persona (@mention / DM / examiner question) — see
-    /// [`Workspace::directed_at_self`].
-    pub directed: bool,
+    /// Addressing and scheduling opportunity travel together without conflation.
+    pub attention: TurnAttention,
     /// The never-stop heartbeat pursuing her own thread (no inbound message) —
     /// see [`Workspace::self_initiated`].
     pub self_initiated: bool,
@@ -845,18 +879,18 @@ impl TurnFraming {
     /// examiner question) — directed, not self-initiated.
     pub fn directed() -> Self {
         Self {
-            directed: true,
+            attention: TurnAttention::Addressed,
             self_initiated: false,
             ..Self::default()
         }
     }
 
-    /// The message path: a turn driven by an inbound message (not self-initiated),
-    /// `directed` iff she was actually named. `false` collapses to [`ambient`] —
-    /// silence stays first-class for room chatter she wasn't addressed in.
-    pub fn message(directed: bool) -> Self {
+    /// The message path: a turn driven by an inbound message (not self-initiated).
+    /// Only literal addressing withholds the silence affordance; an unmentioned
+    /// human message keeps its scheduling opportunity and ambient prompt.
+    pub fn message(attention: TurnAttention) -> Self {
         Self {
-            directed,
+            attention,
             self_initiated: false,
             ..Self::default()
         }
@@ -866,7 +900,7 @@ impl TurnFraming {
     /// perceived (so a question reaching her on the digest path is not ghosted).
     pub fn self_thread(directed: bool) -> Self {
         Self {
-            directed,
+            attention: TurnAttention::for_message(directed, false),
             self_initiated: true,
             ..Self::default()
         }
@@ -924,15 +958,11 @@ pub struct Workspace {
     pub cycle: CycleId,
     /// What entered the bounded workspace and is broadcast (the persona's "now").
     pub broadcast: Vec<Contribution>,
-    /// Is this turn DIRECTED at this persona — a direct @mention, a DM, or (in the
-    /// eval fork) an examiner's question put TO her? When `true`, declining the turn
-    /// by emitting the bare PASS token is NOT a legitimate option: the [Silence
-    /// Option] affordance is for *ambient* participation (room chatter she is free to
-    /// let pass), never for ghosting a question asked of her. The deliberation
-    /// faculty reads this to decide whether to OFFER the silence escape — a framing
-    /// decision over a structural addressing fact (like ACL/routing), NOT a filter on
-    /// her output. `false` (the default) = ambient: silence stays first-class.
-    pub directed_at_self: bool,
+    /// The turn's addressing fact and admission opportunity. Prompt framing reads
+    /// [`directed_at_self`](Self::directed_at_self); resource scheduling reads
+    /// [`TurnAttention::requires_priority`]. A human speaker alone does not mean
+    /// the message names this persona.
+    pub attention: TurnAttention,
     /// Is this a SELF-INITIATED turn — the never-stop heartbeat pursuing the
     /// persona's own thread with no inbound message — versus a turn driven by an
     /// arriving message or an examiner's question? Drives the `[Your own time]`
@@ -996,7 +1026,7 @@ impl Workspace {
             cause: burst.cause,
             cycle: CycleId::UNSTAMPED,
             broadcast: Vec::new(),
-            directed_at_self: false,
+            attention: TurnAttention::Ambient,
             self_initiated: false,
             workspace_deliverable: false,
             now_ms: burst_now,
@@ -1031,8 +1061,19 @@ impl Workspace {
     /// escape so a question put to her is not ghosted; `false` keeps silence
     /// first-class for ambient participation.
     pub fn directed(mut self, directed: bool) -> Self {
-        self.directed_at_self = directed;
+        self.attention = TurnAttention::for_message(directed, false);
         self
+    }
+
+    pub fn with_attention(mut self, attention: TurnAttention) -> Self {
+        self.attention = attention;
+        self
+    }
+
+    /// Whether this message was actually addressed to the persona. Human
+    /// opportunity affects scheduling, not this prompt-grounding fact.
+    pub fn directed_at_self(&self) -> bool {
+        self.attention.is_addressed()
     }
 
     /// Mark whether this turn is the self-initiated heartbeat (builder form). See
@@ -1994,7 +2035,7 @@ impl WorkspaceCycle {
             .await
     }
 
-    /// The live persona path passes `directed`/`self_initiated` here so the
+    /// The live persona path passes `attention`/`self_initiated` here so the
     /// deliberation faculty's system prompt reflects whether a question was put
     /// TO her (suppress the silence escape) and whether this is her own
     /// heartbeat. The room rides ON the burst — one statement of the activity,
@@ -2025,7 +2066,7 @@ impl WorkspaceCycle {
     /// deliberation faculty knows whether to offer the silence escape (see
     /// [`Workspace::directed_at_self`]) and whether to frame the turn as the
     /// persona's own time (see [`Workspace::self_initiated`]); everything else is
-    /// identical across framings — framing only reshapes the system prompt.
+    /// identical across framings. Attention also preserves resource priority.
     async fn run_inner(
         &self,
         burst: Burst,
@@ -2044,11 +2085,11 @@ impl WorkspaceCycle {
         // Carry the structured burst straight through: `from_burst` splits it into
         // the canonical `turns` (the deliberation faculty's role-attribution source)
         // and the `world_state` text projection (every other reader) and takes the
-        // ROOM from the burst itself. Framing reshapes only the system prompt — it
-        // never touches the conversation turns.
+        // ROOM from the burst itself. Framing carries prompt and scheduling facts;
+        // it never touches the conversation turns.
         let mut ws = Workspace::from_burst(burst)
             .with_cycle(cycle)
-            .directed(framing.directed)
+            .with_attention(framing.attention)
             .self_initiated(framing.self_initiated)
             .workspace_deliverable(framing.workspace_deliverable)
             // #169: hand this turn the live streaming sink if the caller set one

--- a/core/continuum-core/src/commands/persona/turn_frame/execute.rs
+++ b/core/continuum-core/src/commands/persona/turn_frame/execute.rs
@@ -257,7 +257,7 @@ crate::action_command! {
             &cycle,
             burst,
             true,
-            crate::cognition::workspace::TurnFraming::message(true),
+            crate::cognition::workspace::TurnFraming::directed(),
             // One-shot directed tick: a fresh ask, so fuller grounding.
             crate::cognition::workspace::Situation::FreshContext,
             &chain,

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -144,20 +144,21 @@ fn signal_if_directed(own: uuid::Uuid, event: &airc_core::TranscriptEvent) {
     let Ok(message) = perceptual_from_event(event) else {
         return;
     };
-    // The SAME predicate the loop head admits with (`turn_is_directed`): a
+    // The SAME priority the loop head admits with (`TurnAttention`): a
     // human line or a line naming her. On 9e8320b60 this site still raised the
     // flag for every non-citizen line, so a holder parked in a lane wait yielded
     // to an agent status line that the loop head then declined — 13 work turns
     // abandoned in 9 ms in half an hour (`delib.gate.yielded_to_directed`).
     let registry = crate::persona::PersonaAircRuntimeRegistry::try_global();
-    let sender_is_citizen = registry.as_ref().is_some_and(|r| r.get(peer).is_some());
     let mentioned = registry
         .as_ref()
         .and_then(|r| r.get(own))
         .map(|rt| crate::persona::persona_identity::PersonaIdentity::new(own, rt.agent_name().to_string()))
         .is_some_and(|me| me.mentions(&message.text));
     let sender_is_human = crate::ipc::positron_presence::is_human_peer(peer);
-    if crate::persona::service_loop::turn_is_directed(mentioned, sender_is_citizen, false, sender_is_human) {
+    if crate::cognition::workspace::TurnAttention::for_message(mentioned, sender_is_human)
+        .requires_priority()
+    {
         crate::cognition::directed_pending::signal(own);
     }
 }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -643,26 +643,18 @@ async fn serve_persona_loop_inner(
         }
         // Whatever was pending is now in hand (the yield signal is consumed here).
         crate::cognition::directed_pending::clear(self_id);
-        // Directed = a line from outside the citizenry (human, agent) or one
-        // that names her — the same addressing FACT the turn frames on.
-        // Holding work = the BOARD says she holds a card (one airc call per
-        // wake), not the acting-root registry: a holder whose hands never
-        // rooted (two held cards → ambiguous staging) still woke on every
-        // agent status line (Lorcan, 2026-09-04).
-        let holding_work = holding_work_now(conversation, self_id).await;
-        let directed_line = |m: &IncomingMessage| {
-            let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
-                .is_some_and(|r| r.get(m.peer_id).is_some());
-            turn_is_directed(
+        // Both a literal mention and a human's opportunity to speak receive
+        // priority. Only the former can tell the mind "this message names you".
+        let priority_line = |m: &IncomingMessage| {
+            crate::cognition::workspace::TurnAttention::for_message(
                 ctx.identity.persona_identity().mentions(&m.text),
-                sender_is_citizen,
-                holding_work,
                 crate::ipc::positron_presence::is_human_peer(m.peer_id),
             )
+            .requires_priority()
         };
         // Every directed line drained is HEARD (delivery receipt), whether or
         // not it becomes the trigger.
-        for m in qualifying.iter().filter(|m| directed_line(m)) {
+        for m in qualifying.iter().filter(|m| priority_line(m)) {
             crate::persona::wake_backlog::publish_heard(self_id, m);
         }
         // An undirected AGENT line (neither human nor citizen, not naming her)
@@ -673,7 +665,7 @@ async fn serve_persona_loop_inner(
         qualifying.retain(|m| {
             let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
                 .is_some_and(|r| r.get(m.peer_id).is_some());
-            crate::persona::wake_backlog::triggers_a_turn(directed_line(m), sender_is_citizen)
+            crate::persona::wake_backlog::triggers_a_turn(priority_line(m), sender_is_citizen)
         });
         let perceived_only = before - qualifying.len();
         if perceived_only > 0 {
@@ -688,7 +680,7 @@ async fn serve_persona_loop_inner(
         // Trigger = newest DIRECTED line in the backlog (a question put to her
         // outranks newer ambient chatter — she answers it WITH the newer
         // context visible in the transcript), else the newest overall.
-        let (msg, coalesced) = match crate::persona::wake_backlog::pick_trigger(qualifying, directed_line) {
+        let (msg, coalesced) = match crate::persona::wake_backlog::pick_trigger(qualifying, priority_line) {
             Some(picked) => picked,
             None => {
                 if stream_ended {
@@ -1125,7 +1117,7 @@ async fn serve_persona_loop_inner(
                 // Per Joel 2026-06-29 ("shouldn't need to be directly addressed — it's
                 // a chat system"): ambient participation is now the DEFAULT posture,
                 // carried by the rebalanced [Conversational Presence] framing, NOT by
-                // `directed`. So `directed` is reserved for its one job — withholding
+                // priority. Literal addressing is reserved for its one job — withholding
                 // the silent-PASS hatch when a message actually NAMES her, so she cannot
                 // ghost a question put to her. Glass-box proved the gap: a cleanly-woken
                 // MSG-turn PASSed a direct question while eval turns SPOKE 36/38 (the
@@ -1138,20 +1130,18 @@ async fn serve_persona_loop_inner(
                 // self-set attention weight — never a hard mute except self-chosen or
                 // flooding) is substrate-blocked on the airc per-(persona,room) state
                 // store (#89); this is the addressing half, unblocked today.
-                let sender_is_citizen = crate::persona::PersonaAircRuntimeRegistry::try_global()
-                    .is_some_and(|r| r.get(msg.peer_id).is_some());
-                let directed = turn_is_directed(
+                // Human opportunity retains priority, but sender kind can be stale
+                // or shared across clients: it cannot assert that she was named.
+                let attention = crate::cognition::workspace::TurnAttention::for_message(
                     ctx.identity.persona_identity().mentions(&msg.text),
-                    sender_is_citizen,
-                    holding_work_now(conversation, ctx.identity.peer_id.as_uuid()).await,
                     crate::ipc::positron_presence::is_human_peer(msg.peer_id),
                 );
-                if directed {
+                if attention.requires_priority() {
                     // Focus = she is TAKING the turn on it; the heard receipt
                     // already fired at the drain (`wake_backlog::publish_heard`).
                     crate::ipc::vitals_emitter::record_focus(ctx.identity.peer_id.as_uuid());
                 }
-                let framing = crate::cognition::workspace::TurnFraming::message(directed);
+                let framing = crate::cognition::workspace::TurnFraming::message(attention);
 
                 // ── Ambient-yield under lane saturation (#171 / #139) ───────────────
                 // The fan-out killer: a room burst wakes N peers, and each spends a full
@@ -1160,10 +1150,10 @@ async fn serve_persona_loop_inner(
                 // of ambient chatter (glass-boxed: first-token up to 28 min). Ambient
                 // participation is the DEFAULT and stays that way — but it is the
                 // LOWEST-priority room work. So when every shared decode slot is busy,
-                // a NON-directed turn YIELDS: she participates ambiently when there's
+                // an ambient turn YIELDS: she participates ambiently when there's
                 // capacity (a later beat, lanes free — a self-tick re-perceives the room
                 // incl. this line), never at the cost of the addressed question. A
-                // DIRECTED turn (she was named) NEVER yields — she answers now.
+                // priority turn (named or human opportunity) keeps its lane.
                 //
                 // This is resource PRIORITY, the same admission doctrine as the idle
                 // self-tick, NOT a `will_respond` gate: the substrate never decides her
@@ -1177,11 +1167,11 @@ async fn serve_persona_loop_inner(
                 // first cut didn't fire: a simultaneous room-burst wakes N peers who all
                 // read inflight=0 (none had generated yet) and stampede. The permit is
                 // held across the whole turn, so ambient concurrency is bounded no matter
-                // when everyone woke. Directed turns bypass entirely — she was named, she
-                // answers now. A yielded ambient turn defers to a later beat with free
+                // when everyone woke. Priority turns bypass entirely, including a human
+                // speaking without a mention. Ambient turns defer to a later beat with free
                 // capacity (a self-tick re-perceives the room); high_water is pre-advanced
                 // so it can't re-trigger, and the durable transcript loses nothing.
-                let _ambient_permit = if directed {
+                let _ambient_permit = if attention.requires_priority() {
                     None
                 } else {
                     match crate::cognition::resource_admission::try_hold_ambient_turn() {
@@ -1888,56 +1878,6 @@ fn push_work_board_anchor(
     turns.push(crate::cognition::workspace::BurstTurn::perception(anchor));
 }
 
-
-/// The WORK-question burst — the input of the second gate a claim-holder's
-/// quiet turn asks (see the `SettleStep::Passed` arm). The burst IS the
-/// question: her held in-progress cards, stated once, with the contract that
-/// passing remains hers. Deliberately NOT the room transcript — the subject of
-/// this turn is the work, and the card details/workspace root arrive through
-/// her own grounding exactly as on any turn.
-/// Whether an inbound room message is DIRECTED at this citizen — the framing
-/// that withholds the silent-PASS hatch and reserves a lane. Two roads in:
-/// she is named, or the speaker is NOT a fellow citizen. A human at the desk or
-/// an agent asking the room is addressing the citizens by construction (being
-/// heard is the scarce thing); citizens talking among themselves — and the
-/// work receipts they radiate — stay ambient, or twelve of them answer every
-/// receipt. Live 2026-09-03: the operator asked a work room a direct question
-/// twice and no citizen answered, because "directed" meant @mention only.
-/// Does she hold a card right now — the board's answer (`active_claims`), or
-/// the acting-root registry when the board cannot be asked (no citizen stream).
-async fn holding_work_now(
-    conversation: &dyn PersonaConversation,
-    self_id: Uuid,
-) -> bool {
-    match conversation.stream_citizen() {
-        Some(citizen) => match citizen.active_claims().await {
-            Ok(held) => !held.is_empty(),
-            Err(_) => crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
-        },
-        None => crate::cognition::persona_workspace::acting_root_of(self_id).is_some(),
-    }
-}
-
-/// `holding_work`: she holds a card. Then only a HUMAN line or an
-/// @mention is directed — agent status traffic in the base room is message
-/// plane for perception, not a wake (working ≠ speaking; a human's question
-/// still is). Measured 2026-09-04: 8 work turns an hour across ten holders
-/// while every agent line in #academy woke all twelve for a message turn.
-pub(crate) fn turn_is_directed(
-    mentioned: bool,
-    sender_is_citizen: bool,
-    holding_work: bool,
-    sender_is_human: bool,
-) -> bool {
-    // Agent (non-human, non-citizen) status traffic is never a wake on its own:
-    // the agents' coordination room is the citizens' base room, and every idle
-    // citizen answered every agent line with a 265 s "nothing names me" turn
-    // (Joaquin, ×6 in 30 min, 2026-09-04). An agent that wants a citizen @mentions
-    // her; a human's line is always directed. `holding_work` narrows nothing
-    // further today but stays the fact the gate reasons on.
-    let _ = (holding_work, sender_is_citizen);
-    mentioned || sender_is_human
-}
 
 
 
@@ -2760,7 +2700,7 @@ async fn run_self_cycle(
     // burst turns, so the mind still SEES that it was named and can choose to answer; it
     // is simply never COMPELLED to on the ambient tick. Anti-ghosting of a genuine direct
     // question is the REACTIVE message path's job (service_loop ~675,
-    // `TurnFraming::message(directed)`), where a real inbound question arrives as an
+    // `TurnFraming::message(attention)`), where a real inbound question arrives as an
     // addressed event — not this ambient digest tick. Framing over a structural fact,
     // never a gate on cognition ([[no-hardcoded-heuristics-to-steer-cognition]]): the
     // previous `self_thread(addressed)` was a dumb function steering the mind away from
@@ -2928,36 +2868,6 @@ async fn next_event(
 mod tests {
     use super::*;
     use airc_core::PeerId;
-
-    // what this catches: the WORK-question burst drifting from its contract — it must
-    // name each held card (short id + title) and pose the act-question with passing
-    // explicitly hers, because this text IS the second gate of a claim-holder's quiet
-    // turn (BigMama's gate-conflation fix, 2026-08-08). A burst that loses the card
-    // names starves the question; one that loses the pass-clause becomes a command.
-    #[test]
-    // what this catches: a human's (or agent's) room line is a DIRECTED turn without
-    // an @mention; citizen chatter stays ambient unless she is named (operator asked
-    // twice, nobody answered — 2026-09-03).
-    #[test]
-    fn a_non_citizen_line_is_directed_and_citizen_chatter_needs_a_mention() {
-        assert!(turn_is_directed(false, false, false, true), "human line: directed");
-        assert!(!turn_is_directed(false, false, false, false), "agent status line, idle citizen: ambient (2026-09-04)");
-        assert!(turn_is_directed(true, false, false, false), "an agent naming her: directed");
-        assert!(turn_is_directed(true, true, false, false), "a citizen naming her: directed");
-        assert!(!turn_is_directed(false, true, false, false), "citizen chatter/receipts: ambient");
-    }
-
-    // what this catches: a citizen HOLDING WORK waking for agent status traffic —
-    // every agent line in #academy woke all twelve holders (8 work turns an hour,
-    // 2026-09-04). Holding work: a human line or a mention is directed; an
-    // agent's line is message plane only.
-    #[test]
-    fn holding_work_only_a_human_line_or_a_mention_is_directed() {
-        assert!(!turn_is_directed(false, false, true, false), "agent line while holding work: ambient");
-        assert!(turn_is_directed(false, false, true, true), "human line while holding work: directed");
-        assert!(turn_is_directed(true, false, true, false), "an agent naming her: directed");
-        assert!(!turn_is_directed(false, true, true, false), "citizen receipts: ambient");
-    }
 
     // what this catches: the resume block carries HER newest thoughts only, oldest
     // first, clipped — never another citizen's line, never a receipt.

--- a/core/continuum-core/src/persona/wake_backlog.rs
+++ b/core/continuum-core/src/persona/wake_backlog.rs
@@ -9,8 +9,8 @@
 //! line that @mentioned her, else the newest overall — a human line without
 //! a mention lost to any newer citizen work receipt, and the "heard by N"
 //! receipt fired only for the chosen line. Now: staleness is by event id
-//! (a ring), the trigger is the newest DIRECTED line (human/agent line or a
-//! mention), and every directed line drained earns its heard receipt.
+//! (a ring), the trigger is the newest priority line (human opportunity or a
+//! mention), and every priority line drained earns its heard receipt.
 
 use std::collections::VecDeque;
 
@@ -53,29 +53,29 @@ pub(crate) fn is_stale(m: &IncomingMessage, seen: &mut SeenIds, high_water: u64)
     }
 }
 
-/// Can this drained line be the TRIGGER of a turn at all? A directed line
+/// Can this drained line be the TRIGGER of a turn at all? A priority line
 /// (human, or anyone naming her) always; an undirected line from a fellow
 /// CITIZEN yes — that is conversation among citizens; an undirected line from
 /// an AGENT (neither human nor citizen) NEVER — it is perceived (transcript,
 /// digest) and takes no lane. Measured 2026-09-05: 34 of Joaquin's last 60
 /// turns were message turns on BigMama's and IntelMac's walls in the project
 /// room; her held card had zero edits in eight hours (card ae4bb4fd).
-pub(crate) fn triggers_a_turn(directed: bool, sender_is_citizen: bool) -> bool {
-    directed || sender_is_citizen
+pub(crate) fn triggers_a_turn(priority: bool, sender_is_citizen: bool) -> bool {
+    priority || sender_is_citizen
 }
 
-/// The trigger for ONE turn over the drained backlog: the newest DIRECTED line
+/// The trigger for ONE turn over the drained backlog: the newest priority line
 /// (a question put to her outranks newer ambient chatter — she answers it with
 /// the newer context visible in the transcript), else the newest overall.
 /// Returns the trigger and how many lines were coalesced into it.
 pub(crate) fn pick_trigger(
     mut qualifying: Vec<IncomingMessage>,
-    directed: impl Fn(&IncomingMessage) -> bool,
+    priority: impl Fn(&IncomingMessage) -> bool,
 ) -> Option<(IncomingMessage, usize)> {
     let coalesced = qualifying.len().saturating_sub(1);
     let picked = qualifying
         .iter()
-        .rposition(|m| directed(m))
+        .rposition(|m| priority(m))
         .map(|i| qualifying.swap_remove(i))
         .or_else(|| qualifying.pop())?;
     Some((picked, coalesced))
@@ -146,12 +146,28 @@ mod tests {
     // what this catches: a human line without an @mention losing the turn to a
     // newer citizen work receipt.
     #[test]
-    fn the_newest_directed_line_wins_over_newer_citizen_chatter() {
+    fn a_human_opportunity_wins_over_newer_citizen_chatter_without_a_mention() {
+        use crate::cognition::workspace::TurnAttention;
+        let identity = crate::persona::persona_identity::PersonaIdentity::new(
+            Uuid::new_v4(),
+            "Kimi",
+        );
         let human = line(1, 3, "Joel here — which card do you hold?");
         let human_id = human.event_id;
         let receipt = line(2, 900, "💭 Let me get my bearings.");
-        let (picked, coalesced) = pick_trigger(vec![human, receipt], |m| m.peer_id == Uuid::from_u128(1)).unwrap();
+        let (picked, coalesced) = pick_trigger(vec![human, receipt], |m| {
+            TurnAttention::for_message(
+                identity.mentions(&m.text),
+                m.peer_id == Uuid::from_u128(1),
+            )
+            .requires_priority()
+        })
+        .unwrap();
         assert_eq!(picked.event_id, human_id);
         assert_eq!(coalesced, 1);
+        assert!(
+            !identity.mentions(&picked.text),
+            "human priority does not require a name"
+        );
     }
 }


### PR DESCRIPTION
A message from a peer classified as human previously received both foreground priority and the instruction “This message names you.” This made an unmentioned message such as `Astra / Codex -> IntelMac` falsely appear addressed to Kimi. `TurnAttention` now distinguishes ambient participation, human opportunity, and explicit addressing. Only the existing identity-aware check on the raw trigger, or an explicitly targeted command/eval, supplies the addressing fact used by the prompt.

Human opportunity retains its existing wake selection, pending signal, foreground lanes, ambient-permit bypass, activity signal, and fresh recall. The typed fact survives act-result re-perception. Removing the classifier's unused work-state argument also removes two unnecessary `active_claims` RPCs; other work gating is unchanged. PR #3901's prompt fitting and payload preservation are retained.

Validation:

- 75 tests passed in the combined validation checkout. Regressions exercise the actual WorkspaceCycle and delivered prompt for Kimi mentions, unmentioned human speech, and the IntelMac message under both agent and stale-human classification, across initial and post-action turns. They also check slot class, newest-human wake selection, and fresh recall.
- Independent source review checked every former scheduling reader, continuation framing, and compatibility: neither changed type was serialized. Diff checks and Rust syntax parsing passed.
- Combined library/test Clippy passed with `-D clippy::await_holding_lock` (716 existing library-test warnings remain; no suppressions added). Live verification is pending. Live acceptance must inspect the submitted prompt and scheduling evidence after deployment; corrected framing alone does not establish improved model behavior.

This is a bounded repair within card `157c095d`, not closure of its broader attribution/authenticity scope. Per-client actor identity and transport targets still need to survive admission, and stale peer-kind/directory-cache classification remains unresolved. Such a stale classification can still grant human opportunity; it can no longer manufacture the literal addressing instruction.

