### PR TITLE
fix(windows): release core sockets while preserved children survive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "livekit-api",
  "llama",
  "metal 0.32.0",
+ "mio",
  "msedge-tts",
  "ndarray",
  "notify",
@@ -6773,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",

--- a/core/continuum-core/Cargo.toml
+++ b/core/continuum-core/Cargo.toml
@@ -270,6 +270,10 @@ tikv-jemallocator = "0.6"
 # 95.9GB-commit-on-63GB incident. Version pinned to one already in the lockfile.
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60", features = ["Win32_System_ProcessStatus", "Win32_Foundation"] }
+# Tokio's Mio sockets must not survive a core restart inside preserved children.
+# Keep the fixed release as a resolution floor, including without our lockfile.
+# Mio #1946 creates sockets with WSA_FLAG_NO_HANDLE_INHERIT (since 1.2.1).
+mio = { version = "1.2.3", default-features = false }
 
 # Metal API — GPU detection (VRAM), compute shaders (RGBA→NV12 on GPU)
 # Version 0.32 matches wgpu-hal 27 (Bevy 0.18) for type compatibility

--- a/core/continuum-core/src/ipc/ws.rs
+++ b/core/continuum-core/src/ipc/ws.rs
@@ -425,6 +425,105 @@ mod tests {
     use super::*;
     use continuum_airc_protocol::{AircCommandRequest, AircCommandResponse};
 
+    // Socket ownership regression (a8cef9d0): a child serving a model can outlive
+    // the core. Dropping the core's listeners must release their ports while
+    // that child is still alive. Mio 1.1.1 inherited both TCP and UDP sockets.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn sockets_release_ports_while_spawned_child_survives() {
+        use std::os::windows::process::CommandExt;
+        use std::process::{Child, Command, Stdio};
+        use std::time::Duration;
+
+        struct OwnedChild(Child);
+        impl Drop for OwnedChild {
+            fn drop(&mut self) {
+                // Only this test's exact child; failure must never orphan it.
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+
+        let tcp = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let udp = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let tcp_addr = tcp.local_addr().unwrap();
+        let udp_addr = udp.local_addr().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let log_path = temp.path().join("child.log");
+        let mut child = OwnedChild(
+            Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "ipc::ws::tests::socket_owner_child_fixture",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env("CONTINUUM_TEST_SOCKET_OWNER_CHILD", temp.path())
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(std::fs::File::create(&log_path).unwrap())
+                .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                .spawn()
+                .unwrap(),
+        );
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        while !temp.path().join("ready").exists() {
+            assert!(
+                child.0.try_wait().unwrap().is_none(),
+                "child exited before ready: {}",
+                std::fs::read_to_string(&log_path).unwrap()
+            );
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "child startup timeout"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        drop(tcp);
+        drop(udp);
+        let rebound_tcp = tokio::net::TcpListener::bind(tcp_addr).await;
+        let rebound_udp = tokio::net::UdpSocket::bind(udp_addr).await;
+        assert!(
+            child.0.try_wait().unwrap().is_none(),
+            "child must still be alive"
+        );
+        assert!(
+            rebound_tcp.is_ok(),
+            "TCP listener leaked to child: {rebound_tcp:?}"
+        );
+        assert!(
+            rebound_udp.is_ok(),
+            "UDP socket leaked to child: {rebound_udp:?}"
+        );
+        std::fs::write(temp.path().join("release"), b"release").unwrap();
+        loop {
+            if let Some(status) = child.0.try_wait().unwrap() {
+                assert!(status.success(), "child status: {status}");
+                break;
+            }
+            assert!(tokio::time::Instant::now() < deadline, "child exit timeout");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn socket_owner_child_fixture() {
+        let Some(root) = std::env::var_os("CONTINUUM_TEST_SOCKET_OWNER_CHILD") else {
+            return;
+        };
+        let root = std::path::PathBuf::from(root);
+        std::fs::write(root.join("ready"), b"ready").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !root.join("release").exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "parent did not release child"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     /// An inert nav registry for connection-handler tests: real type, fixed
     /// empty room set, fresh bus. Anonymous test connections never call
     /// `ensure`, and a citizen-scoped test that does gets a projector writing


### PR DESCRIPTION
Preserved model-serving children can keep a Windows core's TCP/UDP sockets alive after that core exits. The next core then cannot bind its desktop, WebSocket and call-plane ports. The live incident had TCP 9100 responding from the new core while 8975/8974/8790 still belonged to the exited core.

Upgrade the shared Mio dependency from 1.1.1 to 1.2.3 and set a Windows resolution floor. Upstream [Mio #1946](https://github.com/tokio-rs/mio/pull/1946) creates sockets with `WSA_FLAG_NO_HANDLE_INHERIT`; this fixes socket creation across Tokio users without adding separate server wrappers. A regression in the existing WebSocket tests spawns a real child, drops the parent's TCP and UDP sockets, and rebinds both ports while the child remains alive.

Validation: the identical regression extracted into a minimal Rust 1.95 Windows crate fails on Mio 1.1.1 with TCP `10048 / AddrInUse` and passes on 1.2.3, including both TCP and UDP rebinds. Strict Clippy passes for that native fixture and the production Windows launch module. Independent source review passed. The actual Continuum Windows TCP/UDP child-survival regression also passed in the expanded native batch. That batch had six failures in separate in-progress recording/training fixtures, which are being corrected separately. This exact PR passed Linux library tests, Windows MSVC library/tests compilation, and generated binding drift CI.

This prevents inheritance of newly created sockets. It does not revoke handles already held by children launched by the old core; clearing that live occupancy requires the coordinated owner handoff. No live core, gateway or installed AIRC changes were made for this PR.

AIRC card: a8cef9d0-f783-4bab-b07b-135c54907876.
