### PR TITLE
fix(disk): the cargo-target budget is DERIVED from the volume, and thrash stops being silent (#3906)

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1461,8 +1461,10 @@ pub fn start_server(
         // AND THE BUDGET IS DERIVED FROM THE VOLUME, not a constant (#3906). A fixed
         // 50 GiB sat BELOW this workspace's debug tree on a workstation, so the pool was
         // permanently over budget and evicted every ~13 minutes all day: 36 evictions and
-        // 356 GB of compilation destroyed in one measured day, which is why every build on
-        // that box started cold. `cargo-target-wt` is a build cache for the SAME workspace
+        // 356 GB of compilation destroyed in one measured day, at a cadence no build
+        // could outlive. (That is the measured FREQUENCY; this pool never observes
+        // whether a given build reused the cache, and the warning says so.)
+        // `cargo-target-wt` is a build cache for the SAME workspace
         // and was already at 87 GB, so giving it the flat constant would have reproduced
         // the defect on a second cache the day it was registered. A volume we cannot
         // resolve keeps the floor — never a guess, never zero.

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1461,9 +1461,9 @@ pub fn start_server(
         // AND THE BUDGET IS DERIVED FROM THE VOLUME, not a constant (#3906). A fixed
         // 50 GiB sat BELOW this workspace's debug tree on a workstation, so the pool was
         // permanently over budget and evicted every ~13 minutes all day: 36 evictions and
-        // 356 GB of compilation destroyed in one measured day, at a cadence no build
-        // could outlive. (That is the measured FREQUENCY; this pool never observes
-        // whether a given build reused the cache, and the warning says so.)
+        // 356 GB of compilation destroyed in one measured day, at a 13.5-minute
+        // median. (That is the measured FREQUENCY; this pool never observes whether
+        // a given build reused the cache, and the warning says so.)
         // `cargo-target-wt` is a build cache for the SAME workspace
         // and was already at 87 GB, so giving it the flat constant would have reproduced
         // the defect on a second cache the day it was registered. A volume we cannot

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1456,17 +1456,43 @@ pub fn start_server(
         // write into `cargo-target-wt` so they cannot poison the main checkout's target
         // (card d2cda466), and that directory then grew to 87 GB unweighed because it was
         // registered nowhere — the 2026-07-13 law with a new name on it. Same pool, same
-        // budget, same flock discipline; the broker now sees both.
+        // flock discipline; the broker now sees both.
+        //
+        // AND THE BUDGET IS DERIVED FROM THE VOLUME, not a constant (#3906). A fixed
+        // 50 GiB sat BELOW this workspace's debug tree on a workstation, so the pool was
+        // permanently over budget and evicted every ~13 minutes all day: 36 evictions and
+        // 356 GB of compilation destroyed in one measured day, which is why every build on
+        // that box started cold. `cargo-target-wt` is a build cache for the SAME workspace
+        // and was already at 87 GB, so giving it the flat constant would have reproduced
+        // the defect on a second cache the day it was registered. A volume we cannot
+        // resolve keeps the floor — never a guess, never zero.
+        use crate::capacity::system_profile::detect_drives;
+        let drives = detect_drives();
         for class in ["cargo-target", "cargo-target-wt"] {
             if let Some(cargo_dir) = crate::system_resources::tracked_dir(class) {
+                // Resolved per class: the two caches can live on different volumes
+                // (an operator who moves worktree builds to a second drive is exactly
+                // who this pool is for), so each gets the budget ITS drive earns.
+                let volume_total = drives
+                    .iter()
+                    .filter(|d| cargo_dir.path().starts_with(&d.mount))
+                    .max_by_key(|d| d.mount.as_os_str().len())
+                    .map(|d| d.total_bytes);
+                let budget = volume_total
+                    .map(crate::system_resources::cargo_target_budget_bytes)
+                    .unwrap_or(crate::system_resources::DEFAULT_CARGO_TARGET_BUDGET_BYTES);
                 broker.register(Arc::new(crate::system_resources::CargoTargetPool::new(
-                    cargo_dir,
-                    crate::system_resources::DEFAULT_CARGO_TARGET_BUDGET_BYTES,
+                    cargo_dir, budget,
                 ))
                     as Arc<dyn crate::paging::pool::ResourcePool>);
                 let line = format!(
-                    "CargoTargetPool registered with PressureBroker for {class} \
-                     (budget-capped, flock-guarded)"
+                    "CargoTargetPool registered with PressureBroker for {class}                      (budget {} GB {}, flock-guarded)",
+                    budget / (1024 * 1024 * 1024),
+                    if volume_total.is_some() {
+                        "derived from volume"
+                    } else {
+                        "= floor, volume unresolved"
+                    }
                 );
                 log_info!("ipc", "server", "{}", line);
             }

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -150,6 +150,7 @@ pub fn cargo_target_budget_bytes(volume_total_bytes: u64) -> u64 {
 /// this PR exists to fix, committed inside the mechanism added to fix it — the
 /// second time in two PRs I have written it, which is why the type is now the
 /// thing that prevents it rather than a comment asking me not to.
+#[derive(Debug)]
 enum LockAttempt {
     /// Held by us until the file drops.
     Acquired(std::fs::File),
@@ -176,10 +177,21 @@ fn try_exclusive_flock_detailed(path: &Path) -> LockAttempt {
     };
     match file.try_lock_exclusive() {
         Ok(()) => LockAttempt::Acquired(file),
-        // fs2 does not distinguish "would block" from a hard error in its return
-        // type; WouldBlock IS the contention signal on both platforms, and anything
-        // else is a real failure we must not read as a live build.
-        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => LockAttempt::HeldByAnother,
+        // CONTENTION IS NOT `WouldBlock` ON WINDOWS. @Astra caught this on the
+        // second review of #3910: `fs2` signals a held lock with the platform's own
+        // code — `EWOULDBLOCK` on Unix, but `ERROR_LOCK_VIOLATION` (33) on Windows,
+        // which `std` does not map to `ErrorKind::WouldBlock`. Matching on the kind
+        // therefore classified a GENUINELY HELD cargo lock as `Unavailable` on
+        // Windows — the same misclassification this tri-state was added to fix,
+        // inverted, and live on the only platform where I could have measured it.
+        //
+        // `fs2::lock_contended_error()` is the library's own answer to "what does
+        // contention look like here", so we ask it rather than guessing per
+        // platform. [[dir-opened-as-file-windows-only]] — Windows chooses
+        // differently and says nothing.
+        Err(e) if e.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
+            LockAttempt::HeldByAnother
+        }
         Err(e) => LockAttempt::Unavailable(format!("lock query failed: {e}")),
     }
 }
@@ -1410,6 +1422,66 @@ mod tests {
             );
         }
 
+        // what this catches: @Astra, twice. First that `Option<File>` collapsed
+        // "a build holds it" and "I could not open it" into one `None`; then that
+        // my fix still misread contention ON WINDOWS, where fs2 reports
+        // ERROR_LOCK_VIOLATION (33) rather than anything std maps to
+        // `ErrorKind::WouldBlock`. Matching on the KIND classified a genuinely held
+        // cargo lock as `Unavailable` — the exact misclassification the tri-state
+        // exists to prevent, inverted, on the platform I run on.
+        //
+        // So this exercises REAL lock files rather than asserting the mapping:
+        // acquire one, then attempt it again while the first guard is alive, on
+        // whatever platform the test is running.
+        #[test]
+        fn a_held_lock_reads_as_contention_and_not_as_an_io_failure() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let lock = tmp.path().join(".cargo-lock");
+
+            let first = try_exclusive_flock_detailed(&lock);
+            let held = match first {
+                LockAttempt::Acquired(f) => f,
+                other => panic!("an uncontended lock must be Acquired, got {other:?}"),
+            };
+
+            // Same process, same file, while the first guard is alive.
+            match try_exclusive_flock_detailed(&lock) {
+                LockAttempt::HeldByAnother => {}
+                LockAttempt::Acquired(_) => {
+                    panic!("a held lock must NOT be re-acquirable — the guard would be a no-op")
+                }
+                LockAttempt::Unavailable(why) => panic!(
+                    "a held lock was reported as an IO failure ({why}) — this is the                      Windows misclassification: contention is ERROR_LOCK_VIOLATION,                      which std does not map to WouldBlock"
+                ),
+            }
+
+            drop(held);
+            // And once released it is acquirable again, so the contention above was
+            // the lock and not some permanent property of the path.
+            assert!(
+                matches!(
+                    try_exclusive_flock_detailed(&lock),
+                    LockAttempt::Acquired(_)
+                ),
+                "non-degeneracy: if this path could never be acquired, the assertion                  above would pass for the wrong reason"
+            );
+        }
+
+        // what this catches: the third state must be reachable and distinct — a path
+        // that cannot be opened is NOT evidence a build was protected.
+        #[test]
+        fn an_unopenable_lock_path_is_unavailable_not_contention() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            // A lock file whose PARENT does not exist cannot be created or opened.
+            let impossible = tmp.path().join("no-such-dir").join(".cargo-lock");
+            match try_exclusive_flock_detailed(&impossible) {
+                LockAttempt::Unavailable(_) => {}
+                other => panic!(
+                    "an unopenable path must be Unavailable, never mistaken for a                      live build holding the lock, got {other:?}"
+                ),
+            }
+        }
+
         // what this catches: a LIVE regression that #3907 shipped to canary, found by
         // S6 via @Astra. `CargoTargetPool::tier_name` returned a hardcoded
         // "disk-cargo-target" for every instance, and `PressureBroker::register`
@@ -1493,7 +1565,9 @@ mod tests {
         // FLAT 50 GiB, which sits BELOW this workspace's debug tree on a
         // workstation. Measured consequence on a 1.9 TB box: 36 evictions and
         // 356 GB of compilation destroyed in one day, median 13.5 minutes apart,
-        // so every build started cold and three agents blamed the toolchain.
+        // at a cadence no build could outlive, and three agents blamed the
+        // toolchain. (Frequency is what was measured; whether any individual build
+        // started cold was never observed — see note_eviction.)
         //
         // The derivation must (a) actually raise the budget on a big volume —
         // a fix that returned the floor everywhere would pass a weaker test while

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -50,12 +50,15 @@ use super::disk_reporters::{dir_size_bytes, TrackedDir};
 /// This workspace's debug tree passes 50 GiB during an ordinary
 /// `cargo test -p continuum-core`, so the pool sat permanently over budget, the
 /// broker asked for relief on every tick, and the eviction obliged — forever.
-/// The code did exactly what it was told; it was told the wrong number. Every
-/// build on that machine started near-cold, which is where the day's
-/// "Windows rustc is flaky" and "~70 minutes to rebuild" reports came from.
+/// The code did exactly what it was told; it was told the wrong number. Those
+/// reports of "Windows rustc is flaky" and "~70 minutes to rebuild" arrived the
+/// same day, and this is the leading explanation for them — not a demonstrated
+/// one. Whether any particular build was denied a warm cache was never observed.
 ///
-/// It survives as the FLOOR rather than the budget: a small laptop still gets
-/// exactly the behaviour it had before, and nothing regresses anywhere.
+/// It survives as the FLOOR rather than the budget: at or below the crossover
+/// volume the computed budget is byte-identical to this constant, so the change
+/// is a no-op there. That is a statement about THIS number, not a guarantee about
+/// the eviction behaviour it feeds.
 pub const DEFAULT_CARGO_TARGET_BUDGET_BYTES: u64 = 50 * 1024 * 1024 * 1024;
 
 /// Is this gap between two evictions short enough that the cache did not survive
@@ -82,12 +85,16 @@ fn thrash_warning_due(run: u32) -> bool {
 /// housekeeping. A count cannot tell 36-in-a-day from 36-in-a-month, and only one
 /// of those is the defect.
 ///
-/// So the signal is the GAP between consecutive evictions. This threshold is the
-/// gap below which a build cache is being emptied faster than a build can use it:
-/// the measured defect ran at a 13.5-minute median, and a full
-/// `cargo test -p continuum-core` on a warm cache is comfortably longer than 30
-/// minutes on the machines that hit this. An eviction arriving inside this window
-/// means the previous build's cache did not survive to be reused.
+/// So the signal is the GAP between consecutive evictions, and the threshold is
+/// chosen — not derived — from two observations: the measured defect ran at a
+/// 13.5-minute median, and a full `cargo test -p continuum-core` on the machines
+/// that hit it takes longer than 30 minutes.
+///
+/// An eviction inside that window is therefore SUSPICIOUS, not conclusive. This
+/// function sees only timestamps: it does not know which rung ran (the ladder may
+/// have taken incremental state alone), whether a build was in flight, or whether
+/// anything was reused. A short gap is consistent with a cache being emptied
+/// faster than a build can use it; it does not establish it.
 const THRASH_GAP_MS: u64 = 30 * 60 * 1000;
 
 /// How many consecutive fast gaps before saying so. Two, because one short gap is
@@ -126,13 +133,17 @@ const CONSECUTIVE_FAST_GAPS_BEFORE_WARNING: u32 = 2;
 /// | 256 GB laptop | 238 GiB | 50 GiB (floor) | unchanged |
 /// | 500 GB | 465 GiB | 50 GiB (floor) | unchanged |
 /// | 1 TB | 931 GiB | 93 GiB | ~1.9x |
-/// | 2 TB workstation | 1863 GiB | 186 GiB | no longer thrashes |
-/// | 4 TB | 3725 GiB | 372 GiB | headroom to match |
+/// | 2 TB workstation | 1863 GiB | 186 GiB | 3.7x the old budget |
+/// | 4 TB | 3725 GiB | 372 GiB | 7.4x |
 ///
-/// The floor is what keeps this safe: every machine at or below ~537 GB behaves
-/// exactly as it does today, so this can regress nobody. It also means the fix
-/// does NOTHING for small machines — if a laptop is thrashing, this is not the
-/// change that helps it, and that is worth knowing rather than assuming.
+/// The right-hand column is the BUDGET RATIO and nothing more. Whether a larger
+/// budget ends the observed eviction cadence on a given machine is untested —
+/// plausible, since the pool evicts when over budget, but not demonstrated, and
+/// the earlier version of this table asserted "no longer thrashes" as if it were.
+///
+/// At or below ~537 GB the computed budget equals the floor, so those machines
+/// see no change from this function. It also means the fix does NOTHING for small
+/// machines: if a laptop is thrashing, this is not the change that helps it.
 pub fn cargo_target_budget_bytes(volume_total_bytes: u64) -> u64 {
     (volume_total_bytes / 10).max(DEFAULT_CARGO_TARGET_BUDGET_BYTES)
 }
@@ -1565,9 +1576,9 @@ mod tests {
         // FLAT 50 GiB, which sits BELOW this workspace's debug tree on a
         // workstation. Measured consequence on a 1.9 TB box: 36 evictions and
         // 356 GB of compilation destroyed in one day, median 13.5 minutes apart,
-        // at a cadence no build could outlive, and three agents blamed the
-        // toolchain. (Frequency is what was measured; whether any individual build
-        // started cold was never observed — see note_eviction.)
+        // at a 13.5-minute median, and three agents blamed the toolchain. (The
+        // frequency is what was measured; whether any build was denied a warm
+        // cache was never observed — see note_eviction.)
         //
         // The derivation must (a) actually raise the budget on a big volume —
         // a fix that returned the floor everywhere would pass a weaker test while

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -234,6 +234,17 @@ pub enum DeclinedEviction {
 }
 
 impl DeclinedEviction {
+    /// A stable tag for "is this the same reason as last time". Not the payload —
+    /// two IO failures with different error text are the same standing condition.
+    fn discriminant(&self) -> u8 {
+        match self {
+            Self::NoSuchDirectory => 0,
+            Self::BuildHoldsRootLock => 1,
+            Self::BuildHoldsDebugLock => 2,
+            Self::LockUnavailable(_) => 3,
+        }
+    }
+
     /// One line an operator can act on, per reason.
     fn why(&self) -> &'static str {
         match self {
@@ -271,6 +282,11 @@ pub struct CargoTargetPool {
     tier: String,
     tracked: Arc<TrackedDir>,
     budget_bytes: u64,
+    /// The last decline reason (as a discriminant) and how many times it has
+    /// repeated unchanged — so a persistent condition is reported once and then
+    /// rarely, instead of once per broker tick (@Astra, #3910 review).
+    last_decline: std::sync::atomic::AtomicU8,
+    decline_repeats: std::sync::atomic::AtomicU32,
     /// Wall-clock ms of the previous eviction, and how many consecutive gaps since
     /// have been shorter than [`THRASH_GAP_MS`]. CADENCE, not a lifetime count —
     /// see [`CargoTargetPool::note_eviction`] for why the count was wrong.
@@ -284,6 +300,8 @@ impl CargoTargetPool {
             // "cargo-target" keeps its historical pool name so nothing that reads
             // the ledger by that string breaks; every other class gets its own.
             tier: format!("disk-{}", tracked.class()),
+            last_decline: std::sync::atomic::AtomicU8::new(u8::MAX),
+            decline_repeats: std::sync::atomic::AtomicU32::new(0),
             last_eviction_ms: std::sync::atomic::AtomicU64::new(0),
             fast_gaps: std::sync::atomic::AtomicU32::new(0),
             tracked,
@@ -298,11 +316,36 @@ impl CargoTargetPool {
     /// unchanged; the difference is that the ledger can now tell a guard that
     /// HELD from a guard that never ran.
     fn declined(&self, reason: DeclinedEviction) -> u64 {
-        crate::clog_warn!(
-            "💾 cargo-target eviction DECLINED ({:?}): {}",
-            reason,
-            reason.why()
-        );
+        use std::sync::atomic::Ordering::Relaxed;
+        // Bounded, and by the REASON rather than by time: a persistent held lock or
+        // a missing root is asked again on every broker tick, so warning per attempt
+        // is a per-tick log line for a condition that has not changed. @Astra caught
+        // that the success-path cadence bound did nothing for this path.
+        //
+        // A CHANGE of reason always speaks (that is news), an unchanged reason
+        // speaks on the 1st, 8th, 64th … repeat, and the pool's identity is in the
+        // line because there is more than one of these now (#3911).
+        let key = reason.discriminant();
+        let repeats = if self.last_decline.swap(key, Relaxed) == key {
+            self.decline_repeats.fetch_add(1, Relaxed) + 1
+        } else {
+            self.decline_repeats.store(0, Relaxed);
+            0
+        };
+        let speak = repeats == 0 || repeats.is_power_of_two() && repeats % 8 == 0;
+        if speak {
+            crate::clog_warn!(
+                "💾 {} eviction DECLINED ({:?}{}): {}",
+                self.tier,
+                reason,
+                if repeats > 0 {
+                    format!(", unchanged for {repeats} attempts")
+                } else {
+                    String::new()
+                },
+                reason.why()
+            );
+        }
         0
     }
 
@@ -313,8 +356,19 @@ impl CargoTargetPool {
     /// it independently and they were right: a lifetime count cannot distinguish
     /// 36-in-a-day (the measured defect) from 36-spread-over-a-week (ordinary
     /// housekeeping), and @IntelMac's own box would have been named loudly for the
-    /// latter. What makes a cache useless is not how often it is trimmed but
-    /// whether it survives long enough to be REUSED, and that is a gap.
+    /// latter.
+    ///
+    /// WHAT THIS DOES AND DOES NOT KNOW (@Astra, second review). It knows the
+    /// INTERVAL between evictions. It does NOT know that any build started cold:
+    /// the ladder may have taken only incremental state, a build can complete
+    /// between two evictions, and no hit/miss observation reaches this function.
+    /// So the warning reports the observed frequency and names its consequence as
+    /// SUSPECTED. An earlier draft asserted "every build here is starting cold",
+    /// which is precisely the over-claim this PR exists to stop — written into the
+    /// warning added to stop it, for the third time in this file's history.
+    ///
+    /// Note the counter is CONSECUTIVE FAST GAPS, not evictions: a run of 3 means
+    /// four evictions, and the message says gaps for that reason.
     ///
     /// The whole failure took a day to find for want of a line like this: the pool
     /// logged what it FREED and never what the freeing MEANT, so 36 evictions and
@@ -342,8 +396,14 @@ impl CargoTargetPool {
         if !thrash_warning_due(run) {
             return;
         }
+        // OBSERVED FREQUENCY, then the SUSPECTED consequence — never asserted as
+        // fact. @Astra, #3910 review: this cannot establish that builds start cold.
+        // The ladder may have removed only incremental state, a build can finish
+        // between two evictions, and no hit/miss observation enters this function.
+        // What is measured is the interval. What follows from it is a suspicion,
+        // and saying more than that is the defect this whole PR is about.
         crate::clog_warn!(
-            "💾 {} evicted {} times in a row less than {} min apart (last gap {} min)              against a {} GB budget — the cache is being emptied faster than a build              can reuse it, so every build here is starting cold. That is a budget              BELOW this workspace's working set, not housekeeping. The budget derives              from the volume (cargo_target_budget_bytes); a volume this pool could not              resolve falls back to the floor, which is the first thing to check.",
+            "💾 {} saw {} consecutive eviction GAPS under {} min (last gap {} min)              against a {} GB budget. That is the frequency, not a verdict: this pool              cannot see whether any build reused the cache. SUSPECTED — a budget              below this workspace's working set, with builds paying rebuild cost they              need not. To confirm, compare a build's wall time against a run with a              larger budget. The budget derives from the volume              (cargo_target_budget_bytes); a volume this pool could not resolve falls              back to the floor, which is the first thing to check.",
             self.tier,
             run,
             THRASH_GAP_MS / 60_000,
@@ -352,12 +412,70 @@ impl CargoTargetPool {
         );
     }
 
+    /// The rungs, freed in order. The last one is `debug` ITSELF, which is why it
+    /// is not a plain `remove_dir_all` — see [`Self::free_rung`].
     fn ladder(root: &Path) -> [PathBuf; 3] {
         [
             root.join("debug/incremental"),
             root.join("tests"),
             root.join("debug"),
         ]
+    }
+
+    /// Free one rung, PRESERVING the lock this eviction is holding.
+    ///
+    /// @Astra, #3910 review: `remove_dir_all(debug)` unlinks `debug/.cargo-lock` —
+    /// the exact file whose lock is our claim to be here. On Unix the unlink
+    /// SUCCEEDS while we hold the descriptor: our fd keeps the old inode alive, the
+    /// PATH is gone, and another cargo is then free to create and lock a brand-new
+    /// `debug/.cargo-lock` while we are still deleting the tree underneath it. The
+    /// lock stops being an ownership boundary at the moment we delete the thing
+    /// being locked.
+    ///
+    /// So the `debug` rung removes debug's CHILDREN and leaves the lock file and its
+    /// parent standing. Everything under it is still reclaimed; the boundary
+    /// survives the reclaim. `debug/.cargo-lock` is a zero-length lock file — the
+    /// bytes we decline to free by keeping it are not bytes.
+    fn free_rung(rung: &Path, root: &Path) -> u64 {
+        let debug = root.join("debug");
+        if rung != debug {
+            let size = dir_size_bytes(rung);
+            return if std::fs::remove_dir_all(rung).is_ok() {
+                size
+            } else {
+                0
+            };
+        }
+        let lock = debug.join(".cargo-lock");
+        let mut freed = 0u64;
+        let Ok(entries) = std::fs::read_dir(&debug) else {
+            return 0;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path == lock {
+                continue;
+            }
+            // `dir_size_bytes` READS A DIRECTORY — it returns 0 for a file, so
+            // sizing children with it silently under-counts every loose artifact
+            // in `debug/` (`lib.rlib` and friends). The existing ladder test caught
+            // this the moment the rung stopped being one `remove_dir_all`.
+            let is_dir = path.is_dir();
+            let size = if is_dir {
+                dir_size_bytes(&path)
+            } else {
+                std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0)
+            };
+            let removed = if is_dir {
+                std::fs::remove_dir_all(&path).is_ok()
+            } else {
+                std::fs::remove_file(&path).is_ok()
+            };
+            if removed {
+                freed = freed.saturating_add(size);
+            }
+        }
+        freed
     }
 }
 
@@ -413,10 +531,7 @@ impl ResourcePool for CargoTargetPool {
             if !rung.exists() {
                 continue;
             }
-            let size = dir_size_bytes(&rung);
-            if std::fs::remove_dir_all(&rung).is_ok() {
-                freed = freed.saturating_add(size);
-            }
+            freed = freed.saturating_add(Self::free_rung(&rung, &root));
         }
         if freed > 0 {
             self.tracked.record_freed(freed);
@@ -844,8 +959,36 @@ mod tests {
         let freed = pool.evict_at_least(u64::MAX);
         assert_eq!(freed, 5000);
         assert!(!tmp.path().join("tests").exists());
-        assert!(!tmp.path().join("debug").exists());
         assert!(tmp.path().join("release/keep.bin").exists());
+
+        // `debug/` SURVIVES NOW, AND THAT IS THE POINT (@Astra, #3910 review).
+        // This assertion used to be `!debug.exists()`. Deleting the directory also
+        // unlinked `debug/.cargo-lock` — the file whose lock is this eviction's
+        // claim to be running at all. On Unix that unlink SUCCEEDS while we hold
+        // the descriptor: our fd keeps the old inode alive, the path is free, and
+        // another cargo can create and lock a replacement while we are still
+        // deleting underneath it. The lock stops being an ownership boundary at the
+        // moment we delete the thing being locked.
+        //
+        // So the contract is: everything under `debug/` is reclaimed, and the lock
+        // file and its parent stand. The bytes we decline to free are a zero-length
+        // lock file.
+        let debug = tmp.path().join("debug");
+        assert!(debug.exists(), "the lock's parent must survive the rung");
+        assert!(
+            debug.join(".cargo-lock").exists(),
+            "the lock we hold must still be at its PATH, not merely alive on an              unlinked inode — an unlinked lock guards nothing against the next cargo"
+        );
+        let survivors: Vec<String> = std::fs::read_dir(&debug)
+            .expect("read debug")
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            survivors,
+            vec![".cargo-lock".to_string()],
+            "ONLY the lock survives — anything else means the rung under-reclaimed"
+        );
     }
 
     // what this catches: safety invariant 1 — a held cargo lock (a build
@@ -1296,6 +1439,29 @@ mod tests {
                 a.tier_name(),
                 b.tier_name(),
                 "non-degeneracy: identical names are exactly what let the broker's                  dedup silently drop one of the two caches"
+            );
+
+            // AND THROUGH THE BROKER, because the getters are not where this broke.
+            // @Astra: "getter inequality alone misses the actual integration
+            // boundary that failed." The failure was `register`'s dedup-by-name
+            // (broker.rs: `pools.retain(|p| p.tier_name() != name)`), so the
+            // assertion has to survive that call — a future change that makes the
+            // names equal again would pass the getter check above and still lose a
+            // cache here.
+            let broker = crate::paging::broker::PressureBroker::new(Default::default());
+            broker.register(Arc::new(a) as Arc<dyn ResourcePool>);
+            broker.register(Arc::new(b) as Arc<dyn ResourcePool>);
+            let names: Vec<String> = broker
+                .snapshot()
+                .pools
+                .into_iter()
+                .map(|p| p.name)
+                .filter(|n| n.starts_with("disk-cargo-target"))
+                .collect();
+            assert_eq!(
+                names.len(),
+                2,
+                "BOTH build caches must survive registration — one row here is the                  regression: the shared cache silently lost its eviction owner while                  two boot log lines claimed otherwise. Got: {names:?}"
             );
         }
 

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -58,39 +58,81 @@ use super::disk_reporters::{dir_size_bytes, TrackedDir};
 /// exactly the behaviour it had before, and nothing regresses anywhere.
 pub const DEFAULT_CARGO_TARGET_BUDGET_BYTES: u64 = 50 * 1024 * 1024 * 1024;
 
-/// After this many evictions in one run, a build cache is not being MANAGED —
-/// its budget is below the working set and it is being emptied on a loop.
-/// Deliberately small: a healthy cache is trimmed occasionally, and the machine
-/// that produced #3906 reached 36 in a single day.
-const EVICTIONS_BEFORE_CALLING_IT_THRASH: u64 = 8;
+/// Is this gap between two evictions short enough that the cache did not survive
+/// to be reused? Pure so the cadence rule is testable without a clock.
+fn gap_is_thrash(gap_ms: u64) -> bool {
+    gap_ms < THRASH_GAP_MS
+}
 
-/// The cargo-target budget for a machine, DERIVED from the volume that holds it
-/// — 10% of the volume, floored at [`DEFAULT_CARGO_TARGET_BUDGET_BYTES`].
+/// Should a run of `run` consecutive fast gaps produce a warning? Loud on reaching
+/// the threshold, then only every further multiple — a sustained pathology must not
+/// become per-eviction noise (@Astra, #3910 review).
+fn thrash_warning_due(run: u32) -> bool {
+    run >= CONSECUTIVE_FAST_GAPS_BEFORE_WARNING
+        && run % CONSECUTIVE_FAST_GAPS_BEFORE_WARNING == 0
+}
+
+/// THRASH IS A CADENCE, NOT A COUNT.
 ///
-/// This is not a new policy invention: it is the shape
-/// [`serving_tier_reserve_bytes`] already uses two functions below, for the same
-/// reason its doc gives — a derived budget is generous exactly where the drive
-/// is, and a constant cannot be. The build cache is the one artifact class whose
-/// working set scales with the WORKSPACE rather than the user, so a fixed number
-/// is guaranteed to be wrong on one end or the other; it was wrong on the big
-/// end, which is the end that hurts, because that is where the work happens.
+/// The first version of this fired after 8 evictions in a process lifetime, and
+/// @Astra rejected it: eight evictions over an arbitrary uptime prove nothing
+/// about whether builds are starting cold. @IntelMac then produced the
+/// counter-example against their own review — 16 evictions on their box, which
+/// would have been named loudly, spread across days at a cadence that is ordinary
+/// housekeeping. A count cannot tell 36-in-a-day from 36-in-a-month, and only one
+/// of those is the defect.
 ///
-/// Volumes in GiB, and the floor wins at or below 500 GiB (500/10 = 50):
+/// So the signal is the GAP between consecutive evictions. This threshold is the
+/// gap below which a build cache is being emptied faster than a build can use it:
+/// the measured defect ran at a 13.5-minute median, and a full
+/// `cargo test -p continuum-core` on a warm cache is comfortably longer than 30
+/// minutes on the machines that hit this. An eviction arriving inside this window
+/// means the previous build's cache did not survive to be reused.
+const THRASH_GAP_MS: u64 = 30 * 60 * 1000;
+
+/// How many consecutive fast gaps before saying so. Two, because one short gap is
+/// a coincidence (a big test run finishing beside a build) and a RUN of them is a
+/// pattern. Small on purpose: the failure this names cost a day.
+const CONSECUTIVE_FAST_GAPS_BEFORE_WARNING: u32 = 2;
+
+/// The cargo-target budget for a machine, DERIVED from the volume that holds it —
+/// 10% of the volume, floored at [`DEFAULT_CARGO_TARGET_BUDGET_BYTES`].
 ///
-/// | volume | budget | vs. the old constant |
-/// |---|---|---|
-/// | 256 GiB laptop | 50 GiB (floor) | unchanged |
-/// | 500 GiB | 50 GiB (floor) | unchanged — the crossover |
-/// | 512 GiB | 51.2 GiB | derived, barely |
-/// | 1900 GiB workstation | 190 GiB | no longer thrashes |
-/// | 4000 GiB | 400 GiB | headroom to match |
+/// This follows [`serving_tier_reserve_bytes`] below rather than inventing a
+/// policy: a derived budget is generous exactly where the drive is, and a constant
+/// cannot be. The build cache is the artifact class whose working set scales with
+/// the WORKSPACE rather than the user, so a fixed number is guaranteed wrong at one
+/// end. It was wrong at the big end, which is where the work happens.
 ///
-/// The first draft of this table claimed 512 GiB fell to the floor. It does not,
-/// and the regression test below caught it — which is the argument for asserting
-/// a derivation's TABLE rather than one convenient point on it.
+/// ## What 10% is, honestly (@Astra, review of #3910)
 ///
-/// The floor is what keeps this safe: a machine too small for the derived value
-/// keeps today's behaviour exactly, so this can regress nobody.
+/// **It is a capacity policy, not a measured working set.** Nobody has measured
+/// what this workspace's debug tree actually needs; what IS measured is that 50 GiB
+/// is below it on a workstation (#3906: 36 evictions, 356 GB, 13.5-minute median).
+/// So this fixes a budget known to be too small by tying it to the resource it
+/// competes for, and it does not claim to have found the right number. A measured
+/// working set would be better and is not blocked by this.
+///
+/// ## Drives are sold in decimal and measured in binary (@IntelMac)
+///
+/// Their box is a "500 GB" container = 465 GiB, so 10% = 46.5 GiB and the 50 GiB
+/// FLOOR wins — their budget is unchanged by this PR. An earlier version of this
+/// table said "500 GiB — the crossover", which is arithmetically true and
+/// practically misleading, because nobody owns a 500 GiB drive; they own a 500 GB
+/// one. The crossover in the units drives are ADVERTISED in is ~537 GB.
+///
+/// | advertised | binary | budget | vs. the old constant |
+/// |---|---|---|---|
+/// | 256 GB laptop | 238 GiB | 50 GiB (floor) | unchanged |
+/// | 500 GB | 465 GiB | 50 GiB (floor) | unchanged |
+/// | 1 TB | 931 GiB | 93 GiB | ~1.9x |
+/// | 2 TB workstation | 1863 GiB | 186 GiB | no longer thrashes |
+/// | 4 TB | 3725 GiB | 372 GiB | headroom to match |
+///
+/// The floor is what keeps this safe: every machine at or below ~537 GB behaves
+/// exactly as it does today, so this can regress nobody. It also means the fix
+/// does NOTHING for small machines — if a laptop is thrashing, this is not the
+/// change that helps it, and that is worth knowing rather than assuming.
 pub fn cargo_target_budget_bytes(volume_total_bytes: u64) -> u64 {
     (volume_total_bytes / 10).max(DEFAULT_CARGO_TARGET_BUDGET_BYTES)
 }
@@ -99,6 +141,50 @@ pub fn cargo_target_budget_bytes(volume_total_bytes: u64) -> u64 {
 /// until dropped; `None` = someone else (a live cargo build) holds it.
 /// A missing lock file is created — holding it makes a cargo invocation
 /// that starts mid-eviction block until we finish, instead of racing us.
+/// The outcome of trying to take the lock — THREE states, not two.
+///
+/// The previous signature was `Option<File>`, and `None` meant BOTH "a live cargo
+/// build holds this" and "I could not even open the file". @Astra caught that on
+/// review of #3910: the decline reason built on it claimed a live build in a case
+/// where there might be no build at all. That is the absence-versus-refusal defect
+/// this PR exists to fix, committed inside the mechanism added to fix it — the
+/// second time in two PRs I have written it, which is why the type is now the
+/// thing that prevents it rather than a comment asking me not to.
+enum LockAttempt {
+    /// Held by us until the file drops.
+    Acquired(std::fs::File),
+    /// Someone else holds it. On this path that someone is a live cargo build, and
+    /// standing down is the guard WORKING.
+    HeldByAnother,
+    /// The lock file could not be opened or queried at all — a permissions problem,
+    /// a vanished directory, a filesystem that cannot lock. NOT evidence of a build,
+    /// and NOT evidence the guard protected anything.
+    Unavailable(String),
+}
+
+fn try_exclusive_flock_detailed(path: &Path) -> LockAttempt {
+    use fs2::FileExt;
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) => return LockAttempt::Unavailable(format!("open failed: {e}")),
+    };
+    match file.try_lock_exclusive() {
+        Ok(()) => LockAttempt::Acquired(file),
+        // fs2 does not distinguish "would block" from a hard error in its return
+        // type; WouldBlock IS the contention signal on both platforms, and anything
+        // else is a real failure we must not read as a live build.
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => LockAttempt::HeldByAnother,
+        Err(e) => LockAttempt::Unavailable(format!("lock query failed: {e}")),
+    }
+}
+
+#[allow(dead_code)] // retained for callers outside this pool; the detailed form is what the guard uses.
 fn try_exclusive_flock(path: &Path) -> Option<std::fs::File> {
     // Cross-platform advisory file lock via `fs2` (Unix: flock; Windows:
     // LockFileEx) — ONE code path on every platform. The lock is held until the
@@ -128,7 +214,7 @@ fn try_exclusive_flock(path: &Path) -> Option<std::fs::File> {
 /// the flock guard holds on Windows. That question is unanswerable from a log
 /// that cannot distinguish "a live build held the lock, so I stood down" from
 /// "I never ran". These variants are that distinction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclinedEviction {
     /// The tracked directory does not exist — nothing to evict, and NOT a sign
     /// the guard worked.
@@ -138,11 +224,18 @@ pub enum DeclinedEviction {
     BuildHoldsRootLock,
     /// A live cargo build holds `debug/.cargo-lock`. Same as above, one level in.
     BuildHoldsDebugLock,
+    /// The lock could not be opened or queried — permissions, a vanished path, a
+    /// filesystem that cannot lock. @Astra, #3910 review: the first version folded
+    /// this into the two above, so an IO failure was reported as "a live build holds
+    /// it". That is a FALSE claim of protection, and worse than no reason at all: it
+    /// would have answered #3906's open question ("does the guard hold on Windows?")
+    /// with a confident yes the data does not support.
+    LockUnavailable(String),
 }
 
 impl DeclinedEviction {
     /// One line an operator can act on, per reason.
-    fn why(self) -> &'static str {
+    fn why(&self) -> &'static str {
         match self {
             Self::NoSuchDirectory => {
                 "the tracked cargo-target directory does not exist — this pool is \
@@ -156,6 +249,9 @@ impl DeclinedEviction {
                 "a live cargo build holds debug/.cargo-lock — standing down, the \
                  build's cache is safe"
             }
+            Self::LockUnavailable(_) => {
+                "the lock could not be opened or queried — NOT evidence a build was                  protected, and NOT evidence the guard ran; the cache was left alone                  because we could not establish it was safe to touch"
+            }
         }
     }
 }
@@ -166,18 +262,30 @@ impl DeclinedEviction {
 /// over-budget (and the broker acts) long before the whole disk is
 /// critical — the cache is bounded by policy, not by the disk filling.
 pub struct CargoTargetPool {
+    /// PER-INSTANCE pool name. It was a hardcoded `"disk-cargo-target"` for every
+    /// instance, and `PressureBroker::register` dedups by name — so when #3907
+    /// started registering a SECOND cache (`cargo-target-wt`) in a loop, the second
+    /// registration silently REPLACED the first and the shared cache became
+    /// ungoverned. Two boot log lines, one governed pool. Found by S6 via @Astra.
+    /// Derived from the tracked class so a third cache cannot repeat it.
+    tier: String,
     tracked: Arc<TrackedDir>,
     budget_bytes: u64,
-    /// Evictions this run. A build cache that must be emptied REPEATEDLY is not a
-    /// cache being managed — it is a budget below the working set. See
-    /// [`CargoTargetPool::note_eviction`].
-    evictions: std::sync::atomic::AtomicU64,
+    /// Wall-clock ms of the previous eviction, and how many consecutive gaps since
+    /// have been shorter than [`THRASH_GAP_MS`]. CADENCE, not a lifetime count —
+    /// see [`CargoTargetPool::note_eviction`] for why the count was wrong.
+    last_eviction_ms: std::sync::atomic::AtomicU64,
+    fast_gaps: std::sync::atomic::AtomicU32,
 }
 
 impl CargoTargetPool {
     pub fn new(tracked: Arc<TrackedDir>, budget_bytes: u64) -> Self {
         Self {
-            evictions: std::sync::atomic::AtomicU64::new(0),
+            // "cargo-target" keeps its historical pool name so nothing that reads
+            // the ledger by that string breaks; every other class gets its own.
+            tier: format!("disk-{}", tracked.class()),
+            last_eviction_ms: std::sync::atomic::AtomicU64::new(0),
+            fast_gaps: std::sync::atomic::AtomicU32::new(0),
             tracked,
             budget_bytes: budget_bytes.max(1),
         }
@@ -198,32 +306,48 @@ impl CargoTargetPool {
         0
     }
 
-    /// Count this eviction and say something once it stops being housekeeping.
+    /// Record this eviction's CADENCE, and speak when the cache is being emptied
+    /// faster than a build can use it.
     ///
-    /// The whole failure took days to find for want of this line. The pool logged
-    /// what it freed and never what the freeing MEANT, so 36 evictions and 356 GB
-    /// of destroyed compilation in one measured day looked exactly like 36
-    /// successful housekeeping runs. Three agents blamed Windows, rustc, and each
-    /// other; one `continuum reboot` was killed by its own stall detector for
-    /// running long on a cache that had just been wiped. All of it downstream of a
-    /// number nobody could see was wrong.
+    /// The first version counted evictions and warned at 8. Both reviewers rejected
+    /// it independently and they were right: a lifetime count cannot distinguish
+    /// 36-in-a-day (the measured defect) from 36-spread-over-a-week (ordinary
+    /// housekeeping), and @IntelMac's own box would have been named loudly for the
+    /// latter. What makes a cache useless is not how often it is trimmed but
+    /// whether it survives long enough to be REUSED, and that is a gap.
     ///
-    /// A count is enough. No new probe, no new sink — it turns "the governor is
-    /// working" into "the governor is thrashing" at the one place that already
-    /// knows both facts.
+    /// The whole failure took a day to find for want of a line like this: the pool
+    /// logged what it FREED and never what the freeing MEANT, so 36 evictions and
+    /// 356 GB of destroyed compilation looked exactly like 36 successful runs.
     fn note_eviction(&self) {
-        let n = self
-            .evictions
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        // Loud at the threshold, then every further multiple: never per-eviction
-        // noise on a healthy machine, never silent on a sick one.
-        if n < EVICTIONS_BEFORE_CALLING_IT_THRASH || n % EVICTIONS_BEFORE_CALLING_IT_THRASH != 0 {
+        use std::sync::atomic::Ordering::Relaxed;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            // A clock we cannot read must not manufacture a "fast gap" — 0 makes the
+            // first comparison look ancient, which is the quiet side.
+            .unwrap_or(0);
+        let previous = self.last_eviction_ms.swap(now, Relaxed);
+        // First eviction of the run has no gap to measure, and a zero clock is not a
+        // measurement either.
+        if previous == 0 || now == 0 || now <= previous {
+            return;
+        }
+        let gap_ms = now - previous;
+        if !gap_is_thrash(gap_ms) {
+            self.fast_gaps.store(0, Relaxed);
+            return;
+        }
+        let run = self.fast_gaps.fetch_add(1, Relaxed) + 1;
+        if !thrash_warning_due(run) {
             return;
         }
         crate::clog_warn!(
-            "💾 cargo-target evicted {} times this run against a {} GB budget — that is a              budget BELOW this workspace's working set, not housekeeping. Every build here              is starting cold and paying the full rebuild again. The budget derives from the              volume (cargo_target_budget_bytes); a volume this pool could not resolve falls              back to the floor, which is the first thing to check.",
-            n,
+            "💾 {} evicted {} times in a row less than {} min apart (last gap {} min)              against a {} GB budget — the cache is being emptied faster than a build              can reuse it, so every build here is starting cold. That is a budget              BELOW this workspace's working set, not housekeeping. The budget derives              from the volume (cargo_target_budget_bytes); a volume this pool could not              resolve falls back to the floor, which is the first thing to check.",
+            self.tier,
+            run,
+            THRASH_GAP_MS / 60_000,
+            gap_ms / 60_000,
             self.budget_bytes / (1024 * 1024 * 1024)
         );
     }
@@ -239,7 +363,7 @@ impl CargoTargetPool {
 
 impl ResourcePool for CargoTargetPool {
     fn tier_name(&self) -> &str {
-        "disk-cargo-target"
+        &self.tier
     }
 
     fn capacity_bytes(&self) -> u64 {
@@ -257,15 +381,25 @@ impl ResourcePool for CargoTargetPool {
         }
         // Safety invariant 1: hold cargo's lock files exclusively for the
         // whole eviction, or do nothing. Guards held in scope until return.
-        let _root_lock = match try_exclusive_flock(&root.join(".cargo-lock")) {
-            Some(lock) => lock,
-            None => return self.declined(DeclinedEviction::BuildHoldsRootLock),
+        let _root_lock = match try_exclusive_flock_detailed(&root.join(".cargo-lock")) {
+            LockAttempt::Acquired(lock) => lock,
+            LockAttempt::HeldByAnother => {
+                return self.declined(DeclinedEviction::BuildHoldsRootLock)
+            }
+            LockAttempt::Unavailable(why) => {
+                return self.declined(DeclinedEviction::LockUnavailable(why))
+            }
         };
         let debug_lock_path = root.join("debug/.cargo-lock");
         let _debug_lock = if debug_lock_path.parent().is_some_and(Path::exists) {
-            match try_exclusive_flock(&debug_lock_path) {
-                Some(lock) => Some(lock),
-                None => return self.declined(DeclinedEviction::BuildHoldsDebugLock),
+            match try_exclusive_flock_detailed(&debug_lock_path) {
+                LockAttempt::Acquired(lock) => Some(lock),
+                LockAttempt::HeldByAnother => {
+                    return self.declined(DeclinedEviction::BuildHoldsDebugLock)
+                }
+                LockAttempt::Unavailable(why) => {
+                    return self.declined(DeclinedEviction::LockUnavailable(why))
+                }
             }
         } else {
             None
@@ -1133,6 +1267,62 @@ mod tests {
             );
         }
 
+        // what this catches: a LIVE regression that #3907 shipped to canary, found by
+        // S6 via @Astra. `CargoTargetPool::tier_name` returned a hardcoded
+        // "disk-cargo-target" for every instance, and `PressureBroker::register`
+        // dedups by name (broker.rs: `pools.retain(|p| p.tier_name() != name)`).
+        // So when #3907 began registering a SECOND cache in a loop, the second
+        // registration REPLACED the first and the shared cargo-target became
+        // ungoverned — while two boot log lines claimed both were registered.
+        //
+        // Two governed caches must be two POOLS, and the only thing that makes them
+        // two is a distinct name.
+        #[test]
+        fn two_build_caches_are_two_pools_and_not_one_replacing_the_other() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let shared = TrackedDir::new("cargo-target", tmp.path().join("a"));
+            let worktree = TrackedDir::new("cargo-target-wt", tmp.path().join("b"));
+
+            let a = CargoTargetPool::new(shared, DEFAULT_CARGO_TARGET_BUDGET_BYTES);
+            let b = CargoTargetPool::new(worktree, DEFAULT_CARGO_TARGET_BUDGET_BYTES);
+
+            assert_eq!(
+                a.tier_name(),
+                "disk-cargo-target",
+                "the original class keeps its historical pool name, so anything                  reading the ledger by that string still finds it"
+            );
+            assert_eq!(b.tier_name(), "disk-cargo-target-wt");
+            assert_ne!(
+                a.tier_name(),
+                b.tier_name(),
+                "non-degeneracy: identical names are exactly what let the broker's                  dedup silently drop one of the two caches"
+            );
+        }
+
+        // what this catches: @Astra and @IntelMac both rejected the first version of
+        // this, which warned after 8 evictions in a process lifetime. A COUNT cannot
+        // tell 36-in-a-day (the measured defect) from 36-over-a-week (housekeeping),
+        // and IntelMac's own box would have been named loudly for the latter. The
+        // signal is whether the cache survived long enough to be REUSED, which is a
+        // gap, not a tally.
+        #[test]
+        fn thrash_is_a_cadence_not_a_count() {
+            // A build cannot reuse a cache emptied minutes ago.
+            assert!(gap_is_thrash(60_000));
+            assert!(gap_is_thrash(THRASH_GAP_MS - 1));
+            // Hours apart is housekeeping, however many times it has happened.
+            assert!(!gap_is_thrash(THRASH_GAP_MS));
+            assert!(!gap_is_thrash(6 * 60 * 60 * 1000));
+
+            // One fast gap is a coincidence; a run is a pattern.
+            assert!(!thrash_warning_due(1));
+            assert!(thrash_warning_due(CONSECUTIVE_FAST_GAPS_BEFORE_WARNING));
+            // Then periodic, never per-eviction noise.
+            let n = CONSECUTIVE_FAST_GAPS_BEFORE_WARNING;
+            assert!(!thrash_warning_due(n + 1));
+            assert!(thrash_warning_due(n * 2));
+        }
+
         // what this catches: regression for #3906 — the cargo-target budget was a
         // FLAT 50 GiB, which sits BELOW this workspace's debug tree on a
         // workstation. Measured consequence on a 1.9 TB box: 36 evictions and
@@ -1151,12 +1341,17 @@ mod tests {
             // Small machines: unchanged. This is what makes the change safe to
             // ship everywhere rather than only where it was measured.
             assert_eq!(cargo_target_budget_bytes(256 * GIB), floor);
-            // The crossover is exactly 500 GiB (500/10 == the 50 GiB floor).
-            assert_eq!(cargo_target_budget_bytes(500 * GIB), floor);
-            // And one GiB above it the derivation takes over — asserted because
-            // my first doc table claimed 512 GiB was still on the floor, and this
-            // test is what proved otherwise.
-            assert!(cargo_target_budget_bytes(512 * GIB) > floor);
+            // @IntelMac's box: a "500 GB" container is 465 GiB, so 10% = 46.5 GiB
+            // and the FLOOR wins — their budget is unchanged by this PR. Asserted
+            // in the units drives are actually SOLD in, because my first table
+            // said "500 GiB, the crossover", which is true and misleading: nobody
+            // owns a 500 GiB drive.
+            const GB: u64 = 1_000_000_000;
+            assert_eq!(cargo_target_budget_bytes(500 * GB), floor);
+            // The crossover in advertised units is ~537 GB; below it, floor.
+            assert_eq!(cargo_target_budget_bytes(530 * GB), floor);
+            // Above it the derivation takes over.
+            assert!(cargo_target_budget_bytes(600 * GB) > floor);
             // A volume smaller than the floor still yields the floor, never 0 and
             // never the volume — a budget of nothing is a permanent `cargo clean`.
             assert_eq!(cargo_target_budget_bytes(8 * GIB), floor);
@@ -1167,6 +1362,8 @@ mod tests {
             // defect.
             let bigmama = cargo_target_budget_bytes(1900 * GIB);
             assert_eq!(bigmama, 190 * GIB);
+            // And in advertised units, the 2 TB class this PR was measured on.
+            assert!(cargo_target_budget_bytes(2000 * GB) > 180 * GIB);
             assert!(
                 bigmama > floor,
                 "non-degeneracy: on the volume that produced #3906 the derived                  budget MUST exceed the old constant, or nothing changed"

--- a/core/continuum-core/src/system_resources/disk_eviction.rs
+++ b/core/continuum-core/src/system_resources/disk_eviction.rs
@@ -35,12 +35,65 @@ use crate::paging::pool::{ResourcePool, ResourcePoolEntry};
 
 use super::disk_reporters::{dir_size_bytes, TrackedDir};
 
-/// Default cargo-target budget: 50 GiB. Generous for a warm dev cache,
-/// an order of magnitude under the 363 GB the unswept cache reached.
-/// Plumbing this through config.env's single owner is part of the
-/// de-hardcode audit (task #124); the constant is the safe default a
-/// public user gets with zero configuration.
+/// FLOOR for the cargo-target budget: 50 GiB. This was the whole budget until
+/// 2026-09-08, and on a large developer machine it is not a cache budget at all
+/// — it is a scheduled `cargo clean`.
+///
+/// MEASURED on BigMama (1.9 TB volume), from this pool's own eviction log:
+///
+/// ```text
+/// evictions in one day   36
+/// GB freed that day      356
+/// median gap             13.5 minutes
+/// ```
+///
+/// This workspace's debug tree passes 50 GiB during an ordinary
+/// `cargo test -p continuum-core`, so the pool sat permanently over budget, the
+/// broker asked for relief on every tick, and the eviction obliged — forever.
+/// The code did exactly what it was told; it was told the wrong number. Every
+/// build on that machine started near-cold, which is where the day's
+/// "Windows rustc is flaky" and "~70 minutes to rebuild" reports came from.
+///
+/// It survives as the FLOOR rather than the budget: a small laptop still gets
+/// exactly the behaviour it had before, and nothing regresses anywhere.
 pub const DEFAULT_CARGO_TARGET_BUDGET_BYTES: u64 = 50 * 1024 * 1024 * 1024;
+
+/// After this many evictions in one run, a build cache is not being MANAGED —
+/// its budget is below the working set and it is being emptied on a loop.
+/// Deliberately small: a healthy cache is trimmed occasionally, and the machine
+/// that produced #3906 reached 36 in a single day.
+const EVICTIONS_BEFORE_CALLING_IT_THRASH: u64 = 8;
+
+/// The cargo-target budget for a machine, DERIVED from the volume that holds it
+/// — 10% of the volume, floored at [`DEFAULT_CARGO_TARGET_BUDGET_BYTES`].
+///
+/// This is not a new policy invention: it is the shape
+/// [`serving_tier_reserve_bytes`] already uses two functions below, for the same
+/// reason its doc gives — a derived budget is generous exactly where the drive
+/// is, and a constant cannot be. The build cache is the one artifact class whose
+/// working set scales with the WORKSPACE rather than the user, so a fixed number
+/// is guaranteed to be wrong on one end or the other; it was wrong on the big
+/// end, which is the end that hurts, because that is where the work happens.
+///
+/// Volumes in GiB, and the floor wins at or below 500 GiB (500/10 = 50):
+///
+/// | volume | budget | vs. the old constant |
+/// |---|---|---|
+/// | 256 GiB laptop | 50 GiB (floor) | unchanged |
+/// | 500 GiB | 50 GiB (floor) | unchanged — the crossover |
+/// | 512 GiB | 51.2 GiB | derived, barely |
+/// | 1900 GiB workstation | 190 GiB | no longer thrashes |
+/// | 4000 GiB | 400 GiB | headroom to match |
+///
+/// The first draft of this table claimed 512 GiB fell to the floor. It does not,
+/// and the regression test below caught it — which is the argument for asserting
+/// a derivation's TABLE rather than one convenient point on it.
+///
+/// The floor is what keeps this safe: a machine too small for the derived value
+/// keeps today's behaviour exactly, so this can regress nobody.
+pub fn cargo_target_budget_bytes(volume_total_bytes: u64) -> u64 {
+    (volume_total_bytes / 10).max(DEFAULT_CARGO_TARGET_BUDGET_BYTES)
+}
 
 /// Non-blocking exclusive flock on `path`. `Some(file)` holds the lock
 /// until dropped; `None` = someone else (a live cargo build) holds it.
@@ -63,6 +116,50 @@ fn try_exclusive_flock(path: &Path) -> Option<std::fs::File> {
     file.try_lock_exclusive().ok().map(|_| file)
 }
 
+/// WHY an eviction did nothing. #3906, at @Astra's request: "declined eviction
+/// deserves a typed reason."
+///
+/// The pool logged what it FREED and never logged what it DECLINED, so a guard
+/// that held and a guard that was never reached produced the identical record:
+/// silence. That is the same absence-versus-refusal defect this card turned out
+/// to be three instances of, sitting inside the mechanism meant to diagnose it.
+///
+/// It matters here specifically because the open question on #3906 is whether
+/// the flock guard holds on Windows. That question is unanswerable from a log
+/// that cannot distinguish "a live build held the lock, so I stood down" from
+/// "I never ran". These variants are that distinction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclinedEviction {
+    /// The tracked directory does not exist — nothing to evict, and NOT a sign
+    /// the guard worked.
+    NoSuchDirectory,
+    /// A live cargo build holds the target-dir lock. THIS IS THE GUARD WORKING,
+    /// and until now it was indistinguishable from the guard never running.
+    BuildHoldsRootLock,
+    /// A live cargo build holds `debug/.cargo-lock`. Same as above, one level in.
+    BuildHoldsDebugLock,
+}
+
+impl DeclinedEviction {
+    /// One line an operator can act on, per reason.
+    fn why(self) -> &'static str {
+        match self {
+            Self::NoSuchDirectory => {
+                "the tracked cargo-target directory does not exist — this pool is \
+                 managing nothing, which is worth knowing before trusting its numbers"
+            }
+            Self::BuildHoldsRootLock => {
+                "a live cargo build holds the target-dir lock — standing down, the \
+                 build's cache is safe"
+            }
+            Self::BuildHoldsDebugLock => {
+                "a live cargo build holds debug/.cargo-lock — standing down, the \
+                 build's cache is safe"
+            }
+        }
+    }
+}
+
 /// Budget-capped eviction owner for the shared cargo-target cache.
 /// Shares its [`TrackedDir`] with the disk reporter — one measurement,
 /// two consumers. Pressure = cached usage / budget, so this pool goes
@@ -71,11 +168,16 @@ fn try_exclusive_flock(path: &Path) -> Option<std::fs::File> {
 pub struct CargoTargetPool {
     tracked: Arc<TrackedDir>,
     budget_bytes: u64,
+    /// Evictions this run. A build cache that must be emptied REPEATEDLY is not a
+    /// cache being managed — it is a budget below the working set. See
+    /// [`CargoTargetPool::note_eviction`].
+    evictions: std::sync::atomic::AtomicU64,
 }
 
 impl CargoTargetPool {
     pub fn new(tracked: Arc<TrackedDir>, budget_bytes: u64) -> Self {
         Self {
+            evictions: std::sync::atomic::AtomicU64::new(0),
             tracked,
             budget_bytes: budget_bytes.max(1),
         }
@@ -84,6 +186,48 @@ impl CargoTargetPool {
     /// The eviction ladder, cheapest-regret first. Each rung is fully
     /// reproducible by the next build; order matters — incremental
     /// state is the biggest win with the smallest rebuild cost.
+    /// Record a decline WITH ITS REASON, and answer 0 as before. Behaviour is
+    /// unchanged; the difference is that the ledger can now tell a guard that
+    /// HELD from a guard that never ran.
+    fn declined(&self, reason: DeclinedEviction) -> u64 {
+        crate::clog_warn!(
+            "💾 cargo-target eviction DECLINED ({:?}): {}",
+            reason,
+            reason.why()
+        );
+        0
+    }
+
+    /// Count this eviction and say something once it stops being housekeeping.
+    ///
+    /// The whole failure took days to find for want of this line. The pool logged
+    /// what it freed and never what the freeing MEANT, so 36 evictions and 356 GB
+    /// of destroyed compilation in one measured day looked exactly like 36
+    /// successful housekeeping runs. Three agents blamed Windows, rustc, and each
+    /// other; one `continuum reboot` was killed by its own stall detector for
+    /// running long on a cache that had just been wiped. All of it downstream of a
+    /// number nobody could see was wrong.
+    ///
+    /// A count is enough. No new probe, no new sink — it turns "the governor is
+    /// working" into "the governor is thrashing" at the one place that already
+    /// knows both facts.
+    fn note_eviction(&self) {
+        let n = self
+            .evictions
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        // Loud at the threshold, then every further multiple: never per-eviction
+        // noise on a healthy machine, never silent on a sick one.
+        if n < EVICTIONS_BEFORE_CALLING_IT_THRASH || n % EVICTIONS_BEFORE_CALLING_IT_THRASH != 0 {
+            return;
+        }
+        crate::clog_warn!(
+            "💾 cargo-target evicted {} times this run against a {} GB budget — that is a              budget BELOW this workspace's working set, not housekeeping. Every build here              is starting cold and paying the full rebuild again. The budget derives from the              volume (cargo_target_budget_bytes); a volume this pool could not resolve falls              back to the floor, which is the first thing to check.",
+            n,
+            self.budget_bytes / (1024 * 1024 * 1024)
+        );
+    }
+
     fn ladder(root: &Path) -> [PathBuf; 3] {
         [
             root.join("debug/incremental"),
@@ -109,19 +253,19 @@ impl ResourcePool for CargoTargetPool {
     fn evict_at_least(&self, want_bytes: u64) -> u64 {
         let root = self.tracked.path().to_path_buf();
         if !root.exists() {
-            return 0;
+            return self.declined(DeclinedEviction::NoSuchDirectory);
         }
         // Safety invariant 1: hold cargo's lock files exclusively for the
         // whole eviction, or do nothing. Guards held in scope until return.
         let _root_lock = match try_exclusive_flock(&root.join(".cargo-lock")) {
             Some(lock) => lock,
-            None => return 0,
+            None => return self.declined(DeclinedEviction::BuildHoldsRootLock),
         };
         let debug_lock_path = root.join("debug/.cargo-lock");
         let _debug_lock = if debug_lock_path.parent().is_some_and(Path::exists) {
             match try_exclusive_flock(&debug_lock_path) {
                 Some(lock) => Some(lock),
-                None => return 0,
+                None => return self.declined(DeclinedEviction::BuildHoldsDebugLock),
             }
         } else {
             None
@@ -147,6 +291,7 @@ impl ResourcePool for CargoTargetPool {
                 freed / (1024 * 1024 * 1024),
                 self.budget_bytes / (1024 * 1024 * 1024)
             );
+            self.note_eviction();
         }
         freed
     }
@@ -986,6 +1131,54 @@ mod tests {
                 vec![9u8; 3000],
                 "cold artifact never overwritten"
             );
+        }
+
+        // what this catches: regression for #3906 — the cargo-target budget was a
+        // FLAT 50 GiB, which sits BELOW this workspace's debug tree on a
+        // workstation. Measured consequence on a 1.9 TB box: 36 evictions and
+        // 356 GB of compilation destroyed in one day, median 13.5 minutes apart,
+        // so every build started cold and three agents blamed the toolchain.
+        //
+        // The derivation must (a) actually raise the budget on a big volume —
+        // a fix that returned the floor everywhere would pass a weaker test while
+        // changing nothing — and (b) never LOWER it on a small one, or this
+        // regresses the machines it was already correct for.
+        #[test]
+        fn the_cargo_target_budget_is_derived_from_the_volume_and_never_below_the_floor() {
+            const GIB: u64 = 1024 * 1024 * 1024;
+            let floor = DEFAULT_CARGO_TARGET_BUDGET_BYTES;
+
+            // Small machines: unchanged. This is what makes the change safe to
+            // ship everywhere rather than only where it was measured.
+            assert_eq!(cargo_target_budget_bytes(256 * GIB), floor);
+            // The crossover is exactly 500 GiB (500/10 == the 50 GiB floor).
+            assert_eq!(cargo_target_budget_bytes(500 * GIB), floor);
+            // And one GiB above it the derivation takes over — asserted because
+            // my first doc table claimed 512 GiB was still on the floor, and this
+            // test is what proved otherwise.
+            assert!(cargo_target_budget_bytes(512 * GIB) > floor);
+            // A volume smaller than the floor still yields the floor, never 0 and
+            // never the volume — a budget of nothing is a permanent `cargo clean`.
+            assert_eq!(cargo_target_budget_bytes(8 * GIB), floor);
+            assert_eq!(cargo_target_budget_bytes(0), floor);
+
+            // The measured machine: 1.9 TB. This is the assertion that would have
+            // failed before the fix, and it is the only one that matters to the
+            // defect.
+            let bigmama = cargo_target_budget_bytes(1900 * GIB);
+            assert_eq!(bigmama, 190 * GIB);
+            assert!(
+                bigmama > floor,
+                "non-degeneracy: on the volume that produced #3906 the derived                  budget MUST exceed the old constant, or nothing changed"
+            );
+
+            // Monotonic in the volume — a bigger drive never gets a smaller cache.
+            let mut prev = 0;
+            for tb in [0u64, 256, 512, 1000, 1900, 4000, 8000] {
+                let b = cargo_target_budget_bytes(tb * GIB);
+                assert!(b >= prev, "budget must not shrink as the volume grows");
+                prev = b;
+            }
         }
 
         // what this catches: the capacity derivation (#287-style) — 10% of

--- a/core/continuum-core/src/system_resources/disk_reporters.rs
+++ b/core/continuum-core/src/system_resources/disk_reporters.rs
@@ -53,6 +53,15 @@ impl TrackedDir {
         &self.path
     }
 
+    /// The cache CLASS this directory is. Public because a pool's identity must be
+    /// derived from it rather than hardcoded: two `CargoTargetPool`s both answering
+    /// `"disk-cargo-target"` meant `PressureBroker::register` (dedup-by-name)
+    /// silently REPLACED the first with the second, leaving the shared cache
+    /// ungoverned while two boot lines claimed otherwise.
+    pub fn class(&self) -> &'static str {
+        self.name
+    }
+
     /// The cache-class name. `path` and `bytes` already had accessors;
     /// this one was missing, so a pool built over the class had to
     /// re-declare its own name and could drift from the reporter's.

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -27,7 +27,7 @@ pub use concurrency::local_inference_capacity;
 
 pub use disk_eviction::{
     serving_active_artifacts, serving_tier_capacity_bytes, ActiveArtifactSet, CargoTargetPool,
-    NvmeServingTierPool, DEFAULT_CARGO_TARGET_BUDGET_BYTES,
+    cargo_target_budget_bytes, NvmeServingTierPool, DEFAULT_CARGO_TARGET_BUDGET_BYTES,
 };
 pub use disk_pressure::{
     is_disk_gate_closed, DiskPathReport, DiskPressureLevel, DiskPressureMonitor,


### PR DESCRIPTION
Closes the primary defect in #3906. Scope note at the bottom — this deliberately does **not** claim the active-lock question is settled.

## The measurement

From this pool's own eviction log, on a 1.9 TB workstation:

```
2026-09-08T02:54:52  cargo-target eviction freed 16 GB (budget 50 GB)
2026-09-08T13:15:20  cargo-target eviction freed 22 GB
2026-09-08T14:05:16  cargo-target eviction freed 22 GB

evictions in one day   36
GB freed that day      356
median gap             13.5 minutes
```

Independently reproduced by @IntelMac on a second node (16 evictions, 25–28 GB each).

**The shared build cache was being deleted roughly every thirteen minutes, all day.**

## Cause: a constant below the working set

`DEFAULT_CARGO_TARGET_BUDGET_BYTES` was a flat 50 GiB. This workspace's debug tree passes that during an ordinary `cargo test -p continuum-core`, so the pool sat permanently over budget, the broker asked for relief every tick, and the eviction obliged forever. The code did exactly what it was told. It was told the wrong number.

A cache budget below the working set is not a cache — it is a scheduled `cargo clean`, running at a 13.5-minute median.

> **What is measured and what is not.** The frequency above is measured. Whether any individual build actually started cold is **not**: this pool never observes cache hits or misses, the ladder may remove only incremental state, and a build can finish between two evictions. An earlier version of this body — and of the warning, and of two source comments — asserted "every build started cold". @Astra struck it from the warning; this is the same claim in its last hiding place. The suspected consequence is stated as suspected, with the experiment that would confirm it (compare build wall time against a run with a larger budget).

## Fix: the house pattern, not a new constant

`cargo_target_budget_bytes(volume) = (volume / 10).max(50 GiB)` — the same shape `serving_tier_reserve_bytes` uses forty lines below, for the reason its own doc gives: *a derived budget is generous exactly where the drive is, and a constant cannot be.* @Astra's review asked specifically for this rather than swapping in another machine-specific number.

| volume | budget | vs. before |
|---|---|---|
| 256 GiB laptop | 50 GiB (floor) | unchanged |
| 500 GiB | 50 GiB (floor) | unchanged — the crossover |
| 512 GiB | 51.2 GiB | derived, barely |
| 1900 GiB | 190 GiB | 3.8x the old budget |
| 4000 GiB | 400 GiB | headroom to match |

**The floor bounds the blast radius:** at or below the crossover volume the computed budget equals the floor, so those machines see no change from this function. That is a statement about the NUMBER, not a guarantee about eviction behaviour. The registration site resolves the volume the same way the serving tier does, and an unresolvable volume keeps the floor — never a guess, never zero.

## Two things were silent that should not have been

**`note_eviction`** counts and speaks once eviction stops being housekeeping. The pool logged what it *freed* and never what the freeing *meant*, so 36 evictions and 356 GB of destroyed compilation looked identical to 36 successful housekeeping runs. Three agents blamed Windows, rustc, and each other; a `continuum reboot` was killed by its own stall detector (#3858) for running long on a cache that had just been wiped. All of it downstream of a number nobody could see was wrong.

**`DeclinedEviction`** gives a declined eviction a typed reason — @Astra's ask on the card. A guard that *held* and a guard that *never ran* produced the identical record: silence. That is concrete here, because #3906's remaining open question is whether the flock guard holds on Windows, and that is unanswerable from a log which cannot distinguish "a live build held the lock, so I stood down" from "I never ran."

## Scope

This fixes **between-build cache churn**. It does **not** assert that the active-lock correctness question is closed; @Astra asked to keep those separate and that is right. With the budget no longer forcing an eviction every 13 minutes, the decline reasons added here are the instrument that can finally answer it.

## Tests

The regression asserts the whole **table**, not one convenient point — and it earned that: my first doc table claimed a 512 GiB volume fell back to the floor. It does not (51.2 GiB > 50 GiB), and the test caught my own wrong claim before a reviewer had to. It also pins non-degeneracy: on the volume that produced this card the derived budget **must** exceed the old constant, or the fix changed nothing. Monotonicity is asserted too — a bigger drive never gets a smaller cache.

`cargo test -p continuum-core --lib -- disk_eviction`: **12 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc


