### PR TITLE
fix(persona): retain capture and memory across native Windows launches

### DIFF
--- a/core/continuum-core/src/cognition/introspect_commands.rs
+++ b/core/continuum-core/src/cognition/introspect_commands.rs
@@ -32,9 +32,9 @@ const DEFAULT_LIMIT: usize = 10;
 const MAX_LIMIT: usize = 100;
 
 /// Read the last `limit` JSONL lines from a per-persona fixture file under
-/// `~/.continuum/fixtures/<subdir>/<persona_id>.jsonl`. Missing file → empty.
-fn tail_persona_jsonl(
-    subdir: &str,
+/// the shared fixture directory. Missing file → empty.
+pub(super) fn tail_persona_jsonl(
+    relative_dir: &str,
     persona_id: &str,
     limit: usize,
 ) -> Result<Vec<String>, CommandError> {
@@ -49,11 +49,8 @@ fn tail_persona_jsonl(
             "persona_id '{persona_id}' is not a valid id token"
         )));
     }
-    let home = std::env::var("HOME")
-        .map_err(|_| CommandError::Internal("HOME unset; no fixtures root".into()))?;
-    let path = std::path::Path::new(&home)
-        .join(".continuum/fixtures")
-        .join(subdir)
+    let path = crate::persona::recorder::fixture_dir(relative_dir)
+        .ok_or_else(|| CommandError::Internal("cannot resolve capture home directory".into()))?
         .join(format!("{persona_id}.jsonl"));
     let body = match std::fs::read_to_string(&path) {
         Ok(b) => b,
@@ -112,7 +109,11 @@ impl ActionCommand for CognitionTrace {
         p: CognitionTraceParams,
     ) -> Result<CognitionTraceResult, CommandError> {
         let limit = p.limit.map(|n| n as usize).unwrap_or(DEFAULT_LIMIT);
-        let records = tail_persona_jsonl("workspace-traces", p.persona_id.as_str(), limit)?;
+        let records = tail_persona_jsonl(
+            super::workspace_capture::FIXTURE_DIR,
+            p.persona_id.as_str(),
+            limit,
+        )?;
         Ok(CognitionTraceResult {
             persona_id: p.persona_id,
             count: records.len() as u32,
@@ -162,7 +163,11 @@ impl ActionCommand for CognitionPrompt {
         p: CognitionPromptParams,
     ) -> Result<CognitionPromptResult, CommandError> {
         let limit = p.limit.map(|n| n as usize).unwrap_or(DEFAULT_LIMIT);
-        let records = tail_persona_jsonl("prompt-captures", p.persona_id.as_str(), limit)?;
+        let records = tail_persona_jsonl(
+            super::prompt_capture::FIXTURE_DIR,
+            p.persona_id.as_str(),
+            limit,
+        )?;
         Ok(CognitionPromptResult {
             persona_id: p.persona_id,
             count: records.len() as u32,
@@ -245,8 +250,15 @@ mod tests {
     // refused, so the command can't read outside the fixtures dir.
     #[test]
     fn rejects_non_id_persona_tokens() {
-        assert!(tail_persona_jsonl("workspace-traces", "../../etc/passwd", 5).is_err());
-        assert!(tail_persona_jsonl("workspace-traces", "a/b", 5).is_err());
+        assert!(tail_persona_jsonl(
+            super::super::workspace_capture::FIXTURE_DIR,
+            "../../etc/passwd",
+            5
+        )
+        .is_err());
+        assert!(
+            tail_persona_jsonl(super::super::workspace_capture::FIXTURE_DIR, "a/b", 5).is_err()
+        );
     }
 
     // what this catches: a missing trace is an empty result, not an error — "no
@@ -254,7 +266,7 @@ mod tests {
     #[test]
     fn missing_trace_is_empty_not_error() {
         let r = tail_persona_jsonl(
-            "workspace-traces",
+            super::super::workspace_capture::FIXTURE_DIR,
             "00000000-0000-0000-0000-000000000000",
             5,
         );

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -443,8 +443,7 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // the total ≤ window.
     let grounding_budget = super::rag_source_faculty::grounding_budget_for(cfg.context_window);
     for g in cfg.grounding_sources {
-        let faculty =
-            RagSourceFaculty::new(cfg.persona_id, g.source, g.policy)
+        let faculty = RagSourceFaculty::new(cfg.persona_id, g.source, g.policy)
             .with_budget(grounding_budget)
             .with_volatile_content(g.volatile_content);
         match g.deferrability {
@@ -522,18 +521,15 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // Verbatim prompt capture (best-effort): the EXACT system prompt + message
     // thread + raw response of every deliberation LLM call → a per-persona JSONL
     // under the same fixtures root as the workspace trace. So "what tokens was she
-    // fed, what did she emit?" is answerable token-for-token. HOME unset → opt-out.
-    if let Ok(dir) = std::env::var("HOME")
-        .map(|h| std::path::Path::new(&h).join(".continuum/fixtures/prompt-captures"))
-    {
-        match super::prompt_capture::JsonlPromptCaptureSink::open(&dir, cfg.persona_id) {
-            Ok(sink) => deliberation = deliberation.with_prompt_capture(Arc::new(sink)),
-            Err(e) => tracing::warn!(
-                persona_id = %cfg.persona_id,
-                error = %e,
-                "prompt capture unavailable; deliberation runs without verbatim capture"
-            ),
-        }
+    // fed, what did she emit?" is answerable token-for-token. Native hosts use
+    // the recorder's shared home discovery even without a shell HOME variable.
+    match super::prompt_capture::JsonlPromptCaptureSink::open_for_persona(cfg.persona_id) {
+        Ok(sink) => deliberation = deliberation.with_prompt_capture(Arc::new(sink)),
+        Err(e) => tracing::warn!(
+            persona_id = %cfg.persona_id,
+            error = %e,
+            "prompt capture unavailable; deliberation runs without verbatim capture"
+        ),
     }
 
     faculties.push(Arc::new(deliberation));
@@ -582,23 +578,16 @@ pub fn build_workspace_cycle(cfg: PersonaBrainConfig) -> WorkspaceCycle {
     // path; THIS is what instruments the path that actually runs. Best-effort —
     // if the fixtures dir can't be opened we log and run with Noop capture; a
     // persona's mind never fails to assemble over an observability hiccup.
-    match std::env::var("HOME")
-        .map(|h| std::path::Path::new(&h).join(".continuum/fixtures/workspace-traces"))
-    {
-        Ok(dir) => {
-            match super::workspace_capture::JsonlWorkspaceCaptureSink::open(&dir, cfg.persona_id) {
-                Ok(sink) => cycle.with_capture(Arc::new(sink)),
-                Err(e) => {
-                    tracing::warn!(
-                        persona_id = %cfg.persona_id,
-                        error = %e,
-                        "workspace trace capture unavailable; running with Noop capture"
-                    );
-                    cycle
-                }
-            }
+    match super::workspace_capture::JsonlWorkspaceCaptureSink::open_for_persona(cfg.persona_id) {
+        Ok(sink) => cycle.with_capture(Arc::new(sink)),
+        Err(e) => {
+            tracing::warn!(
+                persona_id = %cfg.persona_id,
+                error = %e,
+                "workspace trace capture unavailable; running with Noop capture"
+            );
+            cycle
         }
-        Err(_) => cycle, // HOME unset — opt-out, no capture (no warning spam)
     }
 }
 
@@ -765,8 +754,9 @@ async fn drive_create_workspace(
 /// file engine at (a card's checkout), or nothing when she stands in her own
 /// workspace. One truth for the hands, the workspace map she perceives, and the
 /// scope her receipts carry — set at the rooting seam, cleared on restore.
-static ACTING_ROOTS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, ActingPlace>>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+static ACTING_ROOTS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<uuid::Uuid, ActingPlace>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// Where she stands: the checkout root, and the card whose checkout it is when
 /// a held card rooted her (None for a plain workspace_root).
@@ -777,7 +767,11 @@ struct ActingPlace {
 }
 
 pub fn acting_root_of(persona_id: uuid::Uuid) -> Option<std::path::PathBuf> {
-    ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get(&persona_id).map(|p| p.root.clone())  // poisoned lock = read the last state, same policy as every lock in this crate
+    ACTING_ROOTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&persona_id)
+        .map(|p| p.root.clone()) // poisoned lock = read the last state, same policy as every lock in this crate
 }
 
 /// The card her hands are rooted at, if a held card rooted them. Her work
@@ -786,21 +780,36 @@ pub fn acting_root_of(persona_id: uuid::Uuid) -> Option<std::path::PathBuf> {
 /// in #academy — the base room and the agents' coordination room — because the
 /// trigger arrived there; the run room stayed empty for its reviewer).
 pub fn acting_card_of(persona_id: uuid::Uuid) -> Option<uuid::Uuid> {
-    ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get(&persona_id).and_then(|p| p.card)  // poisoned lock = read the last state, same policy as every lock in this crate
+    ACTING_ROOTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&persona_id)
+        .and_then(|p| p.card) // poisoned lock = read the last state, same policy as every lock in this crate
 }
 
 fn note_acting_card(persona_id: uuid::Uuid, card: uuid::Uuid) {
-    if let Some(place) = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()).get_mut(&persona_id) {  // poisoned lock = read the last state, same policy as every lock in this crate
+    if let Some(place) = ACTING_ROOTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get_mut(&persona_id)
+    {
+        // poisoned lock = read the last state, same policy as every lock in this crate
         place.card = Some(card);
     }
 }
 
 fn note_acting_root(persona_id: uuid::Uuid, root: Option<std::path::PathBuf>) {
     {
-        let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner());  // poisoned lock = read the last state, same policy as every lock in this crate
+        let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
         match root {
             Some(r) => {
-                map.insert(persona_id, ActingPlace { root: r, card: None });
+                map.insert(
+                    persona_id,
+                    ActingPlace {
+                        root: r,
+                        card: None,
+                    },
+                );
             }
             None => {
                 map.remove(&persona_id);
@@ -1370,12 +1379,17 @@ impl OwnSpeechPersisted {
     }
 }
 
-fn volatile_path(persona_id: Uuid) -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
-    std::path::PathBuf::from(home)
+fn volatile_path(persona_id: Uuid) -> std::io::Result<std::path::PathBuf> {
+    let home = crate::paths::home_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot resolve persistent home directory",
+        )
+    })?;
+    Ok(home
         .join(".continuum/personas")
         .join(persona_id.to_string())
-        .join("volatile.json")
+        .join("volatile.json"))
 }
 
 /// Persist the volatile tier — atomic tmp+rename so a crash mid-write never
@@ -1389,8 +1403,8 @@ fn save_volatile(persona_id: Uuid, wm: &super::working_memory::WorkingMemory) {
             crate::identity::PeerId::from_uuid(persona_id),
         )),
     };
-    let path = volatile_path(persona_id);
     let write = || -> std::io::Result<()> {
+        let path = volatile_path(persona_id)?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }
@@ -1408,7 +1422,13 @@ fn save_volatile(persona_id: Uuid, wm: &super::working_memory::WorkingMemory) {
 /// return None LOUDLY (a mind-file that fails to parse must never be silently
 /// ignored twice — the warn is the operator's cue to look).
 fn load_volatile(persona_id: Uuid) -> Option<PersistedVolatile> {
-    let path = volatile_path(persona_id);
+    let path = match volatile_path(persona_id) {
+        Ok(path) => path,
+        Err(error) => {
+            tracing::warn!(%persona_id, %error, "volatile-tier root unavailable — previous memory could not be loaded");
+            return None;
+        }
+    };
     let bytes = std::fs::read(&path).ok()?;
     match serde_json::from_slice(&bytes) {
         Ok(p) => Some(p),
@@ -1432,6 +1452,38 @@ mod tests {
     use crate::cognition::workspace::Decision;
     use crate::persona::engram::{ChatMessageRef, Engram, EngramKind, EngramOrigin, TrustState};
     use crate::persona::recall_metadata::{RecallMetadata, RecallMetadataRegistry};
+
+    // What this catches (f098571b): a native launch must restore the same durable
+    // working memory it saved, rather than start a second history under CWD.
+    #[test]
+    fn native_home_volatile_checkpoint_preserves_the_action_receipt() {
+        let home = tempfile::tempdir().unwrap();
+        let _native = crate::paths::NativeHomeOverride::install(home.path());
+        let persona = Uuid::new_v4();
+        let memory = super::super::working_memory::WorkingMemory::new(8);
+        let receipt = "review complete: the caller keeps its room membership";
+        memory.record_receipt(receipt);
+        save_volatile(persona, &memory);
+        assert_eq!(
+            volatile_path(persona).unwrap(),
+            home.path()
+                .join(".continuum/personas")
+                .join(persona.to_string())
+                .join("volatile.json")
+        );
+        let saved = load_volatile(persona).expect("read the native checkpoint");
+        assert!(
+            saved.wm.last_action.is_some(),
+            "the fixture must carry real work"
+        );
+        assert_eq!(saved.wm.last_action, memory.snapshot().last_action);
+        let resumed = super::super::working_memory::WorkingMemory::new(8);
+        resumed.restore(saved.wm);
+        assert_eq!(
+            resumed.snapshot().last_action,
+            memory.snapshot().last_action
+        );
+    }
 
     fn seed_admission(now_ms: u64) -> Arc<AdmissionState> {
         let recall_meta = Arc::new(RecallMetadataRegistry::new());

--- a/core/continuum-core/src/cognition/prompt_capture.rs
+++ b/core/continuum-core/src/cognition/prompt_capture.rs
@@ -28,6 +28,8 @@ use crate::ai::types::{ChatMessage, TextGenerationResponse};
 /// even offered?" because the tools param was the one request axis not captured.
 const SCHEMA_VERSION: u32 = 3;
 
+pub(crate) const FIXTURE_DIR: &str = ".continuum/fixtures/prompt-captures";
+
 /// Records the verbatim request/response of one deliberation LLM call. A `None`
 /// sink (the default) means no capture — zero hot-path cost.
 pub trait PromptCaptureSink: Send + Sync {
@@ -82,6 +84,17 @@ pub struct JsonlPromptCaptureSink {
 }
 
 impl JsonlPromptCaptureSink {
+    /// Use the same native-aware fixture root as introspection and replay.
+    pub(crate) fn open_for_persona(persona_id: Uuid) -> std::io::Result<Self> {
+        let dir = crate::persona::recorder::fixture_dir(FIXTURE_DIR).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot resolve capture home directory",
+            )
+        })?;
+        Self::open(&dir, persona_id)
+    }
+
     /// Open (create + append) the per-persona capture file under `dir`. Errors
     /// only on filesystem failure; the caller degrades to no capture (never fails
     /// persona spawn).

--- a/core/continuum-core/src/cognition/replay.rs
+++ b/core/continuum-core/src/cognition/replay.rs
@@ -39,9 +39,7 @@ use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx};
 /// Where the live cycle writes its per-persona workspace traces (mirror of
 /// `persona_workspace`'s capture wiring). The replay reads the SAME files.
 fn traces_dir() -> Option<std::path::PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .map(|h| std::path::Path::new(&h).join(".continuum/fixtures/workspace-traces"))
+    crate::persona::recorder::fixture_dir(super::workspace_capture::FIXTURE_DIR)
 }
 
 /// One captured bid from the assembled `context` (the broadcast the decider saw).
@@ -255,7 +253,7 @@ fn resolve_burst(
     }
 
     let dir = traces_dir()
-        .ok_or_else(|| CommandError::Invalid("HOME unset — cannot locate workspace traces; pass `world_state` to replay against a supplied burst".into()))?;
+        .ok_or_else(|| CommandError::Invalid("cannot resolve capture home directory; pass `world_state` to replay against a supplied burst".into()))?;
     let path = dir.join(format!("{persona_id}.jsonl"));
     let raw = std::fs::read_to_string(&path).map_err(|e| {
         CommandError::Invalid(format!(
@@ -454,6 +452,108 @@ crate::register_stateless_command!(CognitionReplay);
 mod tests {
     use super::*;
 
+    // What this catches (f098571b): the HOME-absent launch disabled both live
+    // writers and made both inspection/replay readers look in a different root.
+    // Use the actual sink constructors and readers with the existing isolated
+    // native-home seam, not hand-authored JSON or process environment mutation.
+    #[test]
+    fn native_home_capture_round_trips_through_inspection_and_replay() {
+        use crate::ai::types::{ChatMessage, FinishReason, TextGenerationResponse, UsageMetrics};
+        use crate::cognition::prompt_capture::{JsonlPromptCaptureSink, PromptCaptureSink};
+        use crate::cognition::workspace::{WorkspaceCaptureSink, WorkspaceTrace};
+        use crate::cognition::workspace_capture::JsonlWorkspaceCaptureSink;
+
+        let home = tempfile::tempdir().unwrap();
+        let _native = crate::paths::NativeHomeOverride::install(home.path());
+        let persona = Uuid::new_v4();
+        let room = Uuid::new_v4();
+        let request = "Review the subscribed-room change and report its actual receipt.";
+        let grounding = "The ongoing review belongs to this room.";
+        let bid = Contribution::context(FacultyId::Recall, grounding, 0.8, "fixture provenance");
+        let trace = WorkspaceTrace {
+            world_state: request.into(),
+            room_id: room,
+            bids: vec![bid.clone()],
+            context_broadcast: vec![bid.clone()],
+            broadcast: vec![bid],
+            decision: None,
+            timings: Vec::new(),
+        };
+        let workspace = JsonlWorkspaceCaptureSink::open_for_persona(persona).unwrap();
+        workspace.record(&trace);
+        drop(workspace);
+
+        let response = TextGenerationResponse {
+            text: "The source review is complete.".into(),
+            finish_reason: FinishReason::Stop,
+            model: "fixture-model".into(),
+            provider: "fixture".into(),
+            usage: UsageMetrics::default(),
+            response_time_ms: 1,
+            request_id: "capture-roundtrip".into(),
+            content: None,
+            tool_calls: None,
+            reasoning: None,
+            routing: None,
+            error: None,
+            timing: None,
+        };
+        let prompt = JsonlPromptCaptureSink::open_for_persona(persona).unwrap();
+        prompt.record(
+            persona,
+            room,
+            "stimulus",
+            0,
+            grounding,
+            &[ChatMessage::text("user", request)],
+            &[],
+            &response,
+        );
+        drop(prompt);
+
+        let persona_text = persona.to_string();
+        for (relative, field, expected) in [
+            (
+                super::super::workspace_capture::FIXTURE_DIR,
+                "world_state",
+                request,
+            ),
+            (
+                super::super::prompt_capture::FIXTURE_DIR,
+                "system",
+                grounding,
+            ),
+        ] {
+            assert!(home
+                .path()
+                .join(relative)
+                .join(format!("{persona}.jsonl"))
+                .is_file());
+            let rows =
+                super::super::introspect_commands::tail_persona_jsonl(relative, &persona_text, 1)
+                    .unwrap();
+            assert_eq!(rows.len(), 1);
+            let row: serde_json::Value = serde_json::from_str(&rows[0]).unwrap();
+            assert_eq!(row[field], expected);
+            assert_eq!(row["room_id"], room.to_string());
+        }
+        let restored = resolve_burst(
+            &CognitionReplayParams {
+                persona_id: persona_text.into(),
+                faculty: None,
+                world_state: None,
+                turn: None,
+                room_id: None,
+            },
+            &persona,
+        )
+        .unwrap();
+        assert_eq!(restored.world_state, request);
+        assert_eq!(restored.room, room.to_string());
+        assert_eq!(restored.broadcast.len(), 1);
+        assert_eq!(restored.broadcast[0].content, grounding);
+    }
+
     // what this catches: the burst resolver must FAIL LOUD (never an empty burst)
     // when neither a supplied world_state nor a readable capture exists — the
     // no-fallback contract for the factory's input step.
@@ -494,7 +594,10 @@ mod tests {
         assert_eq!(b.source, "supplied");
         // #425: a replay with no named room MINTS a real activity — never nil.
         let minted = Uuid::parse_str(&b.room).expect("room is a real uuid");
-        assert!(!minted.is_nil(), "an unnamed replay room is minted, not nil");
+        assert!(
+            !minted.is_nil(),
+            "an unnamed replay room is minted, not nil"
+        );
         // A bare supplied burst carries NO broadcast — this is the invariant the
         // run() guard relies on to refuse a blind deliberation replay.
         assert!(

--- a/core/continuum-core/src/cognition/working_set.rs
+++ b/core/continuum-core/src/cognition/working_set.rs
@@ -76,17 +76,27 @@ pub fn global() -> WorkingSetRegistry {
 /// Where one mind's measured demand lives across restarts — beside the rest of
 /// her durable state, because it IS her property and should travel with her.
 /// Mirrors `persona_workspace::volatile_path`'s layout exactly.
-fn personas_root() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into()); // JUSTIFIED unwrap_or_else: a HOME-less process is a real environment, not an unknown quantity; "." keeps the path RELATIVE so a demand file lands somewhere inspectable instead of at the filesystem root
-    std::path::PathBuf::from(home).join(".continuum/personas")
+fn personas_root() -> std::io::Result<std::path::PathBuf> {
+    crate::paths::home_dir()
+        .map(|home| home.join(".continuum/personas"))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot resolve persistent home directory",
+            )
+        })
 }
 
-fn demand_path(persona: Uuid) -> std::path::PathBuf {
-    personas_root().join(persona.to_string()).join("working-set.json")
+fn demand_path(persona: Uuid) -> std::io::Result<std::path::PathBuf> {
+    Ok(personas_root()?
+        .join(persona.to_string())
+        .join("working-set.json"))
 }
 
-fn emission_path(persona: Uuid) -> std::path::PathBuf {
-    personas_root().join(persona.to_string()).join("emission.json")
+fn emission_path(persona: Uuid) -> std::io::Result<std::path::PathBuf> {
+    Ok(personas_root()?
+        .join(persona.to_string())
+        .join("emission.json"))
 }
 
 /// One mind's observed demand.
@@ -205,14 +215,26 @@ impl WorkingSetRegistry {
     /// so it records at double (a floor on true demand, and the growth path — see
     /// [`PersonaEmission::peak_tokens`]). Zero-token completions are the empty-
     /// completion fault's territory, not a data point to drag the peak with.
-    pub(crate) fn record_emission(&self, persona: Uuid, output_tokens: u32, hit_cap: bool, now_ms: u64) {
+    pub(crate) fn record_emission(
+        &self,
+        persona: Uuid,
+        output_tokens: u32,
+        hit_cap: bool,
+        now_ms: u64,
+    ) {
         if output_tokens == 0 {
             return;
         }
         let updated = self.record_emission_in_memory(persona, output_tokens, hit_cap, now_ms);
         // Same persistence contract as demand: every observation, atomic, best-effort
         // — a restart is a pause, and a mind must not re-earn its reply size per boot.
-        let path = emission_path(persona);
+        let path = match emission_path(persona) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!(persona_id = %persona, %error, "emission root unavailable — measurement remains in memory");
+                return;
+            }
+        };
         let write = || -> std::io::Result<()> {
             if let Some(dir) = path.parent() {
                 std::fs::create_dir_all(dir)?;
@@ -268,7 +290,13 @@ impl WorkingSetRegistry {
     /// Atomic tmp+rename so a crash mid-write never leaves a torn file that would
     /// fail to parse and silently wake her at the cold-start window.
     fn save(persona: Uuid, demand: &PersonaDemand) {
-        let path = demand_path(persona);
+        let path = match demand_path(persona) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!(persona_id = %persona, %error, "working-set root unavailable — measurement remains in memory");
+                return;
+            }
+        };
         let write = || -> std::io::Result<()> {
             if let Some(dir) = path.parent() {
                 std::fs::create_dir_all(dir)?;
@@ -289,7 +317,13 @@ impl WorkingSetRegistry {
     /// earned rather than the cold-start floor. Unreadable/absent = no observation
     /// (honest), never an invented number.
     pub fn rehydrate(&self, persona: Uuid) {
-        let path = demand_path(persona);
+        let path = match demand_path(persona) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!(persona_id = %persona, %error, "working-set root unavailable — prior demand could not be loaded");
+                return;
+            }
+        };
         let Ok(bytes) = std::fs::read(&path) else {
             return;
         };
@@ -312,7 +346,7 @@ impl WorkingSetRegistry {
         }
         // The emission twin rides the same rehydration pass: absent/unreadable stays
         // silent (the reserve falls back to the cold-start share — honest, never invented).
-        if let Ok(bytes) = std::fs::read(emission_path(persona)) {
+        if let Ok(bytes) = emission_path(persona).and_then(std::fs::read) {
             match serde_json::from_slice::<PersonaEmission>(&bytes) {
                 Ok(e) if e.peak_tokens > 0 => {
                     self.emitted.insert(persona, e);
@@ -349,7 +383,14 @@ impl WorkingSetRegistry {
     /// Unreadable or absent files stay silent — the same honesty `rehydrate` keeps. A
     /// ghost persona dir with no `working-set.json` contributes nothing rather than a zero.
     pub fn rehydrate_all(&self) -> usize {
-        let Ok(entries) = std::fs::read_dir(personas_root()) else {
+        let root = match personas_root() {
+            Ok(root) => root,
+            Err(error) => {
+                tracing::warn!(%error, "working-set root unavailable — persisted demand could not be enumerated");
+                return 0;
+            }
+        };
+        let Ok(entries) = std::fs::read_dir(root) else {
             return 0; // no personas root yet — a fresh install, not an error
         };
         let mut adopted = 0;
@@ -470,7 +511,10 @@ mod tests {
         assert_eq!(reg.emission_of(p(1)).map(|e| e.peak_tokens), Some(2_500));
         reg.record_emission_in_memory(p(1), 3_000, true, 2_000);
         let e = reg.emission_of(p(1)).expect("observed");
-        assert_eq!(e.peak_tokens, 6_000, "a Length stop is a floor, not a measurement");
+        assert_eq!(
+            e.peak_tokens, 6_000,
+            "a Length stop is a floor, not a measurement"
+        );
         assert_eq!(e.turns, 2);
         // and, as on the demand side, a later small reply never lowers the peak
         reg.record_emission_in_memory(p(1), 40, false, 3_000);
@@ -485,15 +529,15 @@ mod tests {
     // restart is a PAUSE, not a death.
     #[test]
     fn a_measured_peak_survives_a_restart_so_a_reboot_is_a_pause_not_a_demotion() {
-        let home = std::env::temp_dir().join(format!("ws-restart-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&home).expect("tmp home");
-        // SAFETY: single-threaded test scope; HOME is restored below.
-        let prior = std::env::var("HOME").ok();
-        std::env::set_var("HOME", &home);
+        let home = tempfile::tempdir().expect("tmp home");
+        // HOME is absent at the shared policy seam; native discovery points at
+        // this thread's isolated home. Never mutate the parallel suite's env.
+        let _native = crate::paths::NativeHomeOverride::install(home.path());
 
         let persona = p(9);
         let before = WorkingSetRegistry::new();
         before.record(persona, 24_126, 1_000);
+        before.record_emission(persona, 321, false, 1_001);
         assert_eq!(before.ceiling(), Some(24_126));
 
         // A fresh process: new registry, nothing in memory.
@@ -503,18 +547,20 @@ mod tests {
             None,
             "a new registry starts genuinely empty"
         );
-        after.rehydrate(persona);
+        assert_eq!(after.rehydrate_all(), 1);
         assert_eq!(
             after.ceiling(),
             Some(24_126),
             "her measured window must survive the restart, not be re-earned turn by turn"
         );
 
-        match prior {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
-        }
-        let _ = std::fs::remove_dir_all(&home);
+        assert_eq!(after.emission_of(persona), before.emission_of(persona));
+        assert!(home
+            .path()
+            .join(".continuum/personas")
+            .join(persona.to_string())
+            .join("working-set.json")
+            .is_file());
     }
 
     // what this catches: an invented number standing in for missing data. Before any

--- a/core/continuum-core/src/cognition/workspace_capture.rs
+++ b/core/continuum-core/src/cognition/workspace_capture.rs
@@ -32,6 +32,8 @@ use super::workspace::{
 /// v2 added per-faculty `timings` (the speed axis / dashboard feed).
 const SCHEMA_VERSION: u32 = 2;
 
+pub(crate) const FIXTURE_DIR: &str = ".continuum/fixtures/workspace-traces";
+
 /// One faculty's bid, projected to a serializable shape. The internal
 /// [`Contribution`] is intentionally NOT `Serialize` (it's a live cognition
 /// type) — we own the wire format here so the capture schema can evolve
@@ -125,6 +127,17 @@ pub struct JsonlWorkspaceCaptureSink {
 }
 
 impl JsonlWorkspaceCaptureSink {
+    /// Use the same native-aware fixture root as introspection and replay.
+    pub(crate) fn open_for_persona(persona_id: Uuid) -> std::io::Result<Self> {
+        let dir = crate::persona::recorder::fixture_dir(FIXTURE_DIR).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "cannot resolve capture home directory",
+            )
+        })?;
+        Self::open(&dir, persona_id)
+    }
+
     /// Open (create + append) the per-persona trace file under `dir`, creating
     /// `dir` if needed. Returns an error only on filesystem failure; the caller
     /// degrades to `Noop` capture on error (never fails persona spawn).

--- a/core/continuum-core/src/paths/mod.rs
+++ b/core/continuum-core/src/paths/mod.rs
@@ -21,3 +21,75 @@
 //! - (future) `nvme_pool` — LoRA Genome Paging tier
 
 pub mod docker;
+
+/// Preserve a nonempty HOME override, then use the OS-native home discovery.
+/// Native Windows embeddings need not inherit a Unix shell environment. Never
+/// substitute the checkout/current directory for missing persistent storage.
+pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(native) = TEST_NATIVE_HOME.with(|root| root.borrow().clone()) {
+        return resolve_home(None, || Some(native));
+    }
+    resolve_home(std::env::var_os("HOME").map(Into::into), dirs::home_dir)
+}
+
+fn resolve_home(
+    explicit: Option<std::path::PathBuf>,
+    native: impl FnOnce() -> Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    explicit
+        .filter(|path| !path.as_os_str().is_empty())
+        .or_else(native)
+}
+
+#[cfg(test)]
+thread_local! {
+    // The recorder's existing per-thread fixture-root seam, shared with the
+    // other readers/writers using this policy. Models HOME absence and a native
+    // home without mutating process-global environment or touching real data.
+    static TEST_NATIVE_HOME: std::cell::RefCell<Option<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) struct NativeHomeOverride(Option<std::path::PathBuf>);
+
+#[cfg(test)]
+impl NativeHomeOverride {
+    pub(crate) fn install(path: &std::path::Path) -> Self {
+        Self(TEST_NATIVE_HOME.with(|root| root.replace(Some(path.to_path_buf()))))
+    }
+}
+
+#[cfg(test)]
+impl Drop for NativeHomeOverride {
+    fn drop(&mut self) {
+        TEST_NATIVE_HOME.with(|root| *root.borrow_mut() = self.0.take());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // What this catches (f098571b): native fallback must not replace an explicit
+    // HOME override; unresolved storage must not become the current directory.
+    #[test]
+    fn explicit_home_wins_and_missing_native_home_stays_unavailable() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_home(Some(dir.path().to_path_buf()), || panic!(
+                "HOME takes precedence"
+            )),
+            Some(dir.path().to_path_buf()),
+        );
+        let native = dir.path().join("native-home");
+        assert_eq!(
+            resolve_home(Some(std::path::PathBuf::new()), || Some(native.clone())),
+            Some(native),
+            "an empty HOME is absent, never a current-directory storage root",
+        );
+        assert_eq!(resolve_home(Some(std::path::PathBuf::new()), || None), None);
+        assert_eq!(resolve_home(None, || None), None);
+    }
+}

--- a/core/continuum-core/src/persona/recorder.rs
+++ b/core/continuum-core/src/persona/recorder.rs
@@ -378,7 +378,7 @@ fn persist_turn_payload(input: &RespondInput, payload: serde_json::Value) {
     }
     let dir = match fixture_dir(RESPOND_FIXTURE_DIR) {
         Some(d) => d,
-        None => return, // HOME unset; treat as opted-out, no warning spam
+        None => return, // No home directory is available to this embedding.
     };
     let fname = filename_for(&input.persona.display_name, input.message_id);
     persist_json_payload(&dir, &fname, &payload);
@@ -432,8 +432,6 @@ fn persist_json_payload<T: Serialize>(dir: &Path, fname: &str, payload: &T) {
 // process environment is never touched.
 #[cfg(test)]
 thread_local! {
-    static TEST_FIXTURE_ROOT: std::cell::RefCell<Option<PathBuf>> =
-        const { std::cell::RefCell::new(None) };
     static TEST_DISABLED: std::cell::RefCell<Option<bool>> =
         const { std::cell::RefCell::new(None) };
 }
@@ -448,14 +446,36 @@ fn disabled() -> bool {
         .unwrap_or(false)
 }
 
-fn fixture_dir(relative: &str) -> Option<PathBuf> {
-    #[cfg(test)]
-    if let Some(root) = TEST_FIXTURE_ROOT.with(|r| r.borrow().clone()) {
-        return Some(root.join(relative));
+/// Shared fixture policy for live capture and its readers. Explicit HOME keeps
+/// its existing override semantics; native hosts need not inherit a shell HOME.
+pub(crate) fn fixture_dir(relative: &str) -> Option<PathBuf> {
+    crate::paths::home_dir().map(|h| h.join(relative))
+}
+
+/// Reuses the recorder's per-thread fixture isolation for capture/read tests.
+/// No process-wide HOME or disable flag is changed, including during unwinding.
+#[cfg(test)]
+pub(crate) struct EnvRestore {
+    _home: crate::paths::NativeHomeOverride,
+    disabled: Option<bool>,
+}
+
+#[cfg(test)]
+impl EnvRestore {
+    pub(crate) fn install(home: &Path, disabled: Option<&str>) -> Self {
+        Self {
+            _home: crate::paths::NativeHomeOverride::install(home),
+            disabled: TEST_DISABLED
+                .with(|d| d.replace(Some(matches!(disabled, Some("1" | "true" | "TRUE"))))),
+        }
     }
-    std::env::var("HOME")
-        .ok()
-        .map(|h| PathBuf::from(h).join(relative))
+}
+
+#[cfg(test)]
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        TEST_DISABLED.with(|d| *d.borrow_mut() = self.disabled.take());
+    }
 }
 
 /// Filename: `<persona>-<msgid_prefix>-<ts>-rust.json`. The `-rust`
@@ -625,32 +645,6 @@ mod tests {
         PersonaTurnFrame::from_inbox_frame(frame)
             .replay_record()
             .expect("fixture frame is non-empty")
-    }
-
-    /// Per-thread fixture-root override (#7): points THIS thread's recorder at
-    /// the test's tempdir (plus an optional disable flag) without touching the
-    /// process environment. The old HOME-swap under a private lock only
-    /// serialized recorder tests against each other — every other parallel
-    /// test reading HOME, or writing a fixture mid-swap, raced it. Same
-    /// `install(path, disabled)` shape as the env version it replaces.
-    struct EnvRestore;
-
-    impl EnvRestore {
-        fn install(home: &std::path::Path, disabled: Option<&str>) -> Self {
-            TEST_FIXTURE_ROOT.with(|r| *r.borrow_mut() = Some(home.to_path_buf()));
-            // None mirrors the old remove_var: an inherited process-level
-            // disable must not leak into a test that expects writes.
-            TEST_DISABLED
-                .with(|d| *d.borrow_mut() = Some(matches!(disabled, Some("1" | "true" | "TRUE"))));
-            Self
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            TEST_FIXTURE_ROOT.with(|r| *r.borrow_mut() = None);
-            TEST_DISABLED.with(|d| *d.borrow_mut() = None);
-        }
     }
 
     /// What this catches: filename includes persona name (whitespace
@@ -829,8 +823,12 @@ mod tests {
             .map(|e| e.expect("fixture entry").path())
             .collect();
         assert_eq!(entries.len(), 1);
-        assert!(entries[0].to_string_lossy().contains("/frame-"));
-        assert!(entries[0].to_string_lossy().ends_with("-rust.json"));
+        let filename = entries[0]
+            .file_name()
+            .expect("fixture filename")
+            .to_string_lossy();
+        assert!(filename.starts_with("frame-"));
+        assert!(filename.ends_with("-rust.json"));
 
         let body = std::fs::read_to_string(&entries[0]).expect("fixture json readable");
         let json: serde_json::Value = serde_json::from_str(&body).expect("fixture json parses");


### PR DESCRIPTION
Native Windows launches can have no `HOME` environment variable. Capture writers then stop recording, while recent working-memory checkpoints can silently move into the process's checkout directory. A reboot consequently loses access to the previous checkpoint and prompt inspection cannot show the submitted calls.

Use the shared home resolver for prompt/workspace capture, inspection/replay readers, volatile checkpoints and measured working sets. A nonempty explicit `HOME` still wins; otherwise resolve the native OS home. Missing storage remains an explicit error rather than falling back to the current directory. Preserve the existing Persona UUID directory layout.

Validation: native Windows regressions pass for missing/empty HOME, writer-to-reader capture, volatile action-receipt restoration, retained working-set measurements and recorder filenames. The expanded native library suite passes 124/124; the combined CLI suite passes 37/37. Ordinary full library/CLI/tests Clippy passes. Strict Clippy still fails on repository debt (780 unique diagnostics in this run); exact source mapping finds no diagnostics on this PR's changed lines. The eleven diagnostics in its files point to unchanged baseline code. Independent source review and all CI checks pass.
Before deployment, preserve both divergent checkpoint origins and carry the verified current-life checkpoint through the ordinary shutdown/handoff boundary. This change does not import arbitrary checkout-relative files or merge independent memory histories automatically.

AIRC card: f098571b-fcdc-4f28-a953-2630cf4056b3.
