### PR TITLE
fix(persona): refresh live conversations on room membership changes

### DIFF
--- a/core/continuum-core/src/modules/room.rs
+++ b/core/continuum-core/src/modules/room.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ts_rs::TS;
 
-use crate::modules::work::persona_airc;
+use crate::modules::work::{persona_airc, persona_runtime};
 use crate::persona::room_roster_source::{PRESENCE_WINDOW, ROSTER_SCAN};
 use crate::persona::PersonaAircRuntimeRegistry;
 use crate::runtime::{CommandResult, ModuleConfig, ModuleContext, ModulePriority, ServiceModule};
@@ -353,15 +353,17 @@ impl ActionCommand for RoomJoin {
                     .to_string(),
             ));
         }
-        let airc = persona_airc(&self.registry, ctx, "room/join")?;
+        let runtime = persona_runtime(&self.registry, ctx, "room/join")?;
         // `subscribe_room`, never `join` (airc#1330): `join` would promote this
         // room to her default, so every room she is added to would silently
-        // become the one her un-named reads resolve against.
-        let room = airc
+        // become the one her un-named reads resolve against. Keep the runtime
+        // boundary: it wakes live subscriptions after the durable change.
+        let room = runtime
             .subscribe_room(name)
             .await
             .map_err(|e| CommandError::Internal(format!("join '{name}' failed: {e}")))?;
-        let is_default = airc
+        let is_default = runtime
+            .airc()
             .subscription_set()
             .await
             .ok()
@@ -426,15 +428,16 @@ impl ActionCommand for RoomLeave {
     type Output = RoomLeaveResult;
 
     async fn run(&self, ctx: &Ctx, p: RoomLeaveParams) -> Result<RoomLeaveResult, CommandError> {
-        let airc = persona_airc(&self.registry, ctx, "room/leave")?;
+        let runtime = persona_runtime(&self.registry, ctx, "room/leave")?;
         let named = p.room.as_deref().map(str::trim).filter(|s| !s.is_empty());
-        let room = airc
-            .part_channel(named)
+        let room = runtime
+            .leave_room(named)
             .await
             .map_err(|e| CommandError::Internal(format!("leave failed: {e}")))?;
         // Read the set AFTER parting so `remaining` is the fact, not an
         // arithmetic guess about what the part did.
-        let remaining = airc
+        let remaining = runtime
+            .airc()
             .subscription_set()
             .await
             .map(|s| s.all().count() as u32)
@@ -598,7 +601,10 @@ mod tests {
             room("bench-swe-run-1", false),
         ]);
         assert!(s.starts_with("You belong to 3 room(s)"), "{s}");
-        assert!(s.contains("academy") && s.contains("bench-swe-run-1"), "{s}");
+        assert!(
+            s.contains("academy") && s.contains("bench-swe-run-1"),
+            "{s}"
+        );
         assert!(
             s.contains("default room is academy"),
             "the focus must be named, not just implied: {s}"

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -33,7 +33,7 @@ use airc_lib::{
     HeartbeatWorkClaim, Priority, ReleaseWorkClaim, RepoId, WorkCardId,
 };
 
-use crate::persona::PersonaAircRuntimeRegistry;
+use crate::persona::{PersonaAircRuntime, PersonaAircRuntimeRegistry};
 use crate::runtime::{
     CommandResult, MessageBus, ModuleConfig, ModuleContext, ModulePriority, ModuleRegistry,
     ServiceModule,
@@ -113,7 +113,7 @@ fn first_transition_sighting(card_id: &str, state: &str) -> bool {
     static SEEN: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
     let key = format!("{card_id}\u{1}{state}");
     let seen = SEEN.get_or_init(|| Mutex::new(VecDeque::with_capacity(SEEN_CAP)));
-    let mut seen = seen.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every lock in this crate
+    let mut seen = seen.lock().unwrap_or_else(|p| p.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
     if seen.contains(&key) {
         return false;
     }
@@ -141,7 +141,8 @@ pub(crate) async fn emit_card_state_changed(payload: Value, via: &'static str) {
         "card-state transition published onto the internal bus"
     );
     if let Some((bus, registry)) = WORK_EVENT_BUS.get() {
-        bus.publish(WORK_CARD_STATE_CHANGED, payload, registry).await;
+        bus.publish(WORK_CARD_STATE_CHANGED, payload, registry)
+            .await;
     }
 }
 
@@ -156,7 +157,7 @@ fn first_sighting(event_id: Uuid) -> bool {
     const SEEN_CAP: usize = 256;
     static SEEN: OnceLock<Mutex<VecDeque<Uuid>>> = OnceLock::new();
     let seen = SEEN.get_or_init(|| Mutex::new(VecDeque::with_capacity(SEEN_CAP)));
-    let mut seen = seen.lock().unwrap_or_else(|p| p.into_inner());  // poisoned lock = read the last state, same policy as every lock in this crate
+    let mut seen = seen.lock().unwrap_or_else(|p| p.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
     if seen.contains(&event_id) {
         return false;
     }
@@ -195,10 +196,10 @@ pub async fn bridge_wire_work_event(event: &airc_core::TranscriptEvent) {
 /// TTL than the claim would make "how long is my hold good for" answerable two ways.
 pub(crate) const DEFAULT_CLAIM_TTL_MS: u64 = 30 * 60 * 1000;
 
-/// Resolve the CALLING persona's own airc handle so work ops act as ITS key.
-/// The caller identity is the authenticated airc peer_id the gate already saw;
-/// `None` (substrate-local owner) has no persona runtime → a typed refusal.
-pub(crate) fn persona_airc(
+/// Resolve the caller's runtime, retaining the owner of live membership changes.
+/// A caller-less command uses the operator self-peer; an authenticated caller
+/// must resolve its own runtime and can never fall through to another identity.
+pub(crate) fn persona_runtime(
     registry: &PersonaAircRuntimeRegistry,
     ctx: &Ctx,
     // What the CALLER actually invoked. Was hardcoded to "work commands", which
@@ -206,13 +207,13 @@ pub(crate) fn persona_airc(
     // who is here was told "work commands act as ..." and pointed at `airc work`.
     // A refusal that misnames the thing you called teaches the wrong lesson.
     family: &str,
-) -> Result<Arc<Airc>, CommandError> {
+) -> Result<Arc<PersonaAircRuntime>, CommandError> {
     // A persona acting through her toolbelt acts as HERSELF; the caller-less
     // operator acts as the OPERATOR SELF-PEER (#27, closed 2026-08-30) — the
     // human's in-core identity, booted beside the citizens. The deny below
     // survives only for the boot window before the self-peer is online.
     let Some(peer) = ctx.caller.as_ref().map(|c| c.peer_id.as_uuid()) else {
-        return crate::persona::operator_peer::operator_airc().ok_or_else(|| {
+        return crate::persona::operator_peer::operator_runtime().ok_or_else(|| {
             CommandError::Denied(format!(
                 "{family} acts as the caller's own airc identity, and the operator \
                  self-peer is not online yet this boot (it starts beside the \
@@ -221,10 +222,19 @@ pub(crate) fn persona_airc(
             ))
         });
     };
-    let rt = registry.get(peer).ok_or_else(|| {
-        CommandError::NotFound(format!("no live airc runtime for persona {peer}"))
-    })?;
-    Ok(rt.airc().clone())
+    registry
+        .get(peer)
+        .ok_or_else(|| CommandError::NotFound(format!("no live airc runtime for persona {peer}")))
+}
+
+/// Read/write the caller's own airc handle. Membership mutations use
+/// [`persona_runtime`] instead so they also notify its live subscriptions.
+pub(crate) fn persona_airc(
+    registry: &PersonaAircRuntimeRegistry,
+    ctx: &Ctx,
+    family: &str,
+) -> Result<Arc<Airc>, CommandError> {
+    Ok(persona_runtime(registry, ctx, family)?.airc().clone())
 }
 
 /// Resolve an airc handle for an OPERATOR/curator board write — e.g.
@@ -390,8 +400,13 @@ fn parse_state(s: &str) -> Result<CardState, CommandError> {
 /// so the first hit is the only hit. A caller can only read boards of rooms it is
 /// SUBSCRIBED to, so this widens no visibility — it only stops discarding what
 /// the caller can already see.
-pub(crate) async fn room_holding_card(airc: &Arc<Airc>, card_id: WorkCardId) -> Option<airc_lib::Room> {
-    card_in_subscribed_rooms(airc, card_id).await.map(|(room, _)| room)
+pub(crate) async fn room_holding_card(
+    airc: &Arc<Airc>,
+    card_id: WorkCardId,
+) -> Option<airc_lib::Room> {
+    card_in_subscribed_rooms(airc, card_id)
+        .await
+        .map(|(room, _)| room)
 }
 
 /// The card AND the subscribed room whose board holds it — the one walk behind
@@ -722,10 +737,12 @@ impl ActionCommand for WorkClaim {
                             )
                             .await
                         }
-                        Err(e) => Staging::Failed { stage: "home", error: e.to_string() },
+                        Err(e) => Staging::Failed {
+                            stage: "home",
+                            error: e.to_string(),
+                        },
                     };
-                    let driver =
-                        crate::cognition::bench_round::driver_for_card(card_id.as_uuid());
+                    let driver = crate::cognition::bench_round::driver_for_card(card_id.as_uuid());
                     match (driver, &staging) {
                         (WorkDriver::Citizen, _) => crate::probe!(
                             class = "work.claim.held",
@@ -919,7 +936,9 @@ pub fn spawn_env_prewarm_for_working_rounds() {
         for name in names {
             let mut resolved = None;
             for spec in crate::commands::benchmark::known_benchmarks() {
-                let Some(dataset) = spec.swe_dataset() else { continue };
+                let Some(dataset) = spec.swe_dataset() else {
+                    continue;
+                };
                 if let Ok(instances) = crate::cognition::swe_bench::load_dataset(dataset).await {
                     if let Some(i) = instances.into_iter().find(|i| i.instance_id == name) {
                         resolved = Some(i);
@@ -1223,10 +1242,11 @@ pub(crate) async fn dispatch_staged_swe_solve(
             // Spawn AS the claimer when her runtime is live (she is joined to her
             // own workroom); the caller's handle is the fallback so a dispatch
             // fired before she is resident still names a real activity.
-            let spawner = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
-                .and_then(|reg| reg.get(claimer.as_uuid()))
-                .map(|rt| rt.airc().clone())
-                .unwrap_or_else(|| airc.clone()); // assignee runtime gone → curator's own handle spawns; probed below
+            let spawner =
+                crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+                    .and_then(|reg| reg.get(claimer.as_uuid()))
+                    .map(|rt| rt.airc().clone())
+                    .unwrap_or_else(|| airc.clone()); // assignee runtime gone → curator's own handle spawns; probed below
             let name = format!("swe--{}--{}", instance, short8(card_id.as_uuid()));
             let recipe = crate::experience::source::RecipeExperienceSource::shipped_purpose(
                 crate::experience::source::shipped::BENCHMARK_HARD_RS,
@@ -1267,7 +1287,10 @@ pub(crate) async fn dispatch_staged_swe_solve(
                         room_name: name.clone(),
                         assignee: claimer.as_uuid(),
                     };
-                    crate::cognition::bench_round::record_card_activity(card_id.as_uuid(), act.clone()); // clone: probe below still reads the local
+                    crate::cognition::bench_round::record_card_activity(
+                        card_id.as_uuid(),
+                        act.clone(),
+                    ); // clone: probe below still reads the local
                     crate::probe!(
                         class = "work.solve.room_minted",
                         card_id = %short8(card_id.as_uuid()),
@@ -1305,8 +1328,9 @@ pub(crate) async fn dispatch_staged_swe_solve(
     if !teammates.is_empty() {
         let team_room_name = format!("swe--{}--{}", instance, short8(card_id.as_uuid()));
         for mate in &teammates {
-            let Some(rt) = crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
-                .and_then(|reg| reg.get(mate.as_uuid()))
+            let Some(rt) =
+                crate::persona::airc_runtime_registry::PersonaAircRuntimeRegistry::try_global()
+                    .and_then(|reg| reg.get(mate.as_uuid()))
             else {
                 crate::probe!(
                     class = "work.team.join_skipped",
@@ -1596,13 +1620,25 @@ impl ActionCommand for WorkRelease {
         let card_id = resolve_card_id(&airc, &p.card_id).await?;
         let claim_id = resolve_claim_id(&airc, &p.claim_id).await?;
         let mut attempt = airc
-            .release_work_claim(ReleaseWorkClaim { card_id, claim_id, reason: p.reason.clone() })
+            .release_work_claim(ReleaseWorkClaim {
+                card_id,
+                claim_id,
+                reason: p.reason.clone(),
+            })
             .await;
-        if matches!(attempt, Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. }))
-            && follow_card_room(&airc, card_id, "work/release").await.is_some()
+        if matches!(
+            attempt,
+            Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. })
+        ) && follow_card_room(&airc, card_id, "work/release")
+            .await
+            .is_some()
         {
             attempt = airc
-                .release_work_claim(ReleaseWorkClaim { card_id, claim_id, reason: p.reason })
+                .release_work_claim(ReleaseWorkClaim {
+                    card_id,
+                    claim_id,
+                    reason: p.reason,
+                })
                 .await;
         }
         attempt.map_err(|e| CommandError::Internal(e.to_string()))?;
@@ -1724,12 +1760,22 @@ pub(crate) fn change_verdict(
 pub(crate) fn checkout_change(root: &std::path::Path) -> ChangeVerdict {
     use crate::system_resources::bounded_command::probe;
     let root_s = root.to_string_lossy().to_string();
-    let status = probe("git", &["-C", &root_s, "status", "--porcelain"], CHECKOUT_READ_BOUND);
+    let status = probe(
+        "git",
+        &["-C", &root_s, "status", "--porcelain"],
+        CHECKOUT_READ_BOUND,
+    );
     let Some(porcelain) = status.stdout_if_ok() else {
         return ChangeVerdict::CouldNotLook(format!("git status: {}", status.outcome()));
     };
-    let head = probe("git", &["-C", &root_s, "log", "-1", "--format=%ct"], CHECKOUT_READ_BOUND);
-    let head_ts = head.stdout_if_ok().and_then(|t| t.trim().parse::<u64>().ok());
+    let head = probe(
+        "git",
+        &["-C", &root_s, "log", "-1", "--format=%ct"],
+        CHECKOUT_READ_BOUND,
+    );
+    let head_ts = head
+        .stdout_if_ok()
+        .and_then(|t| t.trim().parse::<u64>().ok());
     let staged_ts = std::fs::metadata(root.join(".git"))
         .and_then(|m| m.modified())
         .ok()
@@ -1808,7 +1854,11 @@ pub(crate) async fn advance_card_state_effective(
             round::settle_review_card(card_id.as_uuid(), passed);
             raw_advance(airc, card_id, CardState::Closed, via).await?;
             let parent_id = WorkCardId::from_uuid(parent);
-            let next = if passed { CardState::Closed } else { CardState::InProgress };
+            let next = if passed {
+                CardState::Closed
+            } else {
+                CardState::InProgress
+            };
             crate::probe!(
                 class = "work.review.verdict",
                 review = %short8(card_id.as_uuid()),
@@ -1863,7 +1913,7 @@ async fn open_review_card(airc: &Arc<Airc>, parent: WorkCardId) -> Result<WorkCa
                 .and_then(|reg| reg.get(o.as_uuid()))
                 .map(|rt| rt.agent_name().to_string())
         })
-        .unwrap_or_else(|| "the owner".to_string());  // unwrap_or: owner not resident = a neutral name in the review body
+        .unwrap_or_else(|| "the owner".to_string()); // unwrap_or: owner not resident = a neutral name in the review body
     let title = crate::commands::benchmark::review_card_title(parent.as_uuid(), &instance, &owner);
     let p8 = parent.as_uuid().simple().to_string()[..8].to_string();
     let body = format!(
@@ -1886,7 +1936,10 @@ async fn open_review_card(airc: &Arc<Airc>, parent: WorkCardId) -> Result<WorkCa
     airc.join(&room.name).await.map_err(|e| e.to_string())?;
     let mut req = CreateWorkCard::new(card.repo.clone(), title, Priority::P1).reviewing(parent);
     req.body = Some(body);
-    let review = airc.create_work_card(req).await.map_err(|e| e.to_string())?;
+    let review = airc
+        .create_work_card(req)
+        .await
+        .map_err(|e| e.to_string())?;
     crate::cognition::bench_round::register_review_card(parent.as_uuid(), review.as_uuid())
         .ok_or_else(|| "parent left its round before the review was registered".to_string())?;
     Ok(review)
@@ -1902,8 +1955,12 @@ async fn raw_advance(
     let mut attempt = airc
         .change_work_card_state(ChangeWorkCardState { card_id, state })
         .await;
-    if matches!(attempt, Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. }))
-        && follow_card_room(airc, card_id, "work/state").await.is_some()
+    if matches!(
+        attempt,
+        Err(airc_lib::AircError::WorkCardNotInCurrentRoom { .. })
+    ) && follow_card_room(airc, card_id, "work/state")
+        .await
+        .is_some()
     {
         attempt = airc
             .change_work_card_state(ChangeWorkCardState { card_id, state })
@@ -1915,7 +1972,7 @@ async fn raw_advance(
     let room_id = room_holding_card(airc, card_id)
         .await
         .map(|r| r.channel.as_uuid().to_string())
-        .unwrap_or_default();  // unwrap_or: a card we cannot place carries an empty room on the bus
+        .unwrap_or_default(); // unwrap_or: a card we cannot place carries an empty room on the bus
     emit_card_state_changed(
         serde_json::json!({
             "card_id": card_id.as_uuid().to_string(),
@@ -2410,7 +2467,9 @@ pub struct WorkModule {
     /// composes OTHER commands — `data/list` to load a recipe row, `serving/pin`
     /// to re-home the lane — through the universal primitive instead of
     /// cross-module state threading. Installed by `install_executor_on_all`.
-    executor_slot: std::sync::Arc<crate::runtime::LateBound<crate::runtime::command_executor::CommandExecutor>>,
+    executor_slot: std::sync::Arc<
+        crate::runtime::LateBound<crate::runtime::command_executor::CommandExecutor>,
+    >,
 }
 
 impl WorkModule {
@@ -2543,7 +2602,10 @@ mod tests {
     #[test]
     fn one_transition_publishes_once_no_matter_which_feeder_sees_it_first() {
         let card = uuid::Uuid::new_v4().to_string();
-        assert!(first_transition_sighting(&card, "closed"), "first sighting publishes");
+        assert!(
+            first_transition_sighting(&card, "closed"),
+            "first sighting publishes"
+        );
         assert!(
             !first_transition_sighting(&card, "closed"),
             "the second feeder for the SAME transition must not publish again"
@@ -3095,10 +3157,25 @@ mod tests {
     // unreadable checkout is named, never assumed either way.
     #[test]
     fn a_done_without_a_write_is_no_change_and_an_unreadable_checkout_is_named() {
-        assert_eq!(change_verdict("", Some(100), Some(200)), ChangeVerdict::NoChange);
-        assert_eq!(change_verdict(" M a.py\n", Some(100), Some(200)), ChangeVerdict::Changed);
-        assert_eq!(change_verdict("", Some(300), Some(200)), ChangeVerdict::Changed);
-        assert!(matches!(change_verdict("", None, Some(200)), ChangeVerdict::CouldNotLook(_)));
-        assert!(matches!(change_verdict("", Some(1), None), ChangeVerdict::CouldNotLook(_)));
+        assert_eq!(
+            change_verdict("", Some(100), Some(200)),
+            ChangeVerdict::NoChange
+        );
+        assert_eq!(
+            change_verdict(" M a.py\n", Some(100), Some(200)),
+            ChangeVerdict::Changed
+        );
+        assert_eq!(
+            change_verdict("", Some(300), Some(200)),
+            ChangeVerdict::Changed
+        );
+        assert!(matches!(
+            change_verdict("", None, Some(200)),
+            ChangeVerdict::CouldNotLook(_)
+        ));
+        assert!(matches!(
+            change_verdict("", Some(1), None),
+            ChangeVerdict::CouldNotLook(_)
+        ));
     }
 }

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -118,7 +118,7 @@ pub trait AircCitizen:
     async fn subscribe_all_rooms(&self) -> Result<FilteredEventStream, AircError>;
 
     /// Watch receiver whose value increments whenever this citizen's room
-    /// membership GROWS at runtime (a join after spawn) — the perception
+    /// membership changes at runtime (a join or leave after spawn) — the perception
     /// stream's rebuild cue (P0 20b44763). airc-lib's
     /// `subscribe_subscribed_filtered` snapshots the subscribed-channel
     /// list ONCE at subscribe time, so a room joined later (benchmark
@@ -335,10 +335,7 @@ pub(crate) async fn room_name_by_id(room_id: Uuid) -> Option<String> {
     let runtimes: Vec<_> = reg.iter().collect();
     for rt in runtimes {
         if let Ok(set) = rt.airc().subscription_set().await {
-            if let Some(sub) = set
-                .all()
-                .find(|s| s.as_room().channel.as_uuid() == room_id)
-            {
+            if let Some(sub) = set.all().find(|s| s.as_room().channel.as_uuid() == room_id) {
                 return Some(sub.name.to_string());
             }
         }

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -153,7 +153,9 @@ fn signal_if_directed(own: uuid::Uuid, event: &airc_core::TranscriptEvent) {
     let mentioned = registry
         .as_ref()
         .and_then(|r| r.get(own))
-        .map(|rt| crate::persona::persona_identity::PersonaIdentity::new(own, rt.agent_name().to_string()))
+        .map(|rt| {
+            crate::persona::persona_identity::PersonaIdentity::new(own, rt.agent_name().to_string())
+        })
         .is_some_and(|me| me.mentions(&message.text));
     let sender_is_human = crate::ipc::positron_presence::is_human_peer(peer);
     if crate::cognition::workspace::TurnAttention::for_message(mentioned, sender_is_human)
@@ -167,7 +169,9 @@ fn signal_if_directed(own: uuid::Uuid, event: &airc_core::TranscriptEvent) {
 /// Message, a text body, wall time, the row id as the event id. Lamport is 0 —
 /// the loop head judges staleness by event id, never by this clock.
 fn event_from_row(room: Uuid, row: crate::persona::durable_history::RoomRow) -> TranscriptEvent {
-    use airc_core::{Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind};
+    use airc_core::{
+        Body, ClientId, EventId, Headers, MentionTarget, PeerId, RoomId, TranscriptKind,
+    };
     let room_id = RoomId::from_uuid(room);
     TranscriptEvent {
         event_id: EventId::from_uuid(row.id),
@@ -205,8 +209,12 @@ async fn catch_up_from_store(
         // THE CORE'S OWN CHAT STORE is the durable page (see
         // `durable_history::room_rows`): the daemon's ring page was empty for
         // the busiest room on every citizen (2026-09-04, `catch_up_rooms`).
-        let mut events = match crate::persona::durable_history::room_rows(room, CATCH_UP_PAGE).await {
-            Ok(rows) => rows.into_iter().map(|r| event_from_row(room, r)).collect::<Vec<_>>(),
+        let mut events = match crate::persona::durable_history::room_rows(room, CATCH_UP_PAGE).await
+        {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|r| event_from_row(room, r))
+                .collect::<Vec<_>>(),
             Err(error) => {
                 // Observable, not silent: on the first build 7 of ~68 rooms paged and
                 // the rest failed unseen, so eleven citizens never saw the operator.
@@ -225,7 +233,7 @@ async fn catch_up_from_store(
         };
         let floor_ms = *seen
             .lock()
-            .unwrap_or_else(|e| e.into_inner())  // poisoned lock = read the last state, same policy as every lock in this crate
+            .unwrap_or_else(|e| e.into_inner()) // poisoned lock = read the last state, same policy as every lock in this crate
             .floor_ms
             .entry(room)
             .or_insert(newest_ms);
@@ -242,12 +250,19 @@ async fn catch_up_from_store(
                     floor_ms,
                     newest_ms,
                     events.len(),
-                    e.peer_id.as_uuid().to_string().chars().take(8).collect::<String>(),
+                    e.peer_id
+                        .as_uuid()
+                        .to_string()
+                        .chars()
+                        .take(8)
+                        .collect::<String>(),
                     e.body
                         .as_ref()
                         .and_then(|b| b.as_text().map(|t| t.chars().take(60).collect::<String>()))
-                        .unwrap_or_else(|| "<non-text>".to_string()),  // unwrap_or: a non-text body renders as a marker, never dropped
-                    seen.lock().unwrap_or_else(|e| e.into_inner()).was_seen(room, e.event_id.as_uuid()),  // poisoned lock = read the last state, same policy as every lock in this crate
+                        .unwrap_or_else(|| "<non-text>".to_string()), // unwrap_or: a non-text body renders as a marker, never dropped
+                    seen.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .was_seen(room, e.event_id.as_uuid()), // poisoned lock = read the last state, same policy as every lock in this crate
                 )
             });
         }
@@ -266,7 +281,7 @@ async fn catch_up_from_store(
                 .ok()
                 .map(|(peer, text)| SeenRooms::fingerprint(peer, &text));
             {
-                let mut s = seen.lock().unwrap_or_else(|e| e.into_inner());  // poisoned lock = read the last state, same policy as every lock in this crate
+                let mut s = seen.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
                 if let Some(fp) = fingerprint {
                     if s.was_seen_text(room, fp) {
                         continue;
@@ -320,6 +335,13 @@ async fn catch_up_from_store(
 
 pub struct AircPersonaConversation {
     runtime: Arc<dyn AircCitizen>,
+    /// The subscription snapshot owned by this conversation. `None` is
+    /// unprimed; an empty set is primed but parked until the next membership
+    /// epoch. Neither state may implicitly join a default room.
+    rooms: Option<Vec<Uuid>>,
+    /// A consumed epoch whose async reattach has not finished. `next_message`
+    /// is cancellation-safe: a competing service-loop wake cannot lose it.
+    refresh_pending: bool,
     /// The persona's own peer_id, captured at construction. Used by
     /// `next_message` to skip self-loop echoes WITHIN the projection
     /// — the service loop ALSO skips by persona's instance peer_id;
@@ -345,7 +367,9 @@ pub struct AircPersonaConversation {
     /// every boot, 12 citizens heard for ~2 min, then the first turns started,
     /// nobody polled for minutes, the daemon's queue filled, the subscriber was
     /// marked lagged and never recovered — the live plane looked dead).
-    inbox: Option<tokio::sync::mpsc::Receiver<Result<std::sync::Arc<TranscriptEvent>, airc_lib::LiveLag>>>,
+    inbox: Option<
+        tokio::sync::mpsc::Receiver<Result<std::sync::Arc<TranscriptEvent>, airc_lib::LiveLag>>,
+    >,
     /// The drain task behind `inbox`; aborted and replaced on every re-open.
     pump: Option<tokio::task::JoinHandle<()>>,
     /// Per-room floors and seen rings, SHARED across pump restarts. A pump
@@ -391,6 +415,8 @@ impl AircPersonaConversation {
         let membership_epoch = runtime.membership_epoch();
         Self {
             runtime,
+            rooms: None,
+            refresh_pending: false,
             own_peer_id,
             inbox: None,
             pump: None,
@@ -410,14 +436,69 @@ impl AircPersonaConversation {
         &self.runtime
     }
 
+    fn stop_stream(&mut self) {
+        if let Some(old) = self.pump.take() {
+            old.abort();
+        }
+        self.inbox = None;
+    }
+
+    /// Rebind the existing perception owner to its durable room set. The SDK's
+    /// empty-set subscribe falls back to general, so an empty membership parks
+    /// here instead. The existing epoch is also how this state resumes.
+    async fn refresh_membership(&mut self) -> Result<bool, String> {
+        let rooms = self
+            .runtime
+            .subscribed_rooms()
+            .await
+            .map_err(|e| format!("subscription set read failed: {e}"))?;
+        let active = !rooms.is_empty();
+        if active {
+            let stream = self
+                .runtime
+                .subscribe_all_rooms()
+                .await
+                .map_err(|e| format!("subscribe failed: {e}"))?;
+            self.install_stream(stream);
+        } else {
+            self.stop_stream();
+            crate::probe!(
+                class = "persona.inbound.no_rooms",
+                persona = %self.own_peer_id,
+                "no subscribed rooms — perception waits for a membership change"
+            );
+        }
+        self.rejoin_backlog
+            .retain(|message| rooms.contains(&message.room_id));
+        self.rooms = Some(rooms);
+        Ok(active)
+    }
+
+    /// Page the actual subscription snapshot, never a lazy default-room read.
+    /// This also keeps a no-focus subscription from replaying another room.
+    async fn page_subscribed_rooms(&self, limit: usize) -> Result<Vec<TranscriptEvent>, String> {
+        let rooms = self
+            .rooms
+            .as_ref()
+            .ok_or_else(|| "conversation history requested before prime()".to_string())?;
+        let mut events = Vec::new();
+        for room in rooms {
+            events.extend(
+                self.runtime
+                    .page_recent_in(Some(airc_core::RoomId::from_uuid(*room)), limit)
+                    .await
+                    .map_err(|e| format!("page room {room} failed: {e}"))?,
+            );
+        }
+        Ok(events)
+    }
+
     /// Install a fresh daemon stream behind the PUMP: a task that drains it
     /// continuously into a bounded in-process inbox. Backpressure, if any, lands
     /// here (in-process, where a turn in progress is the only slow consumer) and
     /// never at the daemon, whose lag policy drops live pushes for good.
     fn install_stream(&mut self, mut stream: FilteredEventStream) {
-        if let Some(old) = self.pump.take() {
-            old.abort();
-        }
+        self.stop_stream();
         let (tx, rx) = tokio::sync::mpsc::channel(INBOX_CAPACITY);
         let persona = self.own_peer_id;
         let runtime = Arc::clone(&self.runtime);
@@ -607,14 +688,12 @@ impl PersonaConversation for AircPersonaConversation {
     /// has identical semantics — it's not a degraded path, it's a
     /// later-binding path.
     async fn prime(&mut self) -> Result<(), String> {
-        if self.inbox.is_some() {
+        if self.rooms.is_some() {
             return Ok(());
         }
-        let stream = self
-            .runtime
-            .subscribe_all_rooms()
-            .await
-            .map_err(|e| format!("subscribe failed: {e}"))?;
+        if !self.refresh_membership().await? {
+            return Ok(());
+        }
         // #146 diagnostic: confirm the CHAT subscribe stream actually opened for
         // this persona. Post-reboot the personas were room-deaf (0 perceptual
         // decodes) while the core-positron raw-attach path received fine — this
@@ -624,21 +703,16 @@ impl PersonaConversation for AircPersonaConversation {
             persona = %self.own_peer_id,
             "persona chat subscribe stream opened (#146)"
         );
-        self.install_stream(stream);
         // Seed the rejoin-replay watermark at the CURRENT transcript head, so the
         // first runtime room-join can never replay pre-subscribe history as fresh
         // perception (the #131 "room starts at join" rule, preserved under replay).
-        self.last_lamport = self.high_water_mark(64).await.unwrap_or(0);  // unwrap_or: an unreadable watermark = 0 (never read), the documented floor
+        self.last_lamport = self.high_water_mark(64).await.unwrap_or(0); // unwrap_or: an unreadable watermark = 0 (never read), the documented floor
         Ok(())
     }
 
     async fn high_water_mark(&self, limit: usize) -> Result<u64, String> {
-        let events = self
-            .runtime
-            .page_recent(limit)
-            .await
-            .map_err(|e| format!("page_recent failed: {e}"))?;
-        Ok(events.iter().map(|e| e.lamport).max().unwrap_or(0))  // unwrap_or: an empty page has no lamport; 0 = never read
+        let events = self.page_subscribed_rooms(limit).await?;
+        Ok(events.iter().map(|e| e.lamport).max().unwrap_or(0)) // unwrap_or: an empty page has no lamport; 0 = never read
     }
 
     async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
@@ -657,7 +731,7 @@ impl PersonaConversation for AircPersonaConversation {
         // visibly — never silently lazy-subscribes (PR #1514 reviewer
         // fix: the soft-language lazy fallback was a silent-degradation
         // shape we refuse).
-        if self.inbox.is_none() {
+        if self.rooms.is_none() {
             return Err(
                 "AircPersonaConversation::next_message called before prime() — caller must \
                  invoke prime() before iterating (serve_persona_loop does this automatically \
@@ -675,8 +749,10 @@ impl PersonaConversation for AircPersonaConversation {
             // Rejoin-replayed turns first — they are OLDER than anything the live
             // stream will yield, and ordering is what keeps an addressed kickoff
             // ahead of the chatter that follows it.
-            if let Some(replayed) = self.rejoin_backlog.pop_front() {
-                return Ok(Some(replayed));
+            if !self.refresh_pending && !self.membership_epoch.has_changed().unwrap_or(false) {
+                if let Some(replayed) = self.rejoin_backlog.pop_front() {
+                    return Ok(Some(replayed));
+                }
             }
             // Wait on EITHER the next event OR a membership-epoch move. The
             // epoch branch is the P0 20b44763 fix: a room joined at runtime
@@ -686,19 +762,25 @@ impl PersonaConversation for AircPersonaConversation {
             // default `membership_epoch` drops its sender) parks on
             // `pending()` — closed means "membership never changes", never
             // an event, or stubs would busy-loop on `changed() == Err`.
-            let polled = {
-                let inbox = self
-                    .inbox
-                    .as_mut()
-                    .expect("inbox checked Some at next_message entry");
+            let polled = if self.refresh_pending {
+                Polled::Membership
+            } else {
+                let active = self.inbox.is_some();
+                let inbox = &mut self.inbox;
                 let epoch = &mut self.membership_epoch;
                 tokio::select! {
-                    ev = inbox.recv() => Polled::Event(ev),
+                    biased;
                     _ = async {
                         if epoch.changed().await.is_err() {
                             std::future::pending::<()>().await;
                         }
                     } => Polled::Membership,
+                    ev = async {
+                        match inbox.as_mut() {
+                            Some(inbox) => inbox.recv().await,
+                            None => std::future::pending().await,
+                        }
+                    } => Polled::Event(ev),
                     // QUIET WATCHDOG (2026-09-04): live streams went silent ~2 min after
                     // prime — 12 citizens received 172 events in the first two minutes,
                     // 2 citizens 5 events in the next two, and an operator line at +12 min
@@ -707,37 +789,37 @@ impl PersonaConversation for AircPersonaConversation {
                     // delivers. So: when nothing has arrived for a window, ask the durable
                     // store whether the room moved on; if it did, the stream is dead —
                     // re-open it and replay the gap, exactly as a membership change does.
-                    _ = tokio::time::sleep_until(self.next_catch_up) => Polled::Quiet,
+                    _ = tokio::time::sleep_until(self.next_catch_up), if active => Polled::Quiet,
                 }
             };
             let reason: &'static str = match polled {
-                Polled::Event(ev) => {
-                    match ev {
-                        None => {
-                            crate::probe!(
-                    class = "persona.inbound.stream_ended",
-                                persona = %self.own_peer_id,
-                                "airc subscribe stream ended unrecoverably — airc-lib dropped \
-                                 the subscription (likely wire-schema drift between continuum \
-                                 and airc builds, or the EventStream was released). NOT \
-                                 auto-resubscribing: airc-lib owns transient reconnection, so \
-                                 a terminal end here is a real fault to fix, not a hiccup to heal."
-                            );
-                            return Ok(None);
-                        }
-                        Some(Err(lag)) => {
-                            return Err(format!("live stream lag: {lag}"));
-                        }
-                        Some(Ok(event)) => {
-                            if let Some(msg) = self.admit_event(event).await {
-                                return Ok(Some(msg));
-                            }
-                            continue;
-                        }
+                Polled::Event(ev) => match ev {
+                    None => {
+                        crate::probe!(
+                        class = "persona.inbound.stream_ended",
+                                    persona = %self.own_peer_id,
+                                    "airc subscribe stream ended unrecoverably — airc-lib dropped \
+                                     the subscription (likely wire-schema drift between continuum \
+                                     and airc builds, or the EventStream was released). NOT \
+                                     auto-resubscribing: airc-lib owns transient reconnection, so \
+                                     a terminal end here is a real fault to fix, not a hiccup to heal."
+                                );
+                        return Ok(None);
                     }
+                    Some(Err(lag)) => {
+                        return Err(format!("live stream lag: {lag}"));
+                    }
+                    Some(Ok(event)) => {
+                        if let Some(msg) = self.admit_event(event).await {
+                            return Ok(Some(msg));
+                        }
+                        continue;
+                    }
+                },
+                Polled::Membership => {
+                    self.refresh_pending = true;
+                    "room membership changed at runtime — refreshing the subscription snapshot"
                 }
-                Polled::Membership => "room membership changed at runtime — re-opening the subscribe \
-                     stream with the enlarged channel snapshot (P0 20b44763)",
                 Polled::Quiet => {
                     // The pump owns the store catch-up on its own clock; the loop's
                     // deadline is only a wake so a long idle never blocks the backlog.
@@ -748,18 +830,16 @@ impl PersonaConversation for AircPersonaConversation {
                 }
             };
             {
+                if !self.refresh_membership().await? {
+                    self.refresh_pending = false;
+                    continue;
+                }
                 crate::probe!(
                     class = "persona.inbound.resubscribed",
                     persona = %self.own_peer_id,
                     reason = reason,
                     "re-opening the subscribe stream"
                 );
-                let stream = self
-                    .runtime
-                    .subscribe_all_rooms()
-                    .await
-                    .map_err(|e| format!("resubscribe after membership change failed: {e}"))?;
-                self.install_stream(stream);
                 // REPLAY THE GAP (2026-08-21, the FOURTH deaf-kickoff variant). The
                 // reopened stream is live-tail: anything published between the
                 // membership change and this reopen was delivered to nobody — and
@@ -770,7 +850,7 @@ impl PersonaConversation for AircPersonaConversation {
                 // strictly newer than the watermark; the same decode + self-skip
                 // rules as the live path apply, and the work-event bridge dedups
                 // by event id, so a replayed card event cannot double-fire.
-                match self.runtime.page_recent(32).await {
+                match self.page_subscribed_rooms(32).await {
                     Ok(events) => {
                         let scanned = events.len();
                         let mut replayed = 0usize;
@@ -782,16 +862,16 @@ impl PersonaConversation for AircPersonaConversation {
                             {
                                 continue;
                             }
-                            self.last_lamport = event.lamport;
                             crate::modules::work::bridge_wire_work_event(event).await;
-                            let Ok(message) = perceptual_from_event(event) else {
-                                continue;
-                            };
-                            if message.peer_id == self.own_peer_id {
-                                continue;
+                            if let Ok(message) = perceptual_from_event(event) {
+                                if message.peer_id != self.own_peer_id {
+                                    replayed += 1;
+                                    self.rejoin_backlog.push_back(message);
+                                }
                             }
-                            replayed += 1;
-                            self.rejoin_backlog.push_back(message);
+                            // Commit only after the async bridge and queue write;
+                            // cancellation must not skip an unqueued receipt.
+                            self.last_lamport = event.lamport;
                         }
                         crate::probe!(
                             class = "persona.inbound.rejoin_replayed",
@@ -799,19 +879,19 @@ impl PersonaConversation for AircPersonaConversation {
                             scanned,
                             replayed,
                             watermark = self.last_lamport,
-                            "membership-change reopen replayed the gap — room turns \
-                             published between join and reopen are now perceivable \
-                             instead of live-tail-lost"
+                            "membership refresh paged subscribed rooms and queued turns \
+                             admitted by the existing replay watermark"
                         );
                     }
                     Err(e) => crate::probe!(
-            class = "persona.inbound.rejoin_page_failed",
-                        persona = %self.own_peer_id,
-                        error = %e,
-                        "rejoin replay page failed — events published between join \
-                         and reopen stay unheard until something else surfaces them"
-                    ),
+                    class = "persona.inbound.rejoin_page_failed",
+                                persona = %self.own_peer_id,
+                                error = %e,
+                                "rejoin replay page failed — events published between join \
+                                 and reopen stay unheard until something else surfaces them"
+                            ),
                 }
+                self.refresh_pending = false;
                 continue;
             };
         }
@@ -882,6 +962,287 @@ fn perceptual_from_event(event: &TranscriptEvent) -> Result<IncomingMessage, &'s
 
 #[cfg(test)]
 mod tests {
+    /// what this catches: e0d64552 — the actual membership commands persisted
+    /// their changes but bypassed the epoch that refreshes a living stream.
+    /// This uses an isolated real scope, not a mocked membership notification.
+    #[tokio::test]
+    async fn membership_commands_refresh_the_callers_runtime_without_moving_focus() {
+        use crate::modules::room::{RoomJoin, RoomJoinParams, RoomLeave, RoomLeaveParams};
+        use crate::persona::airc_citizen::AircCitizen;
+        use crate::persona::identity_provider::PersonaIdentitySource;
+        use crate::persona::PersonaAircRuntime;
+        use crate::persona::PersonaAircRuntimeRegistry;
+        use crate::routing::CallerIdentity;
+        use crate::sdk_codegen::{ActionCommand, CommandError, Ctx};
+        use airc_core::PeerId;
+
+        let home = tempfile::tempdir().expect("isolated airc home and wire root");
+        let airc = Arc::new(
+            airc_lib::Airc::open_with_wire_root_for_test(home.path(), home.path())
+                .await
+                .expect("open without the installed daemon or account wire"),
+        );
+        let academy = airc.join("academy").await.expect("initial focus");
+        let registry = PersonaAircRuntimeRegistry::new();
+        let runtime = registry.register(PersonaAircRuntime::from_attached(
+            airc.peer_id().as_uuid(),
+            "membership-test",
+            home.path().to_path_buf(),
+            airc.clone(),
+            academy.channel,
+            PersonaIdentitySource::FreshlyMinted,
+        ));
+        let ctx = Ctx {
+            caller: Some(CallerIdentity::local_persona(airc.peer_id())),
+            ..Default::default()
+        };
+        let join = RoomJoin {
+            registry: registry.clone(),
+        };
+        let leave = RoomLeave { registry };
+        // The live conversation takes this receiver before subscribing. A raw
+        // Airc mutation below would pass the durable assertions but fail this one.
+        let mut epoch = runtime.membership_epoch();
+        let mut conversation = AircPersonaConversation::new(runtime.clone());
+        conversation
+            .prime()
+            .await
+            .expect("prime before the membership command");
+        let joined = join
+            .run(
+                &ctx,
+                RoomJoinParams {
+                    room: "widgets".into(),
+                },
+            )
+            .await
+            .expect("join through the authenticated command");
+        assert!(epoch.has_changed().expect("runtime still owns the sender"));
+        epoch.borrow_and_update();
+        assert!(
+            !joined.is_default,
+            "joining must not move the existing focus"
+        );
+        let membership = airc.subscription_set().await.expect("joined subscriptions");
+        assert!(membership
+            .all()
+            .any(|s| s.room_id.as_uuid().to_string() == joined.room_id));
+        assert_eq!(
+            membership.default_subscription().expect("default").room_id,
+            academy.channel
+        );
+
+        // The command updates the same durable identity used after a restart.
+        let reopened = airc_lib::Airc::open_with_wire_root_for_test(home.path(), home.path())
+            .await
+            .expect("reopen the same isolated scope");
+        assert_eq!(reopened.peer_id(), airc.peer_id());
+        assert_eq!(
+            reopened
+                .subscription_set()
+                .await
+                .expect("persisted membership"),
+            membership
+        );
+        drop(reopened);
+
+        join.run(
+            &ctx,
+            RoomJoinParams {
+                room: "widgets".into(),
+            },
+        )
+        .await
+        .expect("repeated join is membership-idempotent");
+        assert_eq!(
+            airc.subscription_set().await.expect("same rooms"),
+            membership
+        );
+        // Preserve the existing runtime contract: a successful repeat refreshes
+        // the snapshot too, without duplicating membership or changing focus.
+        assert!(epoch.has_changed().expect("sender alive"));
+        epoch.borrow_and_update();
+
+        for invalid in [" ".to_string(), uuid::Uuid::new_v4().to_string()] {
+            assert!(join
+                .run(&ctx, RoomJoinParams { room: invalid })
+                .await
+                .is_err());
+            assert!(!epoch.has_changed().expect("sender alive"));
+            assert_eq!(
+                airc.subscription_set().await.expect("unchanged membership"),
+                membership
+            );
+        }
+        let unknown = Ctx {
+            caller: Some(CallerIdentity::local_persona(PeerId::new())),
+            ..Default::default()
+        };
+        assert!(matches!(
+            join.run(
+                &unknown,
+                RoomJoinParams {
+                    room: "unrelated".into()
+                }
+            )
+            .await,
+            Err(CommandError::NotFound(_))
+        ));
+        assert!(matches!(
+            leave
+                .run(
+                    &unknown,
+                    RoomLeaveParams {
+                        room: Some("widgets".into())
+                    }
+                )
+                .await,
+            Err(CommandError::NotFound(_))
+        ));
+        assert!(!epoch
+            .has_changed()
+            .expect("an unknown caller cannot mutate this runtime"));
+        assert_eq!(
+            airc.subscription_set()
+                .await
+                .expect("same caller membership"),
+            membership
+        );
+
+        let parted = leave
+            .run(
+                &ctx,
+                RoomLeaveParams {
+                    room: Some("widgets".into()),
+                },
+            )
+            .await
+            .expect("leave through the authenticated command");
+        assert_eq!(parted.room_id, joined.room_id);
+        assert_eq!(parted.remaining, 1);
+        assert!(epoch
+            .has_changed()
+            .expect("part refreshes the live snapshot"));
+        epoch.borrow_and_update();
+        let remaining = airc.subscription_set().await.expect("parted subscriptions");
+        assert!(!remaining
+            .all()
+            .any(|s| s.room_id.as_uuid().to_string() == joined.room_id));
+        assert_eq!(
+            remaining.default_subscription().expect("default").room_id,
+            academy.channel
+        );
+        assert!(leave
+            .run(
+                &ctx,
+                RoomLeaveParams {
+                    room: Some("widgets".into())
+                }
+            )
+            .await
+            .is_err());
+        assert!(!epoch
+            .has_changed()
+            .expect("a rejected repeat must not signal a change"));
+        assert_eq!(
+            airc.subscription_set()
+                .await
+                .expect("unchanged after refusal"),
+            remaining
+        );
+
+        let parted_default = leave
+            .run(&ctx, RoomLeaveParams::default())
+            .await
+            .expect("unnamed leave targets the existing default");
+        assert_eq!(
+            parted_default.room_id,
+            academy.channel.as_uuid().to_string()
+        );
+        assert_eq!(parted_default.remaining, 0);
+        assert!(epoch
+            .has_changed()
+            .expect("leaving the default also refreshes"));
+        let empty = airc.subscription_set().await.expect("no rooms remain");
+        assert!(empty.default_subscription().is_none());
+        assert_eq!(empty.all().count(), 0);
+
+        // Drive the ACTUAL epoch consumer. Before the fix this reattached with
+        // the SDK's empty-set general fallback, then default-room replay durably
+        // rejoined general. Asserting the snapshot and released pump proves the
+        // epoch was processed, rather than merely timing out before the branch.
+        let wait = std::time::Duration::from_secs(1);
+        assert!(tokio::time::timeout(wait, conversation.next_message())
+            .await
+            .is_err());
+        assert_eq!(conversation.rooms.as_deref(), Some(&[][..]));
+        assert!(conversation.pump.is_none() && conversation.inbox.is_none());
+        assert_eq!(
+            airc.subscription_set().await.expect("parked membership"),
+            empty
+        );
+        assert_eq!(
+            conversation
+                .high_water_mark(32)
+                .await
+                .expect("empty history"),
+            0
+        );
+
+        let mut started_empty = AircPersonaConversation::new(runtime.clone());
+        started_empty
+            .prime()
+            .await
+            .expect("priming an empty citizen parks");
+        assert_eq!(started_empty.rooms.as_deref(), Some(&[][..]));
+        assert!(started_empty.pump.is_none() && started_empty.inbox.is_none());
+        assert_eq!(
+            airc.subscription_set().await.expect("empty after prime"),
+            empty
+        );
+
+        let rejoined = join
+            .run(
+                &ctx,
+                RoomJoinParams {
+                    room: "widgets".into(),
+                },
+            )
+            .await
+            .expect("a later join resumes the same living conversation");
+        assert!(tokio::time::timeout(wait, conversation.next_message())
+            .await
+            .is_err());
+        let resumed = uuid::Uuid::parse_str(&rejoined.room_id).expect("room receipt UUID");
+        assert_eq!(conversation.rooms.as_deref(), Some(&[resumed][..]));
+        assert!(conversation.pump.is_some() && conversation.inbox.is_some());
+        assert_eq!(
+            airc.subscription_set()
+                .await
+                .expect("resumed membership")
+                .all()
+                .count(),
+            1
+        );
+
+        leave
+            .run(&ctx, RoomLeaveParams::default())
+            .await
+            .expect("finish parked");
+        assert!(tokio::time::timeout(wait, conversation.next_message())
+            .await
+            .is_err());
+        assert!(conversation.pump.is_none() && conversation.inbox.is_none());
+        assert_eq!(
+            airc.subscription_set()
+                .await
+                .expect("final empty membership")
+                .all()
+                .count(),
+            0
+        );
+    }
+
     use super::*;
 
     // what this catches: the dead-live-stream detector. The first tick after an
@@ -891,11 +1252,20 @@ mod tests {
     // is healthy. usize::MAX is the inbox-gone sentinel, never a count.
     #[test]
     fn the_live_stream_is_dead_only_when_the_store_delivers_and_the_stream_did_not() {
-        assert!(!live_stream_missed(0, 5, true), "first tick admits the backlog");
-        assert!(live_stream_missed(0, 5, false), "store delivered, stream silent");
+        assert!(
+            !live_stream_missed(0, 5, true),
+            "first tick admits the backlog"
+        );
+        assert!(
+            live_stream_missed(0, 5, false),
+            "store delivered, stream silent"
+        );
         assert!(!live_stream_missed(3, 5, false), "live frames flowed");
         assert!(!live_stream_missed(0, 0, false), "nothing to deliver");
-        assert!(!live_stream_missed(0, usize::MAX, false), "inbox gone is not a count");
+        assert!(
+            !live_stream_missed(0, usize::MAX, false),
+            "inbox gone is not a count"
+        );
     }
     use crate::persona::airc_citizen::StubAircCitizen;
 
@@ -1025,7 +1395,10 @@ mod tests {
         fn heartbeat_is_dropped_at_the_door_and_a_say_is_not() {
             let peer = PeerId::from_u128(42);
             let mut headers = Headers::new();
-            headers.insert(airc_lib::HEADER_HEARTBEAT_KIND.to_string(), "alive".to_string());
+            headers.insert(
+                airc_lib::HEADER_HEARTBEAT_KIND.to_string(),
+                "alive".to_string(),
+            );
             let beat = event(peer, Some(Body::text("{\"kind\":\"alive\"}")), headers);
             assert!(crate::persona::airc_citizen::is_heartbeat(&beat));
             let say = event(peer, Some(Body::text("hello from a peer")), Headers::new());
@@ -1133,32 +1506,19 @@ mod tests {
 }
 
 impl AircPersonaConversation {
-    /// The newest lamport across every room she subscribes to (two events per
-    /// room — a tip read, not a page). Falls back to the home room when the
-    /// runtime lists none. A failed read counts as "not moved".
+    /// The newest lamport across the current subscription snapshot (two events
+    /// per room). An empty snapshot has no tip; a failed read counts as not moved.
     async fn rooms_high_water_mark(&self) -> u64 {
-        let rooms = self.runtime.subscribed_rooms().await.unwrap_or_default(); // unwrap_or: an unreadable room list falls back to the home read below
-        if rooms.is_empty() {
-            return self.high_water_mark(32).await.unwrap_or(self.last_lamport); // unwrap_or: a failed page reads as not moved
-        }
-        let mut hwm = 0u64;
-        for room in rooms {
-            if let Ok(events) = self
-                .runtime
-                .page_recent_in(Some(airc_core::RoomId::from_uuid(room)), 2)
-                .await
-            {
-                hwm = hwm.max(events.iter().map(|e| e.lamport).max().unwrap_or(0)); // unwrap_or: an empty room has no tip
-            }
-        }
-        hwm
+        self.high_water_mark(2).await.unwrap_or(self.last_lamport) // unwrap_or: a failed page reads as not moved
     }
 
     /// One live event through the door: heartbeat/chunk guards, the raw probe,
     /// the work-bridge, the decoder, the self-filter, the lamport advance.
     /// `Some(msg)` = a room turn to serve; `None` = consumed, keep polling.
-    async fn admit_event(&mut self, event: std::sync::Arc<TranscriptEvent>) -> Option<IncomingMessage> {
-
+    async fn admit_event(
+        &mut self,
+        event: std::sync::Arc<TranscriptEvent>,
+    ) -> Option<IncomingMessage> {
         // Presence heartbeats are dropped HERE, not at subscribe time — the
         // daemon inverted the subscribe-time filter (see `subscribe_every_room`),
         // and a receive-side check is correct either way. Before any decode/probe.

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -361,20 +361,11 @@ impl PersonaAircRuntime {
         // Slice 4 of #142: symmetric citizens/<kind>/<label>/airc/
         // layout. Use the shared helper so every actor kind shares
         // the same path schema.
-        let home = crate::context::citizen_home_path(
-            continuum_root,
-            kind,
-            provider,
-            &agent_name,
-        );
+        let home = crate::context::citizen_home_path(continuum_root, kind, provider, &agent_name);
 
         // Migration: refuse to use the pre-Slice-4 layout. Hard-error
         // with the exact `mv` command per [[no-fallbacks-ever]].
-        if let Some(legacy) = crate::context::legacy_home_path(
-            continuum_root,
-            kind,
-            &agent_name,
-        ) {
+        if let Some(legacy) = crate::context::legacy_home_path(continuum_root, kind, &agent_name) {
             if tokio::fs::try_exists(&legacy).await.unwrap_or(false) {
                 let new_parent = home
                     .parent()
@@ -755,7 +746,7 @@ impl PersonaAircRuntime {
                         let now_ms = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .map(|d| d.as_millis() as u64)
-                            .unwrap_or_default();  // unwrap_or: nothing recorded / a pre-epoch clock = 0, never a guess
+                            .unwrap_or_default(); // unwrap_or: nothing recorded / a pre-epoch clock = 0, never a guess
                         let idle = crate::persona::cognition_pulse::idle_ms(hb_persona, now_ms);
                         if !crate::persona::cognition_pulse::renewal_earned(
                             idle,
@@ -803,7 +794,7 @@ impl PersonaAircRuntime {
                         let now_ms = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .map(|d| d.as_millis() as u64)
-                            .unwrap_or_default();  // unwrap_or: nothing recorded / a pre-epoch clock = 0, never a guess
+                            .unwrap_or_default(); // unwrap_or: nothing recorded / a pre-epoch clock = 0, never a guess
                         if let Ok(board) = hb_airc
                             .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
                             .await
@@ -814,7 +805,8 @@ impl PersonaAircRuntime {
                             // card, a lapsed one is left for the deck (2026-09-05: a
                             // citizen ended up on two).
                             let holds_live = snapshot.cards.iter().any(|c| {
-                                c.owner == Some(me) && c.claim_expires_at_ms.is_some_and(|e| e > now_ms)
+                                c.owner == Some(me)
+                                    && c.claim_expires_at_ms.is_some_and(|e| e > now_ms)
                             });
                             for card in snapshot.cards.iter().filter(|c| {
                                 !holds_live
@@ -864,7 +856,7 @@ impl PersonaAircRuntime {
                                 .into_iter()
                                 .find(|r| r.peer == me)
                                 .map(|r| r.active_claims)
-                                .unwrap_or_default();  // unwrap_or: a pre-epoch clock reads 0, as every other now_ms here
+                                .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0, as every other now_ms here
                             let mut renewed = 0usize;
                             let mut failed = 0usize;
                             for card in &mine {
@@ -983,7 +975,7 @@ impl PersonaAircRuntime {
                     .into_iter()
                     .find(|r| r.peer == me)
                     .map(|r| r.active_claims)
-                    .unwrap_or_default();  // unwrap_or: nothing recorded = empty, the probe says so
+                    .unwrap_or_default(); // unwrap_or: nothing recorded = empty, the probe says so
                 let mut repos: Vec<airc_lib::RepoId> =
                     claims.iter().map(|c| c.repo.clone()).collect();
                 repos.sort();
@@ -1072,10 +1064,18 @@ impl PersonaAircRuntime {
     /// Bumps the same membership epoch as `join_room`, because a subscription
     /// change is a membership change however the focus lands — routing that off
     /// this epoch must not care which verb moved it.
-    pub async fn subscribe_room(&self, name: &str) -> Result<(), AircError> {
-        self.airc.subscribe_room(name).await?;
+    pub async fn subscribe_room(&self, name: &str) -> Result<airc_lib::Room, AircError> {
+        let room = self.airc.subscribe_room(name).await?;
         self.membership_epoch.send_modify(|e| *e += 1);
-        Ok(())
+        Ok(room)
+    }
+
+    /// Leave a room and refresh the same live subscription snapshot as joining.
+    /// A rejected part (including an already-parted room) leaves the epoch alone.
+    pub async fn leave_room(&self, name: Option<&str>) -> Result<airc_lib::Room, AircError> {
+        let room = self.airc.part_channel(name).await?;
+        self.membership_epoch.send_modify(|e| *e += 1);
+        Ok(room)
     }
 
     /// Wrap an already-attached + already-joined `Arc<Airc>` into a

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -147,7 +147,7 @@ pub async fn ensure_operator_peer(
             }
             for channel in project_bases.iter() {
                 match rt.subscribe_room(channel.as_str()).await {
-                    Ok(()) => crate::probe!(
+                    Ok(_) => crate::probe!(
                         class = "operator.peer.project_base_subscribed",
                         room = %channel.as_str(),
                         "operator self-peer subscribed the project base room (the org room from the git remote)"


### PR DESCRIPTION
A Persona could successfully join or leave a room while its already-running conversation kept the old subscription snapshot. Membership commands now operate through the authenticated caller's existing runtime and notify that conversation through its membership epoch. Focus stays unchanged; leaving the last room parks input cleanly and a later join resumes it.

The existing conversation owner handles refresh, per-room catch-up, deduplication and cancellation. Refresh intent survives cancelled waits, and an empty membership never implicitly joins or reads the default room. The regression uses the actual room commands and AIRC fixture, including cross-room work-card reads.

Validation: 48 selected native Windows tests passed, including membership, work/get and source-hygiene regressions. Library/tests Clippy completed successfully; it still reports the repository's existing warning backlog, so this is not a strict-warning-clean claim. The six touched Rust files were formatted after validation. Independently reviewed by S6 and the conversation reviewer, followed by root review.

Scope: the existing scalar Lamport catch-up watermark remains separate work (a97f2682); this PR does not claim lossless replay across independent publishers. No live AIRC daemon or identity changes.
