### PR TITLE
fix(disk): the substrate weighs and evicts the caches I invented — 110 GB of worktree build output was registered nowhere

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1452,16 +1452,24 @@ pub fn start_server(
         // artifacts only (safe on any user's machine — the next build
         // recreates everything it deletes). Shares its TrackedDir with the
         // disk reporter — one measurement per class.
-        if let Some(cargo_dir) = crate::system_resources::tracked_dir("cargo-target") {
-            broker.register(Arc::new(crate::system_resources::CargoTargetPool::new(
-                cargo_dir,
-                crate::system_resources::DEFAULT_CARGO_TARGET_BUDGET_BYTES,
-            )) as Arc<dyn crate::paging::pool::ResourcePool>);
-            log_info!(
-                "ipc",
-                "server",
-                "CargoTargetPool registered with PressureBroker (budget-capped, flock-guarded)"
-            );
+        // BOTH build caches, not just the shared one. Worktree builds are required to
+        // write into `cargo-target-wt` so they cannot poison the main checkout's target
+        // (card d2cda466), and that directory then grew to 87 GB unweighed because it was
+        // registered nowhere — the 2026-07-13 law with a new name on it. Same pool, same
+        // budget, same flock discipline; the broker now sees both.
+        for class in ["cargo-target", "cargo-target-wt"] {
+            if let Some(cargo_dir) = crate::system_resources::tracked_dir(class) {
+                broker.register(Arc::new(crate::system_resources::CargoTargetPool::new(
+                    cargo_dir,
+                    crate::system_resources::DEFAULT_CARGO_TARGET_BUDGET_BYTES,
+                ))
+                    as Arc<dyn crate::paging::pool::ResourcePool>);
+                let line = format!(
+                    "CargoTargetPool registered with PressureBroker for {class} \
+                     (budget-capped, flock-guarded)"
+                );
+                log_info!("ipc", "server", "{}", line);
+            }
         }
 
         // Rotation-generation eviction owners (2026-08-06): the

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -667,7 +667,20 @@ mod tests {
         // in-flight-set hazard to reason about. Deferring is for
         // classes where blind deletion is UNSAFE (a grading instance,
         // a served model); there is nothing unsafe here to defer for.
-        let owned = ["cargo-target", "genome-models", "logs", "probes"];
+        let owned = [
+            "cargo-target",
+            // Same owner and the same rule as the shared target: derived build output,
+            // re-creatable by definition, evicted oldest-artifact-first under pressure.
+            "cargo-target-wt",
+            "genome-models",
+            "logs",
+            "probes",
+            // Owner: perception::eye_reaper. A profile whose browser is gone is dead
+            // weight the instant the browser dies, so eviction is not age-based — the
+            // reaper removes every profile no live process names, at boot and on the
+            // pressure edge.
+            "eye-profiles",
+        ];
         let deferred = [
             (
                 "hf-hub",

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -186,6 +186,21 @@ pub fn standard_tracked_dirs(home: &std::path::Path) -> Vec<Arc<TrackedDir>> {
 
     let mut dirs = vec![
         TrackedDir::new("cargo-target", home.join(".continuum/cache/cargo-target")),
+        // THE CACHE I INVENTED IS A CACHE THE SUBSTRATE OWNS (Joel, 2026-09-08: "the
+        // system is supposed to manage disk; you've been defying design principles so it
+        // can't"). Worktree builds must not write into the shared target — a worktree
+        // build once latched its CARGO_MANIFEST_DIR into it and broke the main checkout
+        // (card d2cda466) — so every agent building in a worktree exports
+        // CARGO_TARGET_DIR=cargo-target-wt. That directory reached 87 GB unseen, because
+        // it was never registered: the 2026-07-13 law says a new directory the substrate
+        // writes unbounded data into gets a TrackedDir row and an eviction decision, and
+        // hand-sweeping it is exactly the compensation the law exists to end.
+        TrackedDir::new("cargo-target-wt", home.join(".continuum/cache/cargo-target-wt")),
+        // The eye's browser profiles. Playwright defaults them into the OS temp dir,
+        // where nothing of ours can see or evict them: 337 leaked profiles from 31
+        // orphaned browsers accumulated there over a week (card de9b8876). A directory
+        // under our own cache root is one the monitor can weigh and the reaper can clear.
+        TrackedDir::new("eye-profiles", home.join(".continuum/cache/eye-profiles")),
         // The served-weights store. UNTRACKED until 2026-09-06 — the largest class on the
         // volume (360 GB on the M5 that day: Flash-Next 123, Kimi-Linear 95, DeepSeek-V4-Flash
         // 91, Qwen3.8-27B 20, Ornith 20) and invisible to both halves of the governed-disk


### PR DESCRIPTION
fix(disk): the substrate weighs and evicts the caches I invented

Joel, 2026-09-08: "you were supposed to have a system that managed its own disk. This
is a brand new computer with ONLY continuum related things." He is right, and the
reason it did not is mechanical.

MEASURED ON THE M5 TODAY: cache/cargo-target-wt 110 GB, cache/cargo-target 25 GB,
citizens 91 GB, on a volume 10% used. The broker only acts when a POOL is over ITS
budget, and cargo-target-wt was registered nowhere: no TrackedDir row, so
DiskPressureMonitor could not weigh it; no ResourcePool, so nothing could evict it. It
was invisible to the machinery designed to govern exactly this, and the only thing left
was me hand-sweeping — which is the compensation the 2026-07-13 law exists to end.

I created that directory. Worktree builds must not write into the shared target (a
worktree build once latched CARGO_MANIFEST_DIR into it and broke the main checkout,
card d2cda466), so every agent exports CARGO_TARGET_DIR=cargo-target-wt — and I never
gave it an owner. Same mistake in the eye: its browser profiles go to the OS temp dir,
where nothing of ours can see them, and 337 of them accumulated.

- standard_tracked_dirs gains cargo-target-wt and eye-profiles
  (~/.continuum/cache/eye-profiles), so both are weighed like every other class.
- ipc registers a CargoTargetPool for BOTH build caches with the same 50 GB budget and
  the same flock discipline; at 110 GB the worktree cache is over budget by more than
  double, so the broker's next relief pass evicts it without anyone typing a command.
- The eviction-decision test gains both classes: cargo-target-wt owned by the same pool,
  eye-profiles owned by perception::eye_reaper (a profile whose browser is gone is dead
  the instant the browser dies, so it is not age-based).

Acceptance: after deploy, disk.pool rows name cargo-target-wt with its usage against the
50 GB budget, and the next relief pass frees it — with no hand sweeping and no sudo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo