### PR TITLE
fix(cognition): deliver teammate input during active work

### DIFF
--- a/core/continuum-core/src/ai/heuristic_adapter.rs
+++ b/core/continuum-core/src/ai/heuristic_adapter.rs
@@ -95,6 +95,10 @@ const CHARS_PER_TOKEN: usize = 4;
 /// needs a deterministic adapter with controllable timing.
 #[derive(Debug, Default)]
 pub struct HeuristicInferenceAdapter {
+    /// Optional typed response script and exact request observer. These extend
+    /// the shared fixture for real act-to-observe integration tests.
+    responses: Option<std::sync::Mutex<std::collections::VecDeque<TextGenerationResponse>>>,
+    request_recorder: Option<std::sync::Arc<std::sync::Mutex<Vec<TextGenerationRequest>>>>,
     /// Sleep injected before every `generate_text` returns. 0 (default)
     /// is the production-cheap shape. Setting this is useful for
     /// latency-floor regression tests + simulating slow-network
@@ -128,6 +132,18 @@ pub struct HeuristicInferenceAdapter {
 }
 
 impl HeuristicInferenceAdapter {
+    pub fn with_responses(mut self, responses: Vec<TextGenerationResponse>) -> Self {
+        self.responses = Some(std::sync::Mutex::new(responses.into()));
+        self
+    }
+
+    pub fn with_request_recorder(
+        mut self,
+        recorder: std::sync::Arc<std::sync::Mutex<Vec<TextGenerationRequest>>>,
+    ) -> Self {
+        self.request_recorder = Some(recorder);
+        self
+    }
     /// Zero-config constructor — what production code uses.
     pub fn new() -> Self {
         Self::default()
@@ -390,6 +406,12 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
         if let Some(c) = &self.generate_observer {
             c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         }
+        if let Some(recorder) = &self.request_recorder {
+            recorder
+                .lock()
+                .map_err(|_| "request recorder lock poisoned".to_string())?
+                .push(request.clone());
+        }
         // Inject real wall-clock if the caller configured a delay. Used
         // by latency-floor regression tests to verify the substrate's
         // turn_latency metric reflects actual elapsed time, and by
@@ -397,6 +419,13 @@ impl AIProviderAdapter for HeuristicInferenceAdapter {
         // `new()` with delay=0 and pay zero overhead.
         if self.inject_delay_ms > 0 {
             tokio::time::sleep(std::time::Duration::from_millis(self.inject_delay_ms)).await;
+        }
+        if let Some(responses) = &self.responses {
+            return responses
+                .lock()
+                .map_err(|_| "heuristic adapter response script lock poisoned".to_string())?
+                .pop_front()
+                .ok_or_else(|| "heuristic adapter response script exhausted".to_string());
         }
         let model = request
             .model

--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -1282,43 +1282,44 @@ mod tests {
                 .iter()
                 .any(|edge| edge.target == first_act.id
                     && edge.kind == crate::persona::engram_graph::EdgeKind::CausedBy));
-            let requests = recorded.lock().unwrap();
-            assert_eq!(requests.len(), 3);
-            for (index, request) in requests.iter().enumerate() {
-                assert_eq!(request.room_id.as_deref(), Some(room.to_string().as_str()));
-                let text = request
-                    .messages
-                    .iter()
-                    .map(|m| m.content_text())
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                assert!(text.contains(task));
-                if framing.self_initiated {
-                    assert!(!text.contains("This message names you"),
-                    "a priority input must not rewrite the original self-turn's addressing fact");
-                }
-                assert_eq!(
-                    text.matches(&later_message.text).count(),
-                    usize::from(index > 1)
-                );
-                for message in &messages {
-                    assert_eq!(text.matches(&message.text).count(), usize::from(index > 0));
+            {
+                let requests = recorded.lock().unwrap();
+                assert_eq!(requests.len(), 3);
+                for (index, request) in requests.iter().enumerate() {
+                    assert_eq!(request.room_id.as_deref(), Some(room.to_string().as_str()));
+                    let text = request
+                        .messages
+                        .iter()
+                        .map(|m| m.content_text())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    assert!(text.contains(task));
+                    if framing.self_initiated {
+                        assert!(!text.contains("This message names you"),
+                        "a priority input must not rewrite the original self-turn's addressing fact");
+                    }
+                    assert_eq!(
+                        text.matches(&later_message.text).count(),
+                        usize::from(index > 1)
+                    );
+                    for message in &messages {
+                        assert_eq!(text.matches(&message.text).count(), usize::from(index > 0));
+                        if index > 0 {
+                            assert!(text.contains(&format!(
+                                "room {}; peer {}; event {}",
+                                message.room_id, colleague, message.event_id
+                            )));
+                        }
+                    }
                     if index > 0 {
-                        assert!(text.contains(&format!(
-                            "room {}; peer {}; event {}",
-                            message.room_id, colleague, message.event_id
-                        )));
+                        assert!(text.contains(if index == 1 {
+                            "FIRST_COMPLETE_TOOL_RESULT"
+                        } else {
+                            "SECOND_COMPLETE_TOOL_RESULT"
+                        }));
                     }
                 }
-                if index > 0 {
-                    assert!(text.contains(if index == 1 {
-                        "FIRST_COMPLETE_TOOL_RESULT"
-                    } else {
-                        "SECOND_COMPLETE_TOOL_RESULT"
-                    }));
-                }
             }
-            drop(requests);
             // Perception did not steal these inputs from later attention in their own
             // rooms. Each retained source is returned once by the ordinary driver.
             assert!(

--- a/core/continuum-core/src/cognition/act_observe/mod.rs
+++ b/core/continuum-core/src/cognition/act_observe/mod.rs
@@ -41,7 +41,7 @@ mod apply;
 pub use apply::{apply_act, ActChain};
 
 mod settle;
-pub use settle::{drive_to_settle, settle_step};
+pub use settle::{drive_to_settle, drive_to_settle_with_input, settle_step};
 
 #[cfg(test)]
 mod tests {
@@ -113,7 +113,7 @@ mod tests {
                     tool_use_id: c.id.clone(),
                     content: self.result_content.clone(),
                     is_error: None,
-                spill_handle: None,
+                    spill_handle: None,
                 })
                 .collect();
             Ok(NativeBatchOutcome {
@@ -353,8 +353,10 @@ mod tests {
 
         let edges = adm.engram_neighbors(&second);
         assert!(
-            edges.iter().any(|e| e.target == first
-                && e.kind == crate::persona::engram_graph::EdgeKind::CausedBy),
+            edges
+                .iter()
+                .any(|e| e.target == first
+                    && e.kind == crate::persona::engram_graph::EdgeKind::CausedBy),
             "the second act must carry a CausedBy edge to its predecessor — \
              the `because` clause as structure, not prose; got {edges:?}"
         );
@@ -389,8 +391,7 @@ mod tests {
 
         // The kickoff / inbound message that caused this turn to happen at all.
         let trigger = Uuid::new_v4();
-        let chain =
-            ActChain::rooted_in(&crate::cognition::workspace::Cause::Stimulus(trigger));
+        let chain = ActChain::rooted_in(&crate::cognition::workspace::Cause::Stimulus(trigger));
 
         acts_of(apply_act(&cycle, &[tool_call()], "start", room, &chain).await);
         let first = chain.prior().expect("first act admitted onto the chain");
@@ -483,7 +484,15 @@ mod tests {
             .with_acting(body(exec.clone(), adm.clone()));
 
         let room = Uuid::new_v4();
-        let acts = match apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await {
+        let acts = match apply_act(
+            &cycle,
+            &[tool_call()],
+            "check the math",
+            room,
+            &ActChain::new(),
+        )
+        .await
+        {
             ActOutcome::Acted { acts } => acts,
             other => panic!("expected Acted, got {other:?}"),
         };
@@ -535,7 +544,14 @@ mod tests {
         let cycle = WorkspaceCycle::new(Vec::new(), Arc::new(SalienceArbiter), 8);
         assert!(
             matches!(
-                apply_act(&cycle, &[tool_call()], "try", Uuid::new_v4(), &ActChain::new()).await,
+                apply_act(
+                    &cycle,
+                    &[tool_call()],
+                    "try",
+                    Uuid::new_v4(),
+                    &ActChain::new()
+                )
+                .await,
                 ActOutcome::NoHands
             ),
             "no hands → NoHands, never a fabricated success"
@@ -552,7 +568,14 @@ mod tests {
             .with_acting(body(Arc::new(FailingExecutor), adm.clone()));
         assert!(
             matches!(
-                apply_act(&cycle, &[tool_call()], "run", Uuid::new_v4(), &ActChain::new()).await,
+                apply_act(
+                    &cycle,
+                    &[tool_call()],
+                    "run",
+                    Uuid::new_v4(),
+                    &ActChain::new()
+                )
+                .await,
                 ActOutcome::ExecutorError { .. }
             ),
             "a batch-level failure surfaces as ExecutorError, distinct from NoHands"
@@ -587,7 +610,8 @@ mod tests {
             &cycle,
             "[eval]\npeer: what is 2+2?",
             8,
-            TurnFraming::ambient(),)
+            TurnFraming::ambient(),
+        )
         .await;
 
         assert_eq!(outcome.acts, 1, "acted exactly once before settling");
@@ -604,7 +628,8 @@ mod tests {
     // too few — a plan, one act, a second plan ended every work turn). Bounded — the
     // budget spends and it settles, so a determined Speak is never trapped in a loop.
     #[tokio::test]
-    async fn a_zero_change_speak_reperceives_up_to_the_narration_budget_when_the_workspace_is_the_deliverable() {
+    async fn a_zero_change_speak_reperceives_up_to_the_narration_budget_when_the_workspace_is_the_deliverable(
+    ) {
         let speaker = CountingSpeaker::new();
         let wm = Arc::new(WorkingMemory::new(8));
         let exec = Arc::new(RecordingExecutor {
@@ -625,7 +650,8 @@ mod tests {
             &cycle,
             "fix the bug in sympy/core/basic.py",
             8,
-            TurnFraming::directed().on_workspace(),)
+            TurnFraming::directed().on_workspace(),
+        )
         .await;
 
         assert_eq!(
@@ -667,12 +693,8 @@ mod tests {
         )
         .with_acting(body_with_wm(exec, admission(), Arc::clone(&wm)));
 
-        let outcome = drive_to_settle(
-            &cycle,
-            "what do you think?",
-            8,
-            TurnFraming::directed(),)
-        .await;
+        let outcome =
+            drive_to_settle(&cycle, "what do you think?", 8, TurnFraming::directed()).await;
 
         assert_eq!(
             speaker.generations(),
@@ -749,7 +771,8 @@ mod tests {
             &cycle,
             "fix the bug",
             20,
-            TurnFraming::ambient().on_workspace(),)
+            TurnFraming::ambient().on_workspace(),
+        )
         .await;
 
         assert_eq!(
@@ -778,12 +801,7 @@ mod tests {
             8,
         )
         .with_acting(body(exec2, admission()));
-        let ambient = drive_to_settle(
-            &cycle2,
-            "look around",
-            20,
-            TurnFraming::ambient(),)
-        .await;
+        let ambient = drive_to_settle(&cycle2, "look around", 20, TurnFraming::ambient()).await;
         assert_eq!(
             ambient.acts, 20,
             "a non-workspace turn reads to the full budget — the gate scopes to \
@@ -818,7 +836,8 @@ mod tests {
             &cycle,
             "fix the bug",
             6,
-            TurnFraming::ambient().on_workspace(),)
+            TurnFraming::ambient().on_workspace(),
+        )
         .await;
         let entries = wm.recent_entries();
         let budget_facts: Vec<_> = entries
@@ -832,7 +851,9 @@ mod tests {
         // guarantee worth pinning is therefore: at settle, working memory
         // holds at least one [act-budget] fact naming the REAL budget number.
         assert!(
-            budget_facts.iter().any(|e| e.text.contains("of 6 acts") || e.text.contains("my 6 acts")),
+            budget_facts
+                .iter()
+                .any(|e| e.text.contains("of 6 acts") || e.text.contains("my 6 acts")),
             "a budget fact naming the real budget must survive to settle; got: {:?}",
             budget_facts.iter().map(|e| &e.text).collect::<Vec<_>>()
         );
@@ -854,8 +875,7 @@ mod tests {
         .with_acting(body2);
         drive_to_settle(&cycle2, "look around", 6, TurnFraming::ambient()).await;
         assert!(
-            !wm2
-                .recent_entries()
+            !wm2.recent_entries()
                 .iter()
                 .any(|e| e.text.contains("[act-budget]")),
             "speech turns owe no stopwatch — the fact is scoped to workspace-deliverable turns"
@@ -876,8 +896,7 @@ mod tests {
         let cycle = WorkspaceCycle::new(vec![Arc::new(AlwaysAct)], Arc::new(SalienceArbiter), 8)
             .with_acting(body(exec.clone(), adm.clone()));
 
-        let outcome =
-            drive_to_settle(&cycle, "go", 2, TurnFraming::ambient()).await;
+        let outcome = drive_to_settle(&cycle, "go", 2, TurnFraming::ambient()).await;
 
         assert_eq!(outcome.acts, 2, "spent exactly the observer's budget");
         assert!(
@@ -910,8 +929,7 @@ mod tests {
 
         // Budget of 20 acts, but she loops on the identical call — the backstop must fire long
         // before, at 4 acts (3 consecutive identical repeats + the first).
-        let outcome =
-            drive_to_settle(&cycle, "go", 20, TurnFraming::ambient()).await;
+        let outcome = drive_to_settle(&cycle, "go", 20, TurnFraming::ambient()).await;
 
         assert_eq!(
             outcome.acts, 4,
@@ -945,7 +963,8 @@ mod tests {
             false,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(
             matches!(deferred, SettleStep::WouldAct { .. }),
@@ -962,7 +981,8 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(
             matches!(ran, SettleStep::Acted { .. }),
@@ -980,12 +1000,31 @@ mod tests {
     /// Models hands that probe the world and learn something new each reach.
     struct ScriptedExecutor {
         results: Mutex<std::collections::VecDeque<String>>,
+        input: Mutex<
+            std::collections::VecDeque<(
+                crate::persona::scripted_conversation::ScriptedConversationFeed,
+                Vec<crate::persona::service_loop::IncomingMessage>,
+            )>,
+        >,
+        rooms: Mutex<Vec<Uuid>>,
+        pending_persona: Mutex<Option<Uuid>>,
     }
     impl ScriptedExecutor {
         fn new(results: impl IntoIterator<Item = &'static str>) -> Self {
             Self {
                 results: Mutex::new(results.into_iter().map(String::from).collect()),
+                input: Mutex::new(std::collections::VecDeque::new()),
+                rooms: Mutex::new(Vec::new()),
+                pending_persona: Mutex::new(None),
             }
+        }
+        fn with_incoming(
+            self,
+            feed: crate::persona::scripted_conversation::ScriptedConversationFeed,
+            messages: Vec<crate::persona::service_loop::IncomingMessage>,
+        ) -> Self {
+            self.input.lock().unwrap().push_back((feed, messages));
+            self
         }
     }
     #[async_trait]
@@ -993,9 +1032,18 @@ mod tests {
         async fn execute_native_batch(
             &self,
             calls: &[ToolCall],
-            _context: &ToolExecutionContext,
+            context: &ToolExecutionContext,
             _max_result_chars: usize,
         ) -> Result<NativeBatchOutcome, ToolError> {
+            self.rooms.lock().unwrap().push(context.context_id);
+            if let Some((feed, messages)) = self.input.lock().unwrap().pop_front() {
+                for message in messages {
+                    feed.push(Ok(Some(message)));
+                }
+                if let Some(persona) = *self.pending_persona.lock().unwrap() {
+                    crate::cognition::directed_pending::signal(persona);
+                }
+            }
             let content = self
                 .results
                 .lock()
@@ -1008,7 +1056,7 @@ mod tests {
                     tool_use_id: c.id.clone(),
                     content: content.clone(),
                     is_error: None,
-                spill_handle: None,
+                    spill_handle: None,
                 })
                 .collect();
             Ok(NativeBatchOutcome {
@@ -1034,6 +1082,258 @@ mod tests {
             _c: &ToolExecutionContext,
         ) -> Result<Uuid, ToolError> {
             Ok(Uuid::nil())
+        }
+    }
+
+    // what this catches: c5910be2 — an ordinary room drive could not see coaching
+    // until it settled. Inject through the conversation DURING a real tool action,
+    // then inspect the actual second/third adapter requests, not a prompt helper.
+    #[tokio::test]
+    async fn live_room_input_reaches_next_action_without_replacing_task_or_room() {
+        use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+        use crate::ai::types::{
+            FinishReason, TextGenerationRequest, TextGenerationResponse, UsageMetrics,
+        };
+        use crate::cognition::llm_deliberation_faculty::LlmDeliberationFaculty;
+        use crate::cognition::workspace::{Burst, BurstTurn, Cause, TurnAttention};
+        use crate::persona::scripted_conversation::ScriptedConversation;
+        use crate::persona::service_loop::{IncomingMessage, PersonaConversation};
+
+        for framing in [
+            TurnFraming::message(TurnAttention::Addressed),
+            TurnFraming::self_thread(false).on_workspace(),
+        ] {
+            let room = Uuid::new_v4();
+            let other_room = Uuid::new_v4();
+            let colleague = Uuid::new_v4();
+            let messages = vec![
+                IncomingMessage {
+                    event_id: Uuid::new_v4(),
+                    lamport: 1,
+                    peer_id: colleague,
+                    text: "Asha, the review target moved to src/new.rs; preserve the regression."
+                        .into(),
+                    room_id: room,
+                },
+                IncomingMessage {
+                    event_id: Uuid::new_v4(),
+                    lamport: 1,
+                    peer_id: colleague,
+                    text: "Another activity has a question when you have attention available."
+                        .into(),
+                    room_id: other_room,
+                },
+            ];
+            let later_message = IncomingMessage {
+                event_id: Uuid::new_v4(),
+                lamport: 2,
+                peer_id: colleague,
+                room_id: other_room,
+                text: "Asha, newer evidence arrived during your second read; inspect src/final.rs."
+                    .into(),
+            };
+            let mut conversation = ScriptedConversation::new().require_prime_before_next_message();
+            conversation.prime().await.unwrap();
+            let exec = Arc::new(
+                ScriptedExecutor::new([
+                    "FIRST_COMPLETE_TOOL_RESULT",
+                    "SECOND_COMPLETE_TOOL_RESULT",
+                ])
+                .with_incoming(conversation.event_feed(), messages.clone())
+                .with_incoming(conversation.event_feed(), vec![later_message.clone()]),
+            );
+            let mut responses = Vec::new();
+            for step in 0..3 {
+                responses.push(TextGenerationResponse {
+                    text: if step == 2 {
+                        "PASS".into()
+                    } else {
+                        String::new()
+                    },
+                    finish_reason: if step == 2 {
+                        FinishReason::Stop
+                    } else {
+                        FinishReason::ToolUse
+                    },
+                    model: "scripted".into(),
+                    provider: "scripted".into(),
+                    usage: UsageMetrics::default(),
+                    response_time_ms: 0,
+                    request_id: format!("step-{step}"),
+                    content: None,
+                    tool_calls: (step < 2).then(|| {
+                        vec![ToolCall {
+                            id: format!("call-{step}"),
+                            name: "code/read".into(),
+                            input: serde_json::json!({ "path": format!("src/{step}.rs") }),
+                        }]
+                    }),
+                    reasoning: None,
+                    routing: None,
+                    error: None,
+                    timing: None,
+                });
+            }
+            let recorded = Arc::new(Mutex::new(Vec::<TextGenerationRequest>::new()));
+            let adapter = Arc::new(
+                HeuristicInferenceAdapter::new()
+                    .with_responses(responses)
+                    .with_request_recorder(Arc::clone(&recorded)),
+            );
+            let wm = Arc::new(WorkingMemory::new(8));
+            wm.set_served_window(32_768);
+            let adm = admission();
+            let body = body_with_wm(exec.clone(), adm.clone(), Arc::clone(&wm));
+            let persona = body.persona_id;
+            *exec.pending_persona.lock().unwrap() = Some(persona);
+            let faculty =
+                LlmDeliberationFaculty::new(body.persona_id, "Asha", "You are Asha.", adapter)
+                    .with_context_window(32_768)
+                    .with_working_memory(Arc::clone(&wm))
+                    .with_tools(vec![crate::ai::types::NativeToolSpec {
+                        name: "code/read".into(),
+                        description: "Read a workspace file".into(),
+                        input_schema: crate::ai::types::ToolInputSchema {
+                            schema_type: "object".into(),
+                            properties: serde_json::json!({ "path": { "type": "string" } }),
+                            required: Some(vec!["path".into()]),
+                            definitions: None,
+                        },
+                    }]);
+            let cycle = WorkspaceCycle::new(
+                vec![
+                    Arc::new(WorkingMemoryFaculty::new(wm)) as Arc<dyn Faculty>,
+                    Arc::new(faculty),
+                ],
+                Arc::new(SalienceArbiter),
+                8,
+            )
+            .with_acting(body);
+            let task = "Review the original src/lib.rs change and report a reproducible defect.";
+            let cause = Cause::Stimulus(Uuid::new_v4());
+            let burst = Burst::from_turns_at(
+                crate::identity::ActivityRoom::from_uuid(room).unwrap(),
+                vec![BurstTurn::attributed(
+                    false,
+                    colleague.to_string(),
+                    task,
+                    Some(1),
+                )],
+                Some(1),
+                cause,
+            );
+            let original_world = burst.rendered.clone();
+            let outcome =
+                drive_to_settle_with_input(&cycle, burst, 8, framing, &mut conversation).await;
+            assert!(
+                outcome.inference_error.is_none(),
+                "{:?}",
+                outcome.inference_error
+            );
+            assert_eq!(outcome.acts, 2);
+            assert_eq!(outcome.room, room);
+            assert_eq!(outcome.world_state, original_world);
+            assert_eq!(outcome.room_updates.len(), 3);
+            let lived =
+                crate::cognition::experience::ExperienceRecord::from_lived_turn(task, &outcome);
+            let encoded = serde_json::to_string(&lived).unwrap();
+            let mut restored: crate::cognition::experience::ExperienceRecord =
+                serde_json::from_str(&encoded).unwrap();
+            assert_eq!(restored.task.prompt, task);
+            assert_eq!(restored.world_state, original_world);
+            assert_eq!(restored.room, Some(room));
+            for update in messages.iter().chain(std::iter::once(&later_message)) {
+                assert!(restored.room_updates.contains(update));
+                assert!(restored
+                    .training_prompt()
+                    .contains(&update.render_room_update()));
+            }
+            // A later failed episode is taught with the same complete input,
+            // through the ordinary lived-curriculum selector.
+            restored.ok = false;
+            let teaching = crate::commands::genome::curriculum::LivedExpansionSynthesizer::new()
+                .select(std::slice::from_ref(&restored));
+            assert_eq!(teaching, vec![restored.training_prompt()]);
+            let mut legacy: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+            legacy.as_object_mut().unwrap().remove("room_updates");
+            assert!(
+                serde_json::from_value::<crate::cognition::experience::ExperienceRecord>(legacy)
+                    .unwrap()
+                    .room_updates
+                    .is_empty()
+            );
+            assert_eq!(*exec.rooms.lock().unwrap(), vec![room, room]);
+            let engrams = adm.recall_recent(adm.engram_count());
+            let first_act = engrams
+                .iter()
+                .find(|e| e.content.contains("FIRST_COMPLETE_TOOL_RESULT"))
+                .expect("first action retained as an experience");
+            let second_act = engrams
+                .iter()
+                .find(|e| e.content.contains("SECOND_COMPLETE_TOOL_RESULT"))
+                .expect("second action retained as an experience");
+            assert!(adm
+                .engram_neighbors(&first_act.id)
+                .iter()
+                .any(|edge| Some(edge.target) == cause.root()
+                    && edge.kind == crate::persona::engram_graph::EdgeKind::CausedBy));
+            assert!(adm
+                .engram_neighbors(&second_act.id)
+                .iter()
+                .any(|edge| edge.target == first_act.id
+                    && edge.kind == crate::persona::engram_graph::EdgeKind::CausedBy));
+            let requests = recorded.lock().unwrap();
+            assert_eq!(requests.len(), 3);
+            for (index, request) in requests.iter().enumerate() {
+                assert_eq!(request.room_id.as_deref(), Some(room.to_string().as_str()));
+                let text = request
+                    .messages
+                    .iter()
+                    .map(|m| m.content_text())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(text.contains(task));
+                if framing.self_initiated {
+                    assert!(!text.contains("This message names you"),
+                    "a priority input must not rewrite the original self-turn's addressing fact");
+                }
+                assert_eq!(
+                    text.matches(&later_message.text).count(),
+                    usize::from(index > 1)
+                );
+                for message in &messages {
+                    assert_eq!(text.matches(&message.text).count(), usize::from(index > 0));
+                    if index > 0 {
+                        assert!(text.contains(&format!(
+                            "room {}; peer {}; event {}",
+                            message.room_id, colleague, message.event_id
+                        )));
+                    }
+                }
+                if index > 0 {
+                    assert!(text.contains(if index == 1 {
+                        "FIRST_COMPLETE_TOOL_RESULT"
+                    } else {
+                        "SECOND_COMPLETE_TOOL_RESULT"
+                    }));
+                }
+            }
+            drop(requests);
+            // Perception did not steal these inputs from later attention in their own
+            // rooms. Each retained source is returned once by the ordinary driver.
+            assert!(
+                crate::cognition::directed_pending::is_pending(persona),
+                "cooperative intake must never acknowledge the outer driver's shared wake flag"
+            );
+            for expected in messages.into_iter().chain(std::iter::once(later_message)) {
+                assert_eq!(conversation.next_message().await.unwrap(), Some(expected));
+            }
+            assert!(conversation.next_message().await.unwrap().is_none());
+            assert!(
+                conversation.said().is_empty(),
+                "intake must not impose a reply"
+            );
+            crate::cognition::directed_pending::clear(persona);
         }
     }
 
@@ -1136,7 +1436,8 @@ mod tests {
             &cycle,
             "[eval]\npeer: where does the program start and what does it call?",
             8,
-            TurnFraming::ambient(),)
+            TurnFraming::ambient(),
+        )
         .await;
 
         assert_eq!(
@@ -1221,7 +1522,16 @@ mod tests {
         let room = Uuid::new_v4();
 
         // First act genuinely runs; its result lands in working memory.
-        let first = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
+        let first = acts_of(
+            apply_act(
+                &cycle,
+                &[tool_call()],
+                "check the math",
+                room,
+                &ActChain::new(),
+            )
+            .await,
+        );
         assert_eq!(
             first[0].call.name, "code/run",
             "first act names the tool it ran"
@@ -1238,7 +1548,16 @@ mod tests {
 
         // Second, byte-identical act: already satisfied → short-circuit, no re-run.
         // The typed act's OUTPUT carries the nudge and the STATUS names the demotion.
-        let second = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
+        let second = acts_of(
+            apply_act(
+                &cycle,
+                &[tool_call()],
+                "check the math",
+                room,
+                &ActChain::new(),
+            )
+            .await,
+        );
         assert!(
             matches!(second[0].status, ActStatus::AlreadySatisfied { .. }),
             "the second identical act is typed AlreadySatisfied, not Executed"
@@ -1258,7 +1577,16 @@ mod tests {
         // than the second — the proprioception climbs rather than repeating byte-identical
         // text. Without this, static-nudge spam evicts the useful receipt from the bounded
         // recency window and a greedy (temp-0) model re-emits the identical call forever.
-        let third = acts_of(apply_act(&cycle, &[tool_call()], "check the math", room, &ActChain::new()).await);
+        let third = acts_of(
+            apply_act(
+                &cycle,
+                &[tool_call()],
+                "check the math",
+                room,
+                &ActChain::new(),
+            )
+            .await,
+        );
         let third_nudge = third[0].output.result.content.clone();
         assert_ne!(
             second_nudge, third_nudge,
@@ -1438,7 +1766,8 @@ mod tests {
         );
 
         // Second, DIFFERENT-args orientation this concern → demoted, no re-run.
-        let second = acts_of(apply_act(&cycle, &[help], "orient again", room, &ActChain::new()).await);
+        let second =
+            acts_of(apply_act(&cycle, &[help], "orient again", room, &ActChain::new()).await);
         assert!(
             matches!(second[0].status, ActStatus::RedundantOrientation { .. }),
             "the demoted orientation is typed RedundantOrientation, not Executed"
@@ -1494,7 +1823,8 @@ mod tests {
             &cycle,
             "[eval]\npeer: concern A?",
             8,
-            TurnFraming::ambient(),)
+            TurnFraming::ambient(),
+        )
         .await;
         assert_eq!(a.acts, 1, "settled concern A after one act→observe");
         assert!(a.spoken.is_some(), "concern A got a spoken answer");
@@ -1505,7 +1835,8 @@ mod tests {
             &cycle,
             "[eval]\npeer: a totally different concern B?",
             8,
-            TurnFraming::ambient(),)
+            TurnFraming::ambient(),
+        )
         .await;
         assert_eq!(
             b.acts, 1,
@@ -1565,7 +1896,8 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(matches!(step, SettleStep::Spoke(_)));
         assert!(
@@ -1587,7 +1919,8 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(matches!(step2, SettleStep::Spoke(_)));
         assert!(
@@ -1631,7 +1964,8 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(matches!(step, SettleStep::Spoke(_)));
         assert!(
@@ -1659,7 +1993,8 @@ mod tests {
             true,
             TurnFraming::ambient(),
             Situation::FreshContext,
-            &ActChain::new(),)
+            &ActChain::new(),
+        )
         .await;
         assert!(matches!(step2, SettleStep::Spoke(_)));
         assert!(

--- a/core/continuum-core/src/cognition/act_observe/settle.rs
+++ b/core/continuum-core/src/cognition/act_observe/settle.rs
@@ -7,6 +7,7 @@
 //! and the eval driver (`drive_to_settle`, which loops because the grader replaces
 //! the metronome). Live and eval make a turn the IDENTICAL way; only pacing differs.
 
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::ai::types::ToolCall;
@@ -59,13 +60,37 @@ use super::types::{SettleOutcome, SettleStep};
 /// settles without a deliverable (each is re-perceived, not ended).
 pub(super) const NARRATION_BUDGET: usize = 3;
 
-pub async fn drive_to_settle(
+pub fn drive_to_settle(
     cycle: &WorkspaceCycle,
     burst: impl Into<Burst>,
     max_acts: usize,
     framing: TurnFraming,
+) -> impl std::future::Future<Output = SettleOutcome> + Send + '_ {
+    drive_with_input(cycle, burst.into(), max_acts, framing, None)
+}
+
+/// The live driver leases its existing conversation between steps. No second
+/// runner, cancellation of an in-flight tool, or replacement task is involved.
+pub fn drive_to_settle_with_input<'a>(
+    cycle: &'a WorkspaceCycle,
+    burst: Burst,
+    max_acts: usize,
+    framing: TurnFraming,
+    conversation: &'a mut dyn crate::persona::service_loop::PersonaConversation,
+) -> impl std::future::Future<Output = SettleOutcome> + Send + 'a {
+    // Return the shared driver directly: an async forwarding wrapper needlessly
+    // nests its state in every live/eval caller and inflates future layout depth.
+    drive_with_input(cycle, burst, max_acts, framing, Some(conversation))
+}
+
+async fn drive_with_input(
+    cycle: &WorkspaceCycle,
+    burst: Burst,
+    max_acts: usize,
+    framing: TurnFraming,
+    conversation: Option<&mut dyn crate::persona::service_loop::PersonaConversation>,
 ) -> SettleOutcome {
-    let settled = settle_to_outcome(cycle, burst.into(), max_acts, framing).await;
+    let settled = settle_to_outcome(cycle, burst, max_acts, framing, conversation).await;
     if let Some(body) = cycle.acting() {
         crate::cognition::experience::record_lived_turn(
             &crate::modules::persona_instance_manager::resolve_continuum_root(),
@@ -76,13 +101,14 @@ pub async fn drive_to_settle(
     settled
 }
 
-/// The settle loop itself. Private so that [`drive_to_settle`] is the only way to
-/// reach it — every produced outcome therefore passes the lived-experience seam.
+/// The settle loop itself. Both public drivers reach it through the same lived-
+/// experience wrapper, so taking input cannot bypass the recording seam.
 async fn settle_to_outcome(
     cycle: &WorkspaceCycle,
-    burst: Burst,
+    mut burst: Burst,
     max_acts: usize,
-    framing: TurnFraming,
+    mut framing: TurnFraming,
+    mut conversation: Option<&mut dyn crate::persona::service_loop::PersonaConversation>,
 ) -> SettleOutcome {
     // The turn's room comes FROM the burst — witnessed non-nil at construction,
     // so the drive can no longer disagree with the rendered header (#425).
@@ -205,7 +231,84 @@ async fn settle_to_outcome(
     const DELIBERATION_RETRY_BUDGET: u32 = 3;
     let mut delib_retries: u32 = 0;
 
+    let mut first_step = true;
+    const TICK_DEADLINE: std::time::Duration = std::time::Duration::from_secs(25 * 60);
+    let mut seen_inputs = None;
+    let mut input_watermark = 0;
     loop {
+        let tick_deadline = tokio::time::Instant::now() + TICK_DEADLINE;
+        if !first_step {
+            if let (Some(input), Some(body)) = (conversation.as_deref_mut(), cycle.acting()) {
+                let received = match tokio::time::timeout_at(tick_deadline, input.perceive_ready()).await {
+                    Ok(received) => received,
+                    Err(_elapsed) => Err("tick deadline exceeded during room input admission; input remains owned by the conversation".into()),
+                };
+                let admitted = received.and_then(|messages| {
+                    let recipient = crate::persona::persona_identity::PersonaIdentity::new(
+                        body.persona_id, body.persona_name.clone(),
+                    );
+                    for message in messages {
+                        if message.peer_id == body.persona_id
+                            || crate::persona::wake_backlog::is_stale(
+                                message,
+                                seen_inputs.get_or_insert_with(|| crate::persona::wake_backlog::SeenIds::new(
+                                    crate::persona::airc_persona_conversation::INBOX_CAPACITY,
+                                )),
+                                input_watermark,
+                            )
+                        {
+                            continue;
+                        }
+                        input_watermark = input_watermark.max(message.lamport);
+                        let inbox_message = crate::persona::types::InboxMessage {
+                            id: message.event_id,
+                            room_id: message.room_id,
+                            sender_id: message.peer_id,
+                            sender_name: message.peer_id.to_string(),
+                            sender_type: crate::persona::types::SenderType::Persona,
+                            content: message.text.clone(),
+                            timestamp: crate::persona::trace::now_ms(),
+                            priority: 0.5,
+                            source_modality: None,
+                            voice_session_id: None,
+                        };
+                        body.admission.admit(&inbox_message, None)
+                            .map_err(|error| format!("room input admission failed: {error}"))?;
+                        framing.attention = framing.attention.with_input(
+                            crate::cognition::workspace::TurnAttention::for_message(
+                                recipient.mentions(&message.text),
+                                crate::ipc::positron_presence::is_human_peer(message.peer_id),
+                            ),
+                        );
+                        crate::probe!(
+                            class = "persona.turn.input_perceived",
+                            persona = %body.persona_id,
+                            active_room = %room_id,
+                            input_room = %message.room_id,
+                            event_id = %message.event_id,
+                            from_peer = %message.peer_id,
+                            "room input perceived between actions; original task and causal root retained"
+                        );
+                        Arc::make_mut(&mut burst.room_updates).push(Arc::clone(message));
+                    }
+                    Ok(())
+                });
+                if let Err(error) = admitted {
+                    return SettleOutcome {
+                        room: room_id,
+                        decision: Decision::pass(),
+                        spoken: None,
+                        acts,
+                        world_state: burst.rendered.clone(),
+                        room_updates: Arc::clone(&burst.room_updates),
+                        metrics,
+                        inference_error: Some(error),
+                        touched_paths: touched,
+                    };
+                }
+            }
+        }
+        first_step = false;
         // ONE settlement step through the SHARED primitive the live heartbeat uses
         // (`settle_step`). The only thing this driver adds is the LOOP — because the
         // eval room has no metronome, the grader re-perceives by calling step again.
@@ -338,9 +441,8 @@ async fn settle_to_outcome(
         // (Flash-Next deep tick ≈ 10-15 min incl. tools), fatally below forever.
         // Elapse → loud infra outcome; the drive ends; the hold RELEASES; resume
         // retries; nothing stays silently becalmed again.
-        const TICK_DEADLINE: std::time::Duration = std::time::Duration::from_secs(25 * 60);
-        let (step, step_metrics) = match tokio::time::timeout(
-            TICK_DEADLINE,
+        let (step, step_metrics) = match tokio::time::timeout_at(
+            tick_deadline,
             settle_step(cycle, burst.clone(), may_act, framing, situation, &chain),
         )
         .await
@@ -469,6 +571,7 @@ async fn settle_to_outcome(
                     decision: Decision::Speak { text },
                     acts,
                     world_state: burst.rendered.clone(),
+                    room_updates: Arc::clone(&burst.room_updates),
                     metrics,
                     inference_error: None,
                     touched_paths: touched,
@@ -563,6 +666,7 @@ async fn settle_to_outcome(
                     spoken: None,
                     acts,
                     world_state: burst.rendered.clone(),
+                    room_updates: Arc::clone(&burst.room_updates),
                     metrics,
                     inference_error: None,
                     touched_paths: touched,
@@ -575,6 +679,7 @@ async fn settle_to_outcome(
                     spoken: None,
                     acts,
                     world_state: burst.rendered.clone(),
+                    room_updates: Arc::clone(&burst.room_updates),
                     metrics,
                     inference_error: None,
                     touched_paths: touched,
@@ -613,6 +718,7 @@ async fn settle_to_outcome(
                     spoken: None,
                     acts,
                     world_state: burst.rendered.clone(),
+                    room_updates: Arc::clone(&burst.room_updates),
                     metrics,
                     inference_error: Some(error),
                     touched_paths: touched,

--- a/core/continuum-core/src/cognition/act_observe/types.rs
+++ b/core/continuum-core/src/cognition/act_observe/types.rs
@@ -24,6 +24,9 @@ pub struct SettleOutcome {
     /// The final world-state, with each action's observation folded in — what the
     /// last tick perceived. Captured for replay/forensics.
     pub world_state: String,
+    /// Full source-labelled room inputs perceived while this turn was in flight.
+    pub room_updates:
+        std::sync::Arc<Vec<std::sync::Arc<crate::persona::service_loop::IncomingMessage>>>,
     /// The accumulated cost of settling this task: every act→observe deliberation
     /// generation's latency + tokens, summed. `tokens_per_second()` re-derives
     /// throughput from the totals. This is the speed/latency the eval reports next
@@ -66,6 +69,7 @@ impl SettleOutcome {
             spoken: None,
             acts: 0,
             world_state: String::new(),
+            room_updates: Default::default(),
             metrics: TurnMetrics::default(),
             inference_error: Some(cause.into()),
             touched_paths: Vec::new(),
@@ -171,6 +175,7 @@ mod tests {
             decision,
             acts: 0,
             world_state: String::new(),
+            room_updates: Default::default(),
             metrics: TurnMetrics::default(),
             inference_error,
             touched_paths: Vec::new(),
@@ -221,7 +226,9 @@ mod tests {
             },
             None,
         ));
-        assert!(matches!(step, SettleStep::Passed { reason: Some(r) } if r == "done — patch ready"));
+        assert!(
+            matches!(step, SettleStep::Passed { reason: Some(r) } if r == "done — patch ready")
+        );
 
         // inference_error present → InferenceFailed, REGARDLESS of decision — a
         // failed model is never a chosen silence.

--- a/core/continuum-core/src/cognition/experience.rs
+++ b/core/continuum-core/src/cognition/experience.rs
@@ -131,6 +131,10 @@ pub struct ExperienceRecord {
     /// The final act→observe world-state (each action's observation folded in) —
     /// the shape of how she got there, for forensics + expansion synthesis.
     pub world_state: String,
+    /// Source-labelled supplemental inputs that accompanied this episode's answer.
+    /// Old records have none. Only the turn's admitted inputs are stored here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub room_updates: Vec<crate::persona::service_loop::IncomingMessage>,
     /// How many times she acted before settling — the effort proxy (near the
     /// budget = struggle). Surfaced today via `SettleOutcome.acts`.
     pub acts: u32,
@@ -159,6 +163,21 @@ pub struct ExperienceRecord {
 }
 
 impl ExperienceRecord {
+    /// Render the full learning input at the teacher boundary, preserving the
+    /// original stored task and each supplemental event's room and sender.
+    pub fn training_prompt(&self) -> String {
+        let mut prompt = self.task.prompt.clone();
+        self.append_room_updates(&mut prompt);
+        prompt
+    }
+
+    fn append_room_updates(&self, prompt: &mut String) {
+        for message in &self.room_updates {
+            prompt.push_str("\n\n");
+            prompt.push_str(&message.render_room_update());
+        }
+    }
+
     /// Capture a lived eval episode in full, at the grading site — BEFORE the lean
     /// `EvalTaskResult` truncates the answer and drops the trajectory. `ok`/`grade`
     /// are the grader's verdict; `settled` carries her lived trajectory.
@@ -169,6 +188,11 @@ impl ExperienceRecord {
             grade: grade.to_string(),
             answer: settled.spoken.clone().unwrap_or_default(),
             world_state: settled.world_state.clone(),
+            room_updates: settled
+                .room_updates
+                .iter()
+                .map(|m| m.as_ref().clone())
+                .collect(),
             acts: settled.acts as u32,
             source: ExperienceSource::Eval,
             room: Some(settled.room),
@@ -191,6 +215,7 @@ impl ExperienceRecord {
             grade: result.grade.clone(),
             answer: result.answer.clone(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: result.acts,
             source: ExperienceSource::Eval,
             // The outcome is already folded away at this seam — the room went with
@@ -258,6 +283,11 @@ impl ExperienceRecord {
             },
             answer: settled.spoken.clone().unwrap_or_default(),
             world_state: settled.world_state.clone(),
+            room_updates: settled
+                .room_updates
+                .iter()
+                .map(|m| m.as_ref().clone())
+                .collect(),
             acts: settled.acts as u32,
             source: ExperienceSource::Lived,
             room: Some(settled.room),
@@ -286,6 +316,7 @@ impl ExperienceRecord {
             grade: detail.to_string(),
             answer: artifact.to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 0,
             source: ExperienceSource::Eval,
             // Grading is stateless over the artifact — no turn, no room carried.
@@ -336,6 +367,7 @@ impl ExperienceRecord {
             // The lesson itself is the teaching material the synthesizer integrates.
             answer: record.content.clone(),
             world_state: format!("received via memory/share from {shared_by}"),
+            room_updates: Default::default(),
             acts: 0,
             source: ExperienceSource::Received,
             // A received lesson arrives out-of-turn — no room carried.
@@ -471,7 +503,11 @@ pub fn salient_teach_set(
         .iter()
         .filter(|r| detector.assess(r).is_some())
         .filter(|r| r.task.test.is_some())
-        .map(|r| r.task.clone())
+        .map(|r| {
+            let mut task = r.task.clone();
+            r.append_room_updates(&mut task.prompt);
+            task
+        })
         .collect()
 }
 
@@ -678,6 +714,7 @@ mod tests {
             spoken: Some(answer.to_string()),
             acts,
             world_state: world_state.to_string(),
+            room_updates: Default::default(),
             metrics: TurnMetrics::default(),
             inference_error: None,
             touched_paths: Vec::new(),
@@ -719,6 +756,7 @@ mod tests {
             grade: "error[E0308]: mismatched types — expected String, found &str".to_string(),
             answer: "fn rev(s: &str) -> &str { s }".to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 3,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -786,6 +824,7 @@ mod tests {
             grade: "no match".to_string(),
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 8,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -798,6 +837,7 @@ mod tests {
             grade: "tests passed".to_string(),
             answer: "ok".to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 1,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -810,6 +850,7 @@ mod tests {
             grade: "no match".to_string(),
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 2,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -912,7 +953,8 @@ mod tests {
         );
 
         // A lived turn that died on a serving fault: ok=false, honest grade — but STILL untestable.
-        let faulted = SettleOutcome::infra_failure(uuid::Uuid::from_u128(7), "lane 58057 refused qwen3");
+        let faulted =
+            SettleOutcome::infra_failure(uuid::Uuid::from_u128(7), "lane 58057 refused qwen3");
         let lived_fault = ExperienceRecord::from_lived_turn("ping", &faulted);
         assert!(
             !lived_fault.ok,
@@ -935,6 +977,7 @@ mod tests {
             spoken: None,
             acts: 8,
             world_state: "budget exhausted after 8 acts".into(),
+            room_updates: Default::default(),
             metrics: TurnMetrics::default(),
             inference_error: None,
             touched_paths: Vec::new(),
@@ -1042,6 +1085,7 @@ mod tests {
             grade: "no match".to_string(),
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 2,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -1077,6 +1121,7 @@ mod tests {
             grade: "error[E0308]".to_string(),
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 3,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -1129,6 +1174,7 @@ mod tests {
             grade: "error[E0308]".to_string(),
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 4,
             source: ExperienceSource::Eval,
             room: Some(uuid::Uuid::from_u128(7)),
@@ -1143,6 +1189,7 @@ mod tests {
             spoken: None,
             acts: 8,
             world_state: String::new(),
+            room_updates: Default::default(),
             metrics: TurnMetrics::default(),
             inference_error: None,
             touched_paths: Vec::new(),
@@ -1365,8 +1412,11 @@ mod tests {
                 &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
                 &mut files,
             );
-            assert!(!files.is_empty(), "the source walk found nothing — the guard \
-                would be vacuously green, which is worse than red");
+            assert!(
+                !files.is_empty(),
+                "the source walk found nothing — the guard \
+                would be vacuously green, which is worse than red"
+            );
 
             let mut callers: Vec<String> = Vec::new();
             for (path, src) in &files {

--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -639,7 +639,6 @@ impl LlmDeliberationFaculty {
         );
     }
 
-
     /// What the prompt MUST carry before any reserve may claim a token: the tool schemas,
     /// the bare framing, and room for at least one message.
     ///
@@ -873,8 +872,12 @@ impl LlmDeliberationFaculty {
             // offered) announces itself: the body builder bounds the model's
             // thinking on it (card 12ef9c10), the lane class stays Turn.
             purpose: Some(
-                if output_cap.is_some() { "cognition/act" } else { "cognition/deliberation" }
-                    .to_string(),
+                if output_cap.is_some() {
+                    "cognition/act"
+                } else {
+                    "cognition/deliberation"
+                }
+                .to_string(),
             ),
             persona_id: Some(self.persona_id.to_string()),
         }
@@ -1002,7 +1005,10 @@ impl LlmDeliberationFaculty {
     /// derived signal (logprob / uncertainty), NOT a caste weight; it's how sure
     /// THIS mind is, which the arbiter integrates.
     fn verdict(&self, resp: &TextGenerationResponse, ws: &Workspace) -> Contribution {
-        let decision = self.silence_a_parroted_draft(decision_from_response(&resp.text, Some(&self.persona_name)), ws);
+        let decision = self.silence_a_parroted_draft(
+            decision_from_response(&resp.text, Some(&self.persona_name)),
+            ws,
+        );
         let (salience, reasoning) = match &decision {
             Decision::Pass { reason } => (
                 0.5,
@@ -1194,7 +1200,9 @@ impl LlmDeliberationFaculty {
             for (i, unit) in c.parts.iter().enumerate() {
                 let next_bytes = unit_bytes + unit.len() + usize::from(i > 0);
                 let with_notice = next_bytes + 1 + notice_bound.len();
-                if used + Self::context_piece_tokens(c.faculty.as_str(), with_notice) > budget_tokens {
+                if used + Self::context_piece_tokens(c.faculty.as_str(), with_notice)
+                    > budget_tokens
+                {
                     break;
                 }
                 unit_bytes = next_bytes;
@@ -1215,9 +1223,8 @@ impl LlmDeliberationFaculty {
             // — a quieter lie than the empty block this replaces.
             let omitted = c.parts.len() - kept_units.len();
             let notice = format!("…{omitted} more not shown (context budget){how}");
-            let unit_tokens = Self::context_piece_tokens(
-                c.faculty.as_str(), unit_bytes + 1 + notice.len(),
-            );
+            let unit_tokens =
+                Self::context_piece_tokens(c.faculty.as_str(), unit_bytes + 1 + notice.len());
             used += unit_tokens;
             let body = format!("{}\n{notice}", kept_units.join("\n"));
             partial.push(format!(
@@ -1337,7 +1344,7 @@ impl LlmDeliberationFaculty {
                 .iter()
                 .map(|(c, _)| c.salience)
                 .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)); // safe: same NaN-only case as the max_by above — an unorderable salience must not take down the instrument that exists to report it
-            // `None` = nothing survived at all, which is maximal harm, never "no finding".
+                                                                                       // `None` = nothing survived at all, which is maximal harm, never "no finding".
             let fires = cheapest_kept.is_none_or(|kept| worst_sal >= kept);
             if fires {
                 let verdict = match cheapest_kept {
@@ -2084,7 +2091,10 @@ impl LlmDeliberationFaculty {
                 .broadcast
                 .iter()
                 .filter(|c| c.decision.is_none() && c.trailing)
-                .filter(|c| (c.faculty.as_str() == crate::cognition::working_memory::WM_FACULTY_ID) == wm_trail)
+                .filter(|c| {
+                    (c.faculty.as_str() == crate::cognition::working_memory::WM_FACULTY_ID)
+                        == wm_trail
+                })
             {
                 if !c.content.trim().is_empty() {
                     // Same `[faculty]` banner the system block gives its sections —
@@ -2153,6 +2163,14 @@ impl LlmDeliberationFaculty {
             history: messages,
             stimulus,
             latest_result,
+            room_updates: ws
+                .room_updates
+                .iter()
+                .map(|message| {
+                    let body = message.render_room_update();
+                    ChatMessage::text("user", body)
+                })
+                .collect(),
         }
     }
 
@@ -2173,7 +2191,9 @@ impl LlmDeliberationFaculty {
     }
 
     fn working_context_header_cost() -> usize {
-        deliberation_prompt::WORKING_CONTEXT_HEADER.len().div_ceil(GUARD_CHARS_PER_TOKEN)
+        deliberation_prompt::WORKING_CONTEXT_HEADER
+            .len()
+            .div_ceil(GUARD_CHARS_PER_TOKEN)
     }
 
     fn framing_cost(system: &str) -> usize {
@@ -2285,9 +2305,7 @@ impl LlmDeliberationFaculty {
             // (ladder rung 4) replaces this with true causal subtrees.
             let continues_cluster = |m: &ChatMessage| {
                 let body = m.content_text();
-                m.role == "assistant"
-                    || body.starts_with("Full result of")
-                    || body.starts_with('⚙')
+                m.role == "assistant" || body.starts_with("Full result of") || body.starts_with('⚙')
             };
             let mut opener_advance = 0usize;
             while start + 1 < messages.len()
@@ -2297,10 +2315,11 @@ impl LlmDeliberationFaculty {
                 start += 1;
                 opener_advance += 1;
             }
-            }
+        }
         // Move the surviving messages; fitting never clones the entire prompt.
         prompt.history.drain(..start);
         prompt.history.extend(prompt.stimulus);
+        prompt.history.extend(prompt.room_updates);
         prompt.history.extend(prompt.latest_result);
         Ok(prompt.history)
     }
@@ -2411,12 +2430,14 @@ struct PromptMessages {
     history: Vec<ChatMessage>,
     stimulus: Option<ChatMessage>,
     latest_result: Option<ChatMessage>,
+    room_updates: Vec<ChatMessage>,
 }
 
 impl PromptMessages {
     fn required_tokens(&self) -> usize {
         self.stimulus
             .iter()
+            .chain(self.room_updates.iter())
             .chain(self.latest_result.iter())
             .map(|message| LlmDeliberationFaculty::messages_cost(std::slice::from_ref(message)))
             .sum()
@@ -2734,7 +2755,10 @@ impl Faculty for LlmDeliberationFaculty {
                 let mut stops = super::deliberation_budget::peer_stop_sequences(&ws.turns);
                 stops.extend(super::deliberation_budget::reserved_marker_stop_sequences());
                 (!stops.is_empty()).then_some(stops)
-            }, Some(ws.room_id), self.is_work_turn(ws).then_some(Self::ACT_OUTPUT_CAP));
+            },
+            Some(ws.room_id),
+            self.is_work_turn(ws).then_some(Self::ACT_OUTPUT_CAP),
+        );
         // #169 STREAMING: when THIS turn carries a token sink (a live Speak the caller
         // wants progressive), generate through `generate_stream` so each decoded chunk
         // is forwarded to the caller (→ persona.turn.delta → room/TTS/avatar). The
@@ -2779,7 +2803,11 @@ impl Faculty for LlmDeliberationFaculty {
             let path = std::path::Path::new(&dir).join(format!("{}.wire.jsonl", self.persona_name));
             let _ = std::fs::create_dir_all(&dir);
             use std::io::Write as _;
-            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+            {
                 let _ = writeln!(f, "{row}");
             }
         }
@@ -3260,11 +3288,13 @@ fn segment_map(system: &str, messages: &[ChatMessage]) -> Vec<(&'static str, u32
     runs.push(("system", cum as u32));
     for m in messages {
         let body = m.content_text();
-        let label = if body.starts_with('[') || body.starts_with("Full result of") || body.starts_with('⚙') {
-            "grounding"
-        } else {
-            "history"
-        };
+        let label =
+            if body.starts_with('[') || body.starts_with("Full result of") || body.starts_with('⚙')
+            {
+                "grounding"
+            } else {
+                "history"
+            };
         cum += est_tokens(&body) + LlmDeliberationFaculty::PER_MESSAGE_TEMPLATE_TOKENS;
         match runs.last_mut() {
             Some((l, end)) if *l == label => *end = cum as u32,
@@ -3280,7 +3310,10 @@ fn segment_map(system: &str, messages: &[ChatMessage]) -> Vec<(&'static str, u32
 /// the same path as the decision, and the settle loop folds it into the per-task
 /// total. Token counts are 0 when the gateway omitted `usage` (older endpoints);
 /// `latency_ms` is always present (the adapter times every request).
-fn metrics_from(persona: &str, resp: &TextGenerationResponse) -> crate::cognition::workspace::TurnMetrics {
+fn metrics_from(
+    persona: &str,
+    resp: &TextGenerationResponse,
+) -> crate::cognition::workspace::TurnMetrics {
     // The lane's PREFILL-vs-DECODE split (llama-server `timings`), when present:
     // cache_n/prompt_n is the KV-cache hit/miss, prompt_ms/predicted_ms the
     // wall-clock split that lets the harness see where Metal time actually goes.
@@ -3371,16 +3404,38 @@ mod tests {
     // with zero tools (2026-09-04). The filter runs on the raw command names.
     #[test]
     fn hands_surface_is_chosen_on_command_names_and_keeps_the_discovery_pair() {
-        let raw: Vec<NativeToolSpec> = ["code/read", "work/state", "chat/send", "commands/list", "room/join", "code/git/status", "code/git/apply"]
-            .iter()
-            .map(|n| NativeToolSpec {
-                name: (*n).to_string(),
-                description: String::new(),
-                input_schema: crate::ai::types::ToolInputSchema { schema_type: "object".to_string(), properties: serde_json::json!({}), required: None, definitions: None },
-            })
-            .collect();
+        let raw: Vec<NativeToolSpec> = [
+            "code/read",
+            "work/state",
+            "chat/send",
+            "commands/list",
+            "room/join",
+            "code/git/status",
+            "code/git/apply",
+        ]
+        .iter()
+        .map(|n| NativeToolSpec {
+            name: (*n).to_string(),
+            description: String::new(),
+            input_schema: crate::ai::types::ToolInputSchema {
+                schema_type: "object".to_string(),
+                properties: serde_json::json!({}),
+                required: None,
+                definitions: None,
+            },
+        })
+        .collect();
         let hands: Vec<String> = hands_surface(&raw).into_iter().map(|s| s.name).collect();
-        assert_eq!(hands, ["code/read", "work/state", "commands/list", "code/git/status"], "git/apply is a reviewer verb, not a hand");
+        assert_eq!(
+            hands,
+            [
+                "code/read",
+                "work/state",
+                "commands/list",
+                "code/git/status"
+            ],
+            "git/apply is a reviewer verb, not a hand"
+        );
     }
 
     // what this catches: the live registry's command names drifting away from the
@@ -3394,9 +3449,18 @@ mod tests {
             return; // no registry in this test build — nothing to assert against
         }
         let hands = hands_surface(&raw);
-        assert!(!hands.is_empty(), "hands surface is empty against the live registry");
-        assert!(hands.len() < raw.len(), "hands surface should be a strict subset");
-        assert!(hands.iter().any(|s| s.name == "commands/list"), "the discovery pair must survive");
+        assert!(
+            !hands.is_empty(),
+            "hands surface is empty against the live registry"
+        );
+        assert!(
+            hands.len() < raw.len(),
+            "hands surface should be a strict subset"
+        );
+        assert!(
+            hands.iter().any(|s| s.name == "commands/list"),
+            "the discovery pair must survive"
+        );
     }
     use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
     use crate::ai::types::{ToolCall, ToolInputSchema, UsageMetrics};
@@ -3666,58 +3730,58 @@ mod tests {
         // PLUS the generation cap never exceeds the served window. Regression for the
         // abstain-every-tick reliability bug.
         // what this catches: an ACT turn's completion is bounded by ACT_OUTPUT_CAP
-    // under the reserve, and a message turn (no cap) still gets the whole
-    // reserved room. Losing the cap reproduces the 5,316-token act (157 s on
-    // the lane); capping message turns would truncate answers.
-    #[tokio::test]
-    async fn an_act_turn_is_capped_under_the_reserved_room() {
-        let window = 32_768u32;
-        let persona = Uuid::new_v4();
-        let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
-        let faculty = LlmDeliberationFaculty::new(
-            persona,
-            "Ivar",
-            "You are Ivar, a thoughtful engineer on the grid.",
-            adapter,
-        )
-        .with_context_window(window);
-        let ws = Workspace::new("act on the card");
-        let view = faculty.prompt_view(&ws);
-        let binding = faculty.binding.load_full();
-        let reserve = faculty.completion_reserve_within(window);
-        let act = faculty.build_request_within(
-            &binding,
+        // under the reserve, and a message turn (no cap) still gets the whole
+        // reserved room. Losing the cap reproduces the 5,316-token act (157 s on
+        // the lane); capping message turns would truncate answers.
+        #[tokio::test]
+        async fn an_act_turn_is_capped_under_the_reserved_room() {
+            let window = 32_768u32;
+            let persona = Uuid::new_v4();
+            let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
+            let faculty = LlmDeliberationFaculty::new(
+                persona,
+                "Ivar",
+                "You are Ivar, a thoughtful engineer on the grid.",
+                adapter,
+            )
+            .with_context_window(window);
+            let ws = Workspace::new("act on the card");
+            let view = faculty.prompt_view(&ws);
+            let binding = faculty.binding.load_full();
+            let reserve = faculty.completion_reserve_within(window);
+            let act = faculty.build_request_within(
+                &binding,
                 view.completion_reserve,
-            view.messages.clone(),
-            None,
-            view.system.clone(),
-            None,
-            Some(ws.room_id),
-            Some(LlmDeliberationFaculty::ACT_OUTPUT_CAP),
-        );
-        assert_eq!(
-            act.max_tokens,
-            Some(reserve.min(LlmDeliberationFaculty::ACT_OUTPUT_CAP)),
-            "an act turn is capped under the reserve"
-        );
-        let msg = faculty.build_request_within(
-            &binding,
+                view.messages.clone(),
+                None,
+                view.system.clone(),
+                None,
+                Some(ws.room_id),
+                Some(LlmDeliberationFaculty::ACT_OUTPUT_CAP),
+            );
+            assert_eq!(
+                act.max_tokens,
+                Some(reserve.min(LlmDeliberationFaculty::ACT_OUTPUT_CAP)),
+                "an act turn is capped under the reserve"
+            );
+            let msg = faculty.build_request_within(
+                &binding,
                 view.completion_reserve,
-            view.messages.clone(),
-            None,
-            view.system.clone(),
-            None,
-            Some(ws.room_id),
-            None,
-        );
+                view.messages.clone(),
+                None,
+                view.system.clone(),
+                None,
+                Some(ws.room_id),
+                None,
+            );
             assert_eq!(
                 msg.max_tokens,
                 Some(reserve),
                 "a message turn keeps the reserved room"
             );
-    }
+        }
 
-    #[test]
+        #[test]
         fn prompt_plus_completion_cap_never_exceeds_the_served_window() {
             let persona = Uuid::new_v4();
             let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
@@ -4112,8 +4176,7 @@ mod tests {
                 let faculty = faculty_with_the_real_registry(narrow);
                 // A MESSAGE turn — so the narrowing can only be the window.
                 let ws = Workspace::new("anything open?");
-                let selected =
-                    faculty.select_tool_surface(&ws, narrow);
+                let selected = faculty.select_tool_surface(&ws, narrow);
 
                 assert_eq!(
                     selected.reason,
@@ -4164,11 +4227,7 @@ mod tests {
                 for (label, window, ws) in [
                     ("full", fits, Workspace::new("anything open?")),
                     ("hands/work", fits, work_turn()),
-                    (
-                        "hands/budget",
-                        narrow,
-                        Workspace::new("anything open?"),
-                    ),
+                    ("hands/budget", narrow, Workspace::new("anything open?")),
                 ] {
                     let faculty = faculty_with_the_real_registry(window);
                     let selected = faculty.select_tool_surface(&ws, window);
@@ -5029,8 +5088,7 @@ mod tests {
             // their own activities per [[activities-are-self-hosting]]). Same
             // conscious trade as vision/look above.
             const AGENTIC_SURFACE_CEILING: u32 = 10700;
-            let surface =
-                faculty.describe_tool_tokens() as u32 + faculty.framing_floor_tokens();
+            let surface = faculty.describe_tool_tokens() as u32 + faculty.framing_floor_tokens();
             assert!(
                 surface <= AGENTIC_SURFACE_CEILING,
                 "the agentic surface is now {surface} tokens (measured 10098, ceiling \
@@ -5062,7 +5120,8 @@ mod tests {
             // and "we were spending her window on tools we withheld". Only the second
             // was ever true here.
             assert!(
-                view.user_text().contains("LATEST: did the deploy fix land?"),
+                view.user_text()
+                    .contains("LATEST: did the deploy fix land?"),
                 "the newest burst line must survive once the budget prices the surface it \
                  actually sends — if this regresses, the accounting is double-counting the \
                  withheld registry again (card dec1a7ff)\n{}",
@@ -5183,8 +5242,7 @@ mod tests {
         #[test]
         fn fit_front_advances_in_quanta_not_per_act() {
             let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
-            let faculty =
-                LlmDeliberationFaculty::new(Uuid::new_v4(), "T", "You are T.", adapter);
+            let faculty = LlmDeliberationFaculty::new(Uuid::new_v4(), "T", "You are T.", adapter);
             let msgs: Vec<ChatMessage> = (0..40)
                 .map(|i| ChatMessage::text("user", format!("m{i} {}", "word ".repeat(95))))
                 .collect();
@@ -5206,6 +5264,7 @@ mod tests {
                             history: msgs[..n].to_vec(),
                             stimulus: None,
                             latest_result: None,
+                            room_updates: Vec::new(),
                         },
                         budget,
                     )
@@ -5236,7 +5295,10 @@ mod tests {
             // tool-result continuation, the front advances past the fragment.
             let mut clustered: Vec<ChatMessage> = Vec::new();
             for i in 0..30 {
-                clustered.push(ChatMessage::text("user", format!("q{i} {}", "word ".repeat(60))));
+                clustered.push(ChatMessage::text(
+                    "user",
+                    format!("q{i} {}", "word ".repeat(60)),
+                ));
                 clustered.push(ChatMessage::text(
                     "assistant",
                     format!("a{i} {}", "word ".repeat(60)),
@@ -5248,6 +5310,7 @@ mod tests {
                         history: clustered,
                         stimulus: None,
                         latest_result: None,
+                        room_updates: Vec::new(),
                     },
                     budget,
                 )
@@ -5272,6 +5335,7 @@ mod tests {
                 ],
                 stimulus: None,
                 latest_result: None,
+                room_updates: Vec::new(),
             };
             let ambient_cost =
                 LlmDeliberationFaculty::message_cost(ambient().history.last().unwrap());
@@ -5362,7 +5426,10 @@ mod tests {
                 BurstTurn::attributed(false, "Atlas", "shall we outline the steps first?", Some(4)),
                 BurstTurn::attributed(true, "Casper", v3, Some(5)),
             ];
-            let ws = Workspace::new(Burst::from_turns(crate::identity::ActivityRoom::mint(), turns));
+            let ws = Workspace::new(Burst::from_turns(
+                crate::identity::ActivityRoom::mint(),
+                turns,
+            ));
             let view = faculty.prompt_view(&ws);
 
             // Exactly ONE assistant rendering of the template survives.
@@ -5638,6 +5705,16 @@ mod tests {
                         .with_working_memory(wm);
                 let room = crate::identity::ActivityRoom::from_uuid(Uuid::new_v4()).unwrap();
                 let stimulus = "Review PR #3858 against its actual source.";
+                let update = Arc::new(crate::persona::service_loop::IncomingMessage {
+                    event_id: Uuid::new_v4(),
+                    lamport: 1,
+                    peer_id: Uuid::new_v4(),
+                    room_id: Uuid::new_v4(),
+                    text: format!(
+                        "A colleague's additional evidence: {}",
+                        "retained evidence ".repeat(80)
+                    ),
+                });
                 let mut ws = Workspace::new(Burst::from_turns(
                     room,
                     vec![
@@ -5653,9 +5730,13 @@ mod tests {
                     ],
                 ));
                 ws.workspace_deliverable = true;
+                ws.room_updates = Arc::new(vec![Arc::clone(&update)]);
                 ws.broadcast.push(Contribution::context(
                     FacultyId::Custom(crate::persona::active_work_source::SOURCE_ID.into()),
-                    format!("Held activity context: continue independent source review.{}", "x".repeat(padding)),
+                    format!(
+                        "Held activity context: continue independent source review.{}",
+                        "x".repeat(padding)
+                    ),
                     0.9,
                     "held claims",
                 ));
@@ -5688,6 +5769,13 @@ mod tests {
                 assert_eq!(adapter.call_count(), 1);
                 let seen = adapter.seen.lock().unwrap();
                 let request = &seen[0];
+                assert!(
+                    request
+                        .messages
+                        .iter()
+                        .any(|message| message.content_text().ends_with(&update.text)),
+                    "room updates must survive alongside the original task and complete result"
+                );
                 assert!(request
                     .messages
                     .iter()
@@ -5719,10 +5807,11 @@ mod tests {
                     schema_tokens,
                     faculty.select_tool_surface(&ws, window).tokens
                 );
-                let wire_tokens = LlmDeliberationFaculty::framing_cost(request.system_prompt.as_ref().unwrap())
-                    + LlmDeliberationFaculty::messages_cost(&request.messages)
-                    + schema_tokens
-                    + request.max_tokens.unwrap() as usize;
+                let wire_tokens =
+                    LlmDeliberationFaculty::framing_cost(request.system_prompt.as_ref().unwrap())
+                        + LlmDeliberationFaculty::messages_cost(&request.messages)
+                        + schema_tokens
+                        + request.max_tokens.unwrap() as usize;
                 assert!(
                     wire_tokens <= window as usize,
                     "wire {wire_tokens} > window {window}"
@@ -5730,7 +5819,7 @@ mod tests {
             }
         }
 
-        // what this catches: an indivisible oversized stimulus OR active result
+        // what this catches: an indivisible oversized stimulus, room update or active result
         // must fault before inference, including self-ticks with no chat turns.
         // It must still publish demand, so refusal cannot freeze a small window.
         #[tokio::test]
@@ -5739,22 +5828,35 @@ mod tests {
             use crate::cognition::working_set::WorkingSetRegistry;
 
             let window = 8192u32;
-            for oversized_stimulus in [true, false] {
+            for oversized_part in 0..3 {
                 let persona = Uuid::new_v4();
                 let adapter = Arc::new(ScriptedAdapter::new(vec![]));
                 let registry = WorkingSetRegistry::new();
                 let wm = Arc::new(WorkingMemory::new(8));
                 wm.set_served_window(window);
                 let oversized = "payload ".repeat(window as usize);
-                let mut ws = if oversized_stimulus {
+                let mut ws = if oversized_part == 0 {
                     Workspace::new(&oversized)
-                } else {
+                } else if oversized_part == 1 {
                     wm.record_receipt(&format!(
                         "{oversized}\nclaimable_now: 29\ntotal_on_board: 43"
                     ));
                     let mut ws = Workspace::new("");
                     ws.turns.clear();
                     ws.self_initiated = true;
+                    ws
+                } else {
+                    wm.record_receipt("complete active result");
+                    let mut ws = Workspace::new("original task stays required");
+                    ws.room_updates = Arc::new(vec![Arc::new(
+                        crate::persona::service_loop::IncomingMessage {
+                            event_id: Uuid::new_v4(),
+                            lamport: 1,
+                            peer_id: Uuid::new_v4(),
+                            room_id: Uuid::new_v4(),
+                            text: oversized,
+                        },
+                    )]);
                     ws
                 };
                 ws.now_ms = Some(1);

--- a/core/continuum-core/src/cognition/replay.rs
+++ b/core/continuum-core/src/cognition/replay.rs
@@ -67,6 +67,8 @@ struct TraceLine {
     captured_at_ms: u64,
     room_id: String,
     world_state: String,
+    #[serde(default)]
+    room_updates: Vec<crate::persona::service_loop::IncomingMessage>,
     /// The assembled broadcast that reached the decider this tick. Absent on
     /// older traces (pre-context-replay) → empty, handled as "no broadcast".
     #[serde(default)]
@@ -149,9 +151,9 @@ pub struct BudgetLayer {
 
 /// The prompt-budget ledger for the replayed turn: what each layer of her prompt
 /// cost, totalled. `total_tokens = world_state_tokens + context_tokens`, and
-/// `layers` accounts the reconstructed broadcast (the RAG layers she actually
+/// `layers` accounts the reconstructed broadcast and supplemental room inputs (the layers she actually
 /// saw), sorted most-expensive first. Honest about scope: this accounts the
-/// load-bearing CONTENT layers (world_state + broadcast), not the fixed system
+/// load-bearing CONTENT layers (world_state + broadcast + room inputs), not the fixed system
 /// framing — those are the layers you tune, the ones a bad RAG step bloats.
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct PromptBudget {
@@ -197,12 +199,55 @@ struct ResolvedBurst {
     room: String,
     source: String,
     broadcast: Vec<Contribution>,
+    room_updates: Vec<crate::persona::service_loop::IncomingMessage>,
+}
+
+impl ResolvedBurst {
+    fn from_trace(line: &TraceLine, room: String, source: String) -> Self {
+        Self {
+            world_state: line.world_state.clone(),
+            room,
+            source,
+            room_updates: line.room_updates.clone(),
+            broadcast: line
+                .context
+                .iter()
+                .map(|c| {
+                    Contribution::context(
+                        FacultyId::from_kebab(&c.faculty),
+                        c.content.clone(),
+                        c.salience,
+                        c.reasoning.clone(),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn take_workspace(&mut self, room: crate::identity::ActivityRoom) -> Workspace {
+        let mut ws = Workspace::from_burst(crate::cognition::workspace::Burst::raw_in(
+            room,
+            self.world_state.clone(),
+        ));
+        ws.room_updates = std::sync::Arc::new(
+            std::mem::take(&mut self.room_updates)
+                .into_iter()
+                .map(std::sync::Arc::new)
+                .collect(),
+        );
+        ws.broadcast = std::mem::take(&mut self.broadcast);
+        ws
+    }
 }
 
 /// Build the prompt-budget ledger from the burst + the reconstructed broadcast.
 /// Every layer line-itemed in the SAME token unit the RAG sources budget against,
 /// sorted most-expensive first — the "obsess over every prompt layer" instrument.
-fn build_budget(world_state: &str, broadcast: &[Contribution]) -> PromptBudget {
+fn build_budget(
+    world_state: &str,
+    broadcast: &[Contribution],
+    room_updates: &[crate::persona::service_loop::IncomingMessage],
+) -> PromptBudget {
     let world_state_tokens = estimate_prompt_tokens(world_state);
     let mut layers: Vec<BudgetLayer> = broadcast
         .iter()
@@ -212,6 +257,16 @@ fn build_budget(world_state: &str, broadcast: &[Contribution]) -> PromptBudget {
             share_pct: 0.0, // filled once we know the total
         })
         .collect();
+    if !room_updates.is_empty() {
+        layers.push(BudgetLayer {
+            faculty: "room-inputs".into(),
+            tokens: room_updates
+                .iter()
+                .map(|m| estimate_prompt_tokens(&m.render_room_update()))
+                .fold(0u32, u32::saturating_add),
+            share_pct: 0.0,
+        });
+    }
     let context_tokens: u32 = layers.iter().map(|l| l.tokens).sum();
     let total_tokens = world_state_tokens.saturating_add(context_tokens);
     if total_tokens > 0 {
@@ -248,6 +303,7 @@ fn resolve_burst(
             world_state: ws.clone(),
             room,
             source: "supplied".to_string(),
+            room_updates: Vec::new(),
             broadcast: Vec::new(),
         });
     }
@@ -286,26 +342,11 @@ fn resolve_burst(
     }
     let line = &lines[idx as usize];
     let room = p.room_id.clone().unwrap_or_else(|| line.room_id.clone());
-    // Rebuild the broadcast the decider actually saw from the captured context,
-    // so a deliberation faculty replays against its REAL input — not a blind one.
-    let broadcast = line
-        .context
-        .iter()
-        .map(|c| {
-            Contribution::context(
-                FacultyId::from_kebab(&c.faculty),
-                c.content.clone(),
-                c.salience,
-                c.reasoning.clone(),
-            )
-        })
-        .collect();
-    Ok(ResolvedBurst {
-        world_state: line.world_state.clone(),
+    Ok(ResolvedBurst::from_trace(
+        line,
         room,
-        source: format!("capture@{turn} ({}ms)", line.captured_at_ms),
-        broadcast,
-    })
+        format!("capture@{turn} ({}ms)", line.captured_at_ms),
+    ))
 }
 
 #[derive(Default)]
@@ -337,10 +378,12 @@ impl ActionCommand for CognitionReplay {
             CommandError::Invalid(format!("persona_id '{}' is not a valid UUID", p.persona_id))
         })?;
 
-        let burst = resolve_burst(&p, &persona_uuid)?;
+        let mut burst = resolve_burst(&p, &persona_uuid)?;
         let room = Uuid::parse_str(&burst.room).map_err(|_| {
             CommandError::Invalid(format!("room_id '{}' is not a valid UUID", burst.room))
         })?;
+        let room = crate::identity::ActivityRoom::from_uuid(room)
+            .map_err(|error| CommandError::Invalid(format!("room_id '{}': {error}", burst.room)))?;
 
         // Fork the LIVE cycle the humane way: a measured copy, isolated for the
         // duration, paged back out after — her real mind is never touched.
@@ -386,14 +429,9 @@ impl ActionCommand for CognitionReplay {
 
         // Cost the prompt BEFORE the broadcast moves into the workspace — the
         // ledger of every layer she saw, in the RAG sources' own token unit.
-        let budget = build_budget(&burst.world_state, &burst.broadcast);
+        let budget = build_budget(&burst.world_state, &burst.broadcast, &burst.room_updates);
 
-        let mut ws = Workspace::from_burst(crate::cognition::workspace::Burst::raw_in(
-            crate::identity::ActivityRoom::from_uuid(room)
-                .expect("replay room is parsed-or-minted above, never nil"), // parsed-or-minted two lines up; nil is unreachable here
-            burst.world_state.clone(),
-        ));
-        ws.broadcast = burst.broadcast;
+        let ws = burst.take_workspace(room);
         let bids = cycle.replay(&ws, only.as_ref()).await;
 
         drop(isolation);
@@ -452,6 +490,29 @@ crate::register_stateless_command!(CognitionReplay);
 mod tests {
     use super::*;
 
+    // What this catches (c5910be2): a caller-supplied nil room must be refused
+    // before an eval fork is created, rather than panicking after UUID parsing.
+    #[tokio::test]
+    async fn replay_rejects_invalid_activity_room_before_forking() {
+        let persona = Uuid::new_v4();
+        for room in [Uuid::nil().to_string(), "not-a-uuid".into()] {
+            let error = CognitionReplay
+                .run(
+                    &Ctx::default(),
+                    CognitionReplayParams {
+                        persona_id: persona.to_string().into(),
+                        faculty: Some("recall".into()),
+                        world_state: Some("original replay input".into()),
+                        turn: None,
+                        room_id: Some(room),
+                    },
+                )
+                .await
+                .expect_err("invalid room must fail before looking up a live cycle");
+            assert!(matches!(error, CommandError::Invalid(message) if message.contains("room_id")));
+        }
+    }
+
     // What this catches (f098571b): the HOME-absent launch disabled both live
     // writers and made both inspection/replay readers look in a different root.
     // Use the actual sink constructors and readers with the existing isolated
@@ -472,6 +533,7 @@ mod tests {
         let bid = Contribution::context(FacultyId::Recall, grounding, 0.8, "fixture provenance");
         let trace = WorkspaceTrace {
             world_state: request.into(),
+            room_updates: Default::default(),
             room_id: room,
             bids: vec![bid.clone()],
             context_broadcast: vec![bid.clone()],
@@ -554,6 +616,104 @@ mod tests {
         assert_eq!(restored.broadcast[0].content, grounding);
     }
 
+    // The real capture writer, read mirror, reconstruction and LLM request must
+    // agree on coaching input. Older records remain readable with no updates.
+    #[tokio::test]
+    async fn captured_room_inputs_reach_the_replayed_request() {
+        use crate::ai::heuristic_adapter::HeuristicInferenceAdapter;
+        use crate::ai::types::TextGenerationRequest;
+        use crate::cognition::llm_deliberation_faculty::LlmDeliberationFaculty;
+        use crate::cognition::workspace::{Faculty, WorkspaceCaptureSink, WorkspaceTrace};
+        use crate::cognition::workspace_capture::JsonlWorkspaceCaptureSink;
+        use crate::persona::service_loop::IncomingMessage;
+        use std::sync::{Arc, Mutex};
+
+        let dir = tempfile::tempdir().unwrap();
+        let persona = Uuid::new_v4();
+        let room = crate::identity::ActivityRoom::mint();
+        let update = Arc::new(IncomingMessage {
+            event_id: Uuid::new_v4(),
+            lamport: 2,
+            peer_id: Uuid::new_v4(),
+            room_id: Uuid::new_v4(),
+            text: "The teammate's updated review target is src/new.rs; check the failing case."
+                .into(),
+        });
+        let task = "Review the original src/lib.rs change and preserve its regression.";
+        let receipt = "The source read completed successfully: regression_case exists.";
+        let context = vec![Contribution::context(
+            FacultyId::from_kebab("working-memory"),
+            receipt,
+            0.9,
+            "action receipt",
+        )];
+        let trace = WorkspaceTrace {
+            world_state: task.into(),
+            room_updates: Arc::new(vec![Arc::clone(&update)]),
+            room_id: room.as_uuid(),
+            bids: context.clone(),
+            context_broadcast: context.clone(),
+            broadcast: context,
+            decision: None,
+            timings: Vec::new(),
+        };
+        {
+            let sink = JsonlWorkspaceCaptureSink::open(dir.path(), persona).unwrap();
+            sink.record(&trace);
+        }
+        let raw = std::fs::read_to_string(dir.path().join(format!("{persona}.jsonl"))).unwrap();
+        let line: TraceLine = serde_json::from_str(raw.lines().next().unwrap()).unwrap();
+        assert_eq!(line.room_updates, vec![update.as_ref().clone()]);
+        let mut burst =
+            ResolvedBurst::from_trace(&line, room.as_uuid().to_string(), "test capture".into());
+        let budget = build_budget(&burst.world_state, &burst.broadcast, &burst.room_updates);
+        assert!(budget
+            .layers
+            .iter()
+            .any(|l| l.faculty == "room-inputs" && l.tokens > 0));
+        let ws = burst.take_workspace(room);
+        assert_eq!(ws.world_state, task);
+        assert_eq!(ws.room_id, room.as_uuid());
+        let requests = Arc::new(Mutex::new(Vec::<TextGenerationRequest>::new()));
+        let adapter =
+            Arc::new(HeuristicInferenceAdapter::new().with_request_recorder(Arc::clone(&requests)));
+        let faculty = LlmDeliberationFaculty::new(persona, "Asha", "You are Asha.", adapter)
+            .with_context_window(32_768);
+        let bid = faculty
+            .contribute(&ws)
+            .await
+            .expect("replayed deliberation");
+        assert!(bid.fault.is_none());
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let text = requests[0]
+            .messages
+            .iter()
+            .map(|m| m.content_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains(task));
+        assert!(
+            requests[0]
+                .system_prompt
+                .as_deref()
+                .is_some_and(|system| system.contains(receipt)),
+            "captured context must reach the replayed system prompt"
+        );
+        assert!(text.contains(&update.render_room_update()));
+        assert_eq!(
+            requests[0].room_id.as_deref(),
+            Some(room.as_uuid().to_string().as_str())
+        );
+        let mut legacy: serde_json::Value =
+            serde_json::from_str(raw.lines().next().unwrap()).unwrap();
+        legacy.as_object_mut().unwrap().remove("room_updates");
+        assert!(serde_json::from_value::<TraceLine>(legacy)
+            .unwrap()
+            .room_updates
+            .is_empty());
+    }
+
     // what this catches: the burst resolver must FAIL LOUD (never an empty burst)
     // when neither a supplied world_state nor a readable capture exists — the
     // no-fallback contract for the factory's input step.
@@ -625,7 +785,7 @@ mod tests {
                 "r",
             ),
         ];
-        let b = build_budget("hello there", &broadcast);
+        let b = build_budget("hello there", &broadcast, &[]);
         assert_eq!(b.world_state_tokens, estimate_prompt_tokens("hello there"));
         assert_eq!(
             b.context_tokens,

--- a/core/continuum-core/src/cognition/workspace.rs
+++ b/core/continuum-core/src/cognition/workspace.rs
@@ -621,6 +621,11 @@ impl BurstTurn {
 /// stimulus → a single opaque turn rendered verbatim).
 #[derive(Debug, Clone)]
 pub struct Burst {
+    /// Room messages perceived while this turn was already underway. Shared with
+    /// the conversation's retained attention queue; never replace this burst's
+    /// task, room, or causal root. This is the existing chat projection, not a
+    /// replacement for the multimodal sensory faculties.
+    pub room_updates: Arc<Vec<Arc<crate::persona::service_loop::IncomingMessage>>>,
     /// The activity this turn belongs to — REQUIRED at construction, witnessed
     /// non-nil by [`ActivityRoom`]. The burst carries the room because the burst
     /// IS the perception the turn responds to: when the room rode as a separate
@@ -757,6 +762,7 @@ impl Burst {
             rendered,
             now_ms,
             cause,
+            room_updates: Arc::default(),
         }
     }
 
@@ -770,6 +776,7 @@ impl Burst {
             rendered: s,
             now_ms: None,
             cause: Cause::Synthetic,
+            room_updates: Arc::default(),
         }
     }
 }
@@ -789,6 +796,7 @@ impl From<String> for Burst {
             // A raw string arrives with no channel and no antecedent — a fixture, by
             // construction. Honest, never invented.
             cause: Cause::Synthetic,
+            room_updates: Arc::default(),
         }
     }
 }
@@ -817,9 +825,20 @@ pub enum TurnAttention {
     Ambient,
     HumanOpportunity,
     Addressed,
+    /// A priority room input became visible during an existing turn. This grants
+    /// its next perception a foreground lane without changing what originally
+    /// triggered the turn or asserting that original trigger named the persona.
+    PriorityInput,
 }
 
 impl TurnAttention {
+    pub fn with_input(self, input: Self) -> Self {
+        if !self.requires_priority() && input.requires_priority() {
+            Self::PriorityInput
+        } else {
+            self
+        }
+    }
     pub fn for_message(mentioned: bool, sender_is_human: bool) -> Self {
         if mentioned {
             Self::Addressed
@@ -922,6 +941,8 @@ impl TurnFraming {
 /// broadcast back to all faculties.
 #[derive(Debug, Clone)]
 pub struct Workspace {
+    /// Additional room inputs; the active turn's room and task remain separate.
+    pub room_updates: Arc<Vec<Arc<crate::persona::service_loop::IncomingMessage>>>,
     /// The consolidated burst / world-state at service time, as flat text — the
     /// rendered projection of [`turns`](Self::turns). Opaque to the core; the
     /// channel/recipe adapter shapes it. Every TEXT reader (recall, dashboards,
@@ -1022,6 +1043,7 @@ impl Workspace {
         Self {
             world_state: burst.rendered,
             turns: burst.turns,
+            room_updates: burst.room_updates,
             room_id: burst.room.as_uuid(),
             cause: burst.cause,
             cycle: CycleId::UNSTAMPED,
@@ -1383,6 +1405,8 @@ impl Arbiter for SituationFocusArbiter {
 #[derive(Debug, Clone)]
 pub struct WorkspaceTrace {
     pub world_state: String,
+    /// Supplemental inputs admitted before this tick; shared with the live burst.
+    pub room_updates: Arc<Vec<Arc<crate::persona::service_loop::IncomingMessage>>>,
     /// The room/context this tick reasoned within (contextId) — so a replayed
     /// trace correlates to the room it happened in, not a floating burst.
     pub room_id: Uuid,
@@ -1911,7 +1935,9 @@ impl WorkspaceCycle {
     /// is "silence must never be ambiguous with progress" could not tell the two
     /// apart. A wait-free atomic load, safe to poll on a heartbeat.
     pub fn actions_taken(&self) -> Option<u64> {
-        self.acting.as_ref().map(|a| a.working_memory.actions_taken())
+        self.acting
+            .as_ref()
+            .map(|a| a.working_memory.actions_taken())
     }
 
     /// Begin a memory-isolated measurement window over this cycle's hippocampus.
@@ -2020,8 +2046,12 @@ impl WorkspaceCycle {
     /// use [`run_framed`](Self::run_framed) / [`run_situated`](Self::run_situated).
     #[cfg(test)]
     pub async fn run(&self, burst: impl Into<Burst>) -> Workspace {
-        self.run_inner(burst.into(), TurnFraming::ambient(), Situation::FreshContext)
-            .await
+        self.run_inner(
+            burst.into(),
+            TurnFraming::ambient(),
+            Situation::FreshContext,
+        )
+        .await
     }
 
     /// TEST-ONLY compat: ambient tick with an explicit room override.
@@ -2044,7 +2074,8 @@ impl WorkspaceCycle {
         // Fresh-context default: a bare framed tick is a fresh ask (fuller
         // grounding). The act→observe driver calls [`run_situated`] with
         // `PostAction` on re-perception ticks.
-        self.run_inner(burst, framing, Situation::FreshContext).await
+        self.run_inner(burst, framing, Situation::FreshContext)
+            .await
     }
 
     /// Same as [`run_framed`](Self::run_framed) but with the tick's [`Situation`]
@@ -2308,6 +2339,7 @@ impl WorkspaceCycle {
         }
         self.capture.record(&WorkspaceTrace {
             world_state: ws.world_state.clone(),
+            room_updates: Arc::clone(&ws.room_updates),
             room_id: ws.room_id,
             bids: all_bids,
             context_broadcast,

--- a/core/continuum-core/src/cognition/workspace_capture.rs
+++ b/core/continuum-core/src/cognition/workspace_capture.rs
@@ -30,7 +30,8 @@ use super::workspace::{
 
 /// Bumped when the on-disk record shape changes (replay readers gate on it).
 /// v2 added per-faculty `timings` (the speed axis / dashboard feed).
-const SCHEMA_VERSION: u32 = 2;
+/// v3 adds full source-labelled supplemental room inputs.
+const SCHEMA_VERSION: u32 = 3;
 
 pub(crate) const FIXTURE_DIR: &str = ".continuum/fixtures/workspace-traces";
 
@@ -102,13 +103,15 @@ impl From<&FacultyTiming> for TimingRecord {
 
 /// One serialized workspace tick — the full mechanic's view of one turn's mind.
 #[derive(Debug, Serialize)]
-struct WorkspaceTraceRecord {
+struct WorkspaceTraceRecord<'a> {
     schema_version: u32,
     captured_at_ms: u64,
     persona_id: String,
     room_id: String,
     /// The consolidated burst the mind reasoned over this tick.
     world_state: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    room_updates: Vec<&'a crate::persona::service_loop::IncomingMessage>,
     /// EVERY bid this tick (winners + losers, both phases) — the full competition.
     bids: Vec<BidRecord>,
     /// The assembled context that won attention and reached the decider (the RAG).
@@ -167,6 +170,7 @@ impl WorkspaceCaptureSink for JsonlWorkspaceCaptureSink {
             persona_id: self.persona_id.to_string(),
             room_id: trace.room_id.to_string(),
             world_state: trace.world_state.clone(),
+            room_updates: trace.room_updates.iter().map(AsRef::as_ref).collect(),
             bids: trace.bids.iter().map(BidRecord::from).collect(),
             context: trace
                 .context_broadcast
@@ -245,6 +249,7 @@ mod tests {
         };
         let trace = WorkspaceTrace {
             world_state: "teammate: what should we do about the red deploy?".to_string(),
+            room_updates: Default::default(),
             room_id: room,
             bids: vec![recall.clone(), verdict.clone()],
             context_broadcast: vec![recall.clone()],
@@ -325,6 +330,7 @@ mod tests {
         let sink = JsonlWorkspaceCaptureSink::open(&dir, persona).unwrap();
         let mk = |room| WorkspaceTrace {
             world_state: "burst".to_string(),
+            room_updates: Default::default(),
             room_id: room,
             bids: vec![],
             context_broadcast: vec![],

--- a/core/continuum-core/src/cognition/workspace_dashboard.rs
+++ b/core/continuum-core/src/cognition/workspace_dashboard.rs
@@ -233,6 +233,7 @@ mod tests {
         };
         let trace = WorkspaceTrace {
             world_state: "what's the call?".to_string(),
+            room_updates: Default::default(),
             room_id: room,
             bids: vec![recall.clone(), verdict.clone()],
             context_broadcast: vec![recall.clone()],
@@ -325,11 +326,8 @@ mod tests {
 
         // Deferred: the tick serves reprojected last-good, so the grounding faculty
         // reads ~0 and the perception max collapses back to the fast faculty.
-        let off_barrier = critical_path_us(&[
-            fast_perception.clone(),
-            grounding(3),
-            deliberation.clone(),
-        ]);
+        let off_barrier =
+            critical_path_us(&[fast_perception.clone(), grounding(3), deliberation.clone()]);
         assert_eq!(off_barrier, 200 + 5_000);
         assert_eq!(
             on_barrier - off_barrier,

--- a/core/continuum-core/src/commands/genome/curriculum.rs
+++ b/core/continuum-core/src/commands/genome/curriculum.rs
@@ -289,7 +289,7 @@ impl LivedExpansionSynthesizer {
             .iter()
             .filter(|r| r.source == ExperienceSource::Lived)
             .filter(|r| self.detector.assess(r).is_some())
-            .map(|r| r.task.prompt.trim().to_string())
+            .map(|r| r.training_prompt().trim().to_string())
             .filter(|s| !s.is_empty())
             .collect()
     }
@@ -349,6 +349,7 @@ mod tests {
             },
             answer: String::new(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 1,
             source: crate::cognition::experience::ExperienceSource::Eval,
             teammates: Vec::new(),
@@ -423,6 +424,7 @@ mod tests {
             grade: "received lesson from BigMama".to_string(),
             answer: "the call room IS the airc room — never mint a rogue call_id".to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 0,
             source: ExperienceSource::Received,
             teammates: Vec::new(),
@@ -436,6 +438,7 @@ mod tests {
             grade: "lived turn: did not converge".to_string(),
             answer: "half-finished attempt".to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 8,
             source: ExperienceSource::Lived,
             teammates: Vec::new(),
@@ -492,6 +495,7 @@ mod tests {
             },
             answer: "half-finished attempt".to_string(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 8,
             source: ExperienceSource::Lived,
             teammates: Vec::new(),
@@ -525,6 +529,7 @@ mod tests {
             grade: "received lesson from BigMama".into(),
             answer: "the call room IS the airc room".into(),
             world_state: String::new(),
+            room_updates: Default::default(),
             acts: 0,
             source: ExperienceSource::Received,
             teammates: Vec::new(),

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -32,8 +32,8 @@
 //!   refusal is invisible is a gate nobody can debug.
 
 use crate::persona::service_loop::{PersonaConversation, LIVE_MAX_ACTS};
-use crate::persona::work_burst::{held_work_burst, own_recent_thoughts};
 use crate::persona::supervisor::HostedPersona;
+use crate::persona::work_burst::{held_work_burst, own_recent_thoughts};
 
 /// How many run-room rows the write-or-release gate reads to count a holder's
 /// acts since her last write. 80 rows was ~15 minutes of a five-coder room
@@ -121,16 +121,14 @@ pub(crate) async fn ask_the_act_question(
     {
         if let Some(citizen) = conversation.stream_citizen() {
             let claims_result = citizen.active_claims().await;
-            let claims_err =
-                claims_result.as_ref().err().map(|e| e.to_string());
+            let claims_err = claims_result.as_ref().err().map(|e| e.to_string());
             let claims = claims_result.unwrap_or_default();
             let held: Vec<&airc_lib::WorkCard> = claims
                 .iter()
                 .filter(|c| {
                     matches!(
                         c.state,
-                        airc_work::CardState::InProgress
-                            | airc_work::CardState::Claimed
+                        airc_work::CardState::InProgress | airc_work::CardState::Claimed
                     )
                 })
                 .collect();
@@ -139,8 +137,9 @@ pub(crate) async fn ask_the_act_question(
             // resolution was ambiguous, her hands stayed at home, and every act
             // landed in her own repo copy (Lorcan, 2026-09-04). The other card
             // stays held; its turn comes when it is the freshest.
-            let held: Vec<&airc_lib::WorkCard> =
-                crate::persona::work_focus::focus_card(held).into_iter().collect();
+            let held: Vec<&airc_lib::WorkCard> = crate::persona::work_focus::focus_card(held)
+                .into_iter()
+                .collect();
             crate::probe!(
                 class = "persona.work.gate",
                 persona = %ctx.identity.agent_name,
@@ -175,16 +174,20 @@ pub(crate) async fn ask_the_act_question(
                     // `held_work_burst`); paged from the durable store, the
                     // same page the catch-up reads. A failed page is a missing
                     // block, never a failed turn.
-                    let page = crate::persona::durable_history::room_rows(turn_room, WORK_GATE_PAGE_ROWS).await;
+                    let page =
+                        crate::persona::durable_history::room_rows(turn_room, WORK_GATE_PAGE_ROWS)
+                            .await;
                     let last_state = match &page {
                         Ok(rows) => {
                             let about: Vec<String> = held
                                 .iter()
                                 .flat_map(|c| {
-                                    let id8: String = c.card_id.as_uuid().to_string().chars().take(8).collect();
-                                    let inst = crate::commands::benchmark::parse_card_title(&c.title)
-                                        .map(|(_, i)| i)
-                                        .unwrap_or_default();  // unwrap_or: a non-bench title has no instance to scope on
+                                    let id8: String =
+                                        c.card_id.as_uuid().to_string().chars().take(8).collect();
+                                    let inst =
+                                        crate::commands::benchmark::parse_card_title(&c.title)
+                                            .map(|(_, i)| i)
+                                            .unwrap_or_default(); // unwrap_or: a non-bench title has no instance to scope on
                                     [id8, inst]
                                 })
                                 .collect();
@@ -209,14 +212,23 @@ pub(crate) async fn ask_the_act_question(
                     );
                     // No page = no note (a fresh card carries none); the absence is not a quantity.
                     let progress = match &page {
-                        Ok(rows) => crate::persona::work_burst::card_progress(rows, ctx.identity.peer_id.as_uuid()),
+                        Ok(rows) => crate::persona::work_burst::card_progress(
+                            rows,
+                            ctx.identity.peer_id.as_uuid(),
+                        ),
                         Err(_) => crate::persona::work_burst::CardProgress::default(),
                     };
                     let acts_without_write = page
                         .as_ref()
-                        .map(|rows| crate::persona::work_burst::acts_since_last_write(rows, ctx.identity.peer_id.as_uuid()))
+                        .map(|rows| {
+                            crate::persona::work_burst::acts_since_last_write(
+                                rows,
+                                ctx.identity.peer_id.as_uuid(),
+                            )
+                        })
                         .unwrap_or(0); // unwrap_or: no page = no acts counted; the gate stays open, never closes on absence
-                    if acts_without_write >= crate::persona::work_burst::WRITE_OR_RELEASE_AFTER_ACTS {
+                    if acts_without_write >= crate::persona::work_burst::WRITE_OR_RELEASE_AFTER_ACTS
+                    {
                         crate::probe!(
                             class = "persona.work.write_or_release_gate",
                             persona = %ctx.identity.agent_name,
@@ -233,8 +245,11 @@ pub(crate) async fn ask_the_act_question(
                             if crate::commands::benchmark::parse_review_title(&c.title).is_some() {
                                 continue;
                             }
-                            let Some(claim_id) = c.claim_id.clone() else { continue };
-                            let id8: String = c.card_id.as_uuid().to_string().chars().take(8).collect();
+                            let Some(claim_id) = c.claim_id.clone() else {
+                                continue;
+                            };
+                            let id8: String =
+                                c.card_id.as_uuid().to_string().chars().take(8).collect();
                             let reason = format!(
                                 "released by the substrate: {acts_without_write} acts without a write"
                             );
@@ -270,7 +285,12 @@ pub(crate) async fn ask_the_act_question(
                             }
                         }
                     }
-                    let burst_text = crate::persona::work_burst::held_work_burst_gated(&held, &last_state, acts_without_write, &progress);
+                    let burst_text = crate::persona::work_burst::held_work_burst_gated(
+                        &held,
+                        &last_state,
+                        acts_without_write,
+                        &progress,
+                    );
                     // The producer's CONTEXT half, kept before the burst is
                     // moved into the driver — one construction, so the
                     // training example records the prompt she was actually
@@ -284,10 +304,7 @@ pub(crate) async fn ask_the_act_question(
                         burst_text,
                     );
                     let work_framing =
-                        crate::cognition::workspace::TurnFraming::self_thread(
-                            false,
-                        )
-                        .on_workspace();
+                        crate::cognition::workspace::TurnFraming::self_thread(false).on_workspace();
                     // HANDS FOLLOW THE CARD (#456). Her held card may be a
                     // staged benchmark checkout — a real git repo under
                     // `workspace/swe/<instance>`. Without rooting her hands
@@ -331,9 +348,7 @@ pub(crate) async fn ask_the_act_question(
                     let work_hands = match &card_workspace {
                         Some(ws) => {
                             let hands =
-                                crate::cognition::persona_workspace::ActingHands::of(
-                                    &cycle,
-                                );
+                                crate::cognition::persona_workspace::ActingHands::of(&cycle);
                             match crate::cognition::persona_workspace::root_acting_workspace(
                                 &cycle,
                                 &ws.to_string_lossy(),
@@ -373,7 +388,9 @@ pub(crate) async fn ask_the_act_question(
                                         // she never guesses an interpreter.
                                         body.working_memory.pin_fact(
                                             "env",
-                                            &crate::persona::instance_env_fact::instance_env_fact(&ws),
+                                            &crate::persona::instance_env_fact::instance_env_fact(
+                                                &ws,
+                                            ),
                                         );
                                     }
                                     crate::probe!(
@@ -408,11 +425,12 @@ pub(crate) async fn ask_the_act_question(
                         }
                         None => None,
                     };
-                    let work = crate::cognition::act_observe::drive_to_settle(
+                    let work = crate::cognition::act_observe::drive_to_settle_with_input(
                         &cycle,
                         burst,
                         LIVE_MAX_ACTS,
                         work_framing,
+                        conversation,
                     )
                     .await;
                     // Give her back her own hands BEFORE anything else can
@@ -420,10 +438,8 @@ pub(crate) async fn ask_the_act_question(
                     // Acted) must leave her rooted at home (#312).
                     if let Some(hands) = &work_hands {
                         if let Err(e) =
-                            crate::cognition::persona_workspace::restore_acting_workspace(
-                                hands,
-                            )
-                            .await
+                            crate::cognition::persona_workspace::restore_acting_workspace(hands)
+                                .await
                         {
                             tracing::error!(
                                 persona = %ctx.identity.agent_name,
@@ -443,13 +459,9 @@ pub(crate) async fn ask_the_act_question(
                         }
                     }
                     let (work_step, _) =
-                        crate::cognition::act_observe::SettleStep::from_settled(
-                            work,
-                        );
+                        crate::cognition::act_observe::SettleStep::from_settled(work);
                     match work_step {
-                        crate::cognition::act_observe::SettleStep::Spoke(
-                            text,
-                        ) => {
+                        crate::cognition::act_observe::SettleStep::Spoke(text) => {
                             // She worked and has something to report —
                             // that report earned its send.
                             crate::probe!(
@@ -463,9 +475,7 @@ pub(crate) async fn ask_the_act_question(
                             // is the A.6 arrival room already resolved
                             // for this turn, so the report lands in the
                             // room whose work it reports on.
-                            if let Err(e) =
-                                conversation.say_in(turn_room, &text).await
-                            {
+                            if let Err(e) = conversation.say_in(turn_room, &text).await {
                                 tracing::warn!(
                                     error = %e,
                                     "work-turn report failed to send"

--- a/core/continuum-core/src/persona/airc_persona_conversation.rs
+++ b/core/continuum-core/src/persona/airc_persona_conversation.rs
@@ -68,7 +68,7 @@ const QUIET_WATCHDOG: std::time::Duration = std::time::Duration::from_secs(90);
 /// How often the store-backed catch-up pages every subscribed room's tail.
 const CATCH_UP_EVERY: std::time::Duration = std::time::Duration::from_secs(60);
 /// Events paged per room per catch-up tick.
-const CATCH_UP_PAGE: usize = 32;
+pub(crate) const CATCH_UP_PAGE: usize = 32;
 /// Event ids remembered per room to tell "seen" from "dropped" (bounded).
 const SEEN_RING: usize = 128;
 
@@ -342,6 +342,10 @@ pub struct AircPersonaConversation {
     /// A consumed epoch whose async reattach has not finished. `next_message`
     /// is cancellation-safe: a competing service-loop wake cannot lose it.
     refresh_pending: bool,
+    /// Input already perceived during work, still owned for later room attention.
+    perceived_backlog: std::collections::VecDeque<Arc<IncomingMessage>>,
+    /// A live event being admitted; retained across cancellation at the work bridge.
+    ready_event: Option<Arc<TranscriptEvent>>,
     /// The persona's own peer_id, captured at construction. Used by
     /// `next_message` to skip self-loop echoes WITHIN the projection
     /// — the service loop ALSO skips by persona's instance peer_id;
@@ -417,6 +421,8 @@ impl AircPersonaConversation {
             runtime,
             rooms: None,
             refresh_pending: false,
+            perceived_backlog: std::collections::VecDeque::new(),
+            ready_event: None,
             own_peer_id,
             inbox: None,
             pump: None,
@@ -470,6 +476,15 @@ impl AircPersonaConversation {
         }
         self.rejoin_backlog
             .retain(|message| rooms.contains(&message.room_id));
+        self.perceived_backlog
+            .retain(|message| rooms.contains(&message.room_id));
+        if self
+            .ready_event
+            .as_ref()
+            .is_some_and(|event| !rooms.contains(&event.room_id.as_uuid()))
+        {
+            self.ready_event = None;
+        }
         self.rooms = Some(rooms);
         Ok(active)
     }
@@ -611,7 +626,7 @@ impl AircPersonaConversation {
 
 /// In-process inbox depth between the pump and the loop. A turn in progress
 /// can leave the loop away for minutes; 8k events is hours of a busy room.
-const INBOX_CAPACITY: usize = 8_192;
+pub(crate) const INBOX_CAPACITY: usize = 8_192;
 
 /// The live stream is dead when a catch-up tick admits events from the store
 /// while no live frame arrived since the previous tick. The first tick after
@@ -674,48 +689,13 @@ async fn reopen_live_stream(
     }
 }
 
-#[async_trait]
-impl PersonaConversation for AircPersonaConversation {
-    /// Eagerly opens the airc subscribe stream. Idempotent — calling
-    /// twice is a no-op after the first.
-    ///
-    /// Replaces the slice-11 lazy-on-first-next_message subscribe.
-    /// `serve_persona_loop` calls this once at boot so the daemon
-    /// round-trip lands at startup instead of on the first cognition
-    /// turn. The lazy branch in `next_message` stays as a fallback
-    /// for callers that don't call `prime` first (e.g., direct
-    /// integration tests). Per [[no-fallbacks-ever]] the fallback
-    /// has identical semantics — it's not a degraded path, it's a
-    /// later-binding path.
-    async fn prime(&mut self) -> Result<(), String> {
-        if self.rooms.is_some() {
-            return Ok(());
-        }
-        if !self.refresh_membership().await? {
-            return Ok(());
-        }
-        // #146 diagnostic: confirm the CHAT subscribe stream actually opened for
-        // this persona. Post-reboot the personas were room-deaf (0 perceptual
-        // decodes) while the core-positron raw-attach path received fine — this
-        // pins whether prime() even ran per persona.
-        crate::probe!(
-            class = "persona.inbound.subscribe_opened",
-            persona = %self.own_peer_id,
-            "persona chat subscribe stream opened (#146)"
-        );
-        // Seed the rejoin-replay watermark at the CURRENT transcript head, so the
-        // first runtime room-join can never replay pre-subscribe history as fresh
-        // perception (the #131 "room starts at join" rule, preserved under replay).
-        self.last_lamport = self.high_water_mark(64).await.unwrap_or(0); // unwrap_or: an unreadable watermark = 0 (never read), the documented floor
-        Ok(())
-    }
-
-    async fn high_water_mark(&self, limit: usize) -> Result<u64, String> {
-        let events = self.page_subscribed_rooms(limit).await?;
-        Ok(events.iter().map(|e| e.lamport).max().unwrap_or(0)) // unwrap_or: an empty page has no lamport; 0 = never read
-    }
-
-    async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
+impl AircPersonaConversation {
+    async fn next_message_inner(
+        &mut self,
+        wait: bool,
+        take_retained: bool,
+    ) -> Result<Option<IncomingMessage>, String> {
+        let mut ready_scan_remaining = CATCH_UP_PAGE;
         // Per [[no-fallbacks-ever]]: prime() is the substrate's
         // single contract for opening the subscribe stream. If a
         // caller reaches next_message without having primed, the
@@ -746,10 +726,34 @@ impl PersonaConversation for AircPersonaConversation {
         // over-counts skips for events the conversation already
         // knows aren't relevant.
         loop {
+            if !wait
+                && !self.refresh_pending
+                && !matches!(self.membership_epoch.has_changed(), Ok(true))
+            // Closed receiver means fixed membership, matching the parked changed() branch below.
+            {
+                if ready_scan_remaining == 0 {
+                    return Ok(None);
+                }
+                ready_scan_remaining -= 1;
+            }
             // Rejoin-replayed turns first — they are OLDER than anything the live
             // stream will yield, and ordering is what keeps an addressed kickoff
             // ahead of the chatter that follows it.
-            if !self.refresh_pending && !self.membership_epoch.has_changed().unwrap_or(false) {
+            if !self.refresh_pending && !matches!(self.membership_epoch.has_changed(), Ok(true)) {
+                // A closed fixed-membership receiver cannot announce another refresh.
+                if take_retained {
+                    if let Some(message) = self.perceived_backlog.pop_front() {
+                        return Ok(Some(Arc::unwrap_or_clone(message)));
+                    }
+                }
+                if let Some(event) = self.ready_event.clone() {
+                    let message = self.admit_event(event).await;
+                    self.ready_event = None;
+                    if message.is_some() {
+                        return Ok(message);
+                    }
+                    continue;
+                }
                 if let Some(replayed) = self.rejoin_backlog.pop_front() {
                     return Ok(Some(replayed));
                 }
@@ -790,32 +794,35 @@ impl PersonaConversation for AircPersonaConversation {
                     // store whether the room moved on; if it did, the stream is dead —
                     // re-open it and replay the gap, exactly as a membership change does.
                     _ = tokio::time::sleep_until(self.next_catch_up), if active => Polled::Quiet,
+                    _ = std::future::ready(()), if !wait => return Ok(None),
                 }
             };
             let reason: &'static str = match polled {
-                Polled::Event(ev) => match ev {
-                    None => {
-                        crate::probe!(
-                        class = "persona.inbound.stream_ended",
-                                    persona = %self.own_peer_id,
-                                    "airc subscribe stream ended unrecoverably — airc-lib dropped \
-                                     the subscription (likely wire-schema drift between continuum \
-                                     and airc builds, or the EventStream was released). NOT \
-                                     auto-resubscribing: airc-lib owns transient reconnection, so \
-                                     a terminal end here is a real fault to fix, not a hiccup to heal."
-                                );
-                        return Ok(None);
-                    }
-                    Some(Err(lag)) => {
-                        return Err(format!("live stream lag: {lag}"));
-                    }
-                    Some(Ok(event)) => {
-                        if let Some(msg) = self.admit_event(event).await {
-                            return Ok(Some(msg));
+                Polled::Event(ev) => {
+                    match ev {
+                        None => {
+                            crate::probe!(
+                            class = "persona.inbound.stream_ended",
+                                        persona = %self.own_peer_id,
+                                        "airc subscribe stream ended unrecoverably — airc-lib dropped \
+                                         the subscription (likely wire-schema drift between continuum \
+                                         and airc builds, or the EventStream was released). NOT \
+                                         auto-resubscribing: airc-lib owns transient reconnection, so \
+                                         a terminal end here is a real fault to fix, not a hiccup to heal."
+                                    );
+                            return Ok(None);
                         }
-                        continue;
+                        Some(Err(lag)) => {
+                            return Err(format!("live stream lag: {lag}"));
+                        }
+                        Some(Ok(event)) => {
+                            // Own the event before any await in admission. A cancelled
+                            // ready-drain resumes this same event on its next call.
+                            self.ready_event = Some(event);
+                            continue;
+                        }
                     }
-                },
+                }
                 Polled::Membership => {
                     self.refresh_pending = true;
                     "room membership changed at runtime — refreshing the subscription snapshot"
@@ -896,6 +903,70 @@ impl PersonaConversation for AircPersonaConversation {
             };
         }
     }
+}
+
+#[async_trait]
+impl PersonaConversation for AircPersonaConversation {
+    /// Eagerly opens the airc subscribe stream. Idempotent — calling
+    /// twice is a no-op after the first.
+    ///
+    /// Replaces the slice-11 lazy-on-first-next_message subscribe.
+    /// `serve_persona_loop` calls this once at boot so the daemon
+    /// round-trip lands at startup instead of on the first cognition
+    /// turn. The lazy branch in `next_message` stays as a fallback
+    /// for callers that don't call `prime` first (e.g., direct
+    /// integration tests). Per [[no-fallbacks-ever]] the fallback
+    /// has identical semantics — it's not a degraded path, it's a
+    /// later-binding path.
+    async fn prime(&mut self) -> Result<(), String> {
+        if self.rooms.is_some() {
+            return Ok(());
+        }
+        if !self.refresh_membership().await? {
+            return Ok(());
+        }
+        // #146 diagnostic: confirm the CHAT subscribe stream actually opened for
+        // this persona. Post-reboot the personas were room-deaf (0 perceptual
+        // decodes) while the core-positron raw-attach path received fine — this
+        // pins whether prime() even ran per persona.
+        crate::probe!(
+            class = "persona.inbound.subscribe_opened",
+            persona = %self.own_peer_id,
+            "persona chat subscribe stream opened (#146)"
+        );
+        // Seed the rejoin-replay watermark at the CURRENT transcript head, so the
+        // first runtime room-join can never replay pre-subscribe history as fresh
+        // perception (the #131 "room starts at join" rule, preserved under replay).
+        self.last_lamport = self.high_water_mark(64).await.unwrap_or(0); // unwrap_or: an unreadable watermark = 0 (never read), the documented floor
+        Ok(())
+    }
+
+    async fn high_water_mark(&self, limit: usize) -> Result<u64, String> {
+        let events = self.page_subscribed_rooms(limit).await?;
+        Ok(events.iter().map(|e| e.lamport).max().unwrap_or(0)) // unwrap_or: an empty page has no lamport; 0 = never read
+    }
+
+    async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String> {
+        self.next_message_inner(true, true).await
+    }
+
+    async fn perceive_ready(
+        &mut self,
+    ) -> Result<&std::collections::VecDeque<Arc<IncomingMessage>>, String> {
+        for _ in 0..CATCH_UP_PAGE {
+            if self.perceived_backlog.len() >= INBOX_CAPACITY {
+                return Err(
+                    "retained room attention reached inbox capacity; input remains queued"
+                        .to_string(),
+                );
+            }
+            match self.next_message_inner(false, false).await? {
+                Some(message) => self.perceived_backlog.push_back(Arc::new(message)),
+                None => break,
+            }
+        }
+        Ok(&self.perceived_backlog)
+    }
 
     async fn say_in(&self, room_id: Uuid, text: &str) -> Result<(), String> {
         self.runtime
@@ -962,6 +1033,67 @@ fn perceptual_from_event(event: &TranscriptEvent) -> Result<IncomingMessage, &'s
 
 #[cfg(test)]
 mod tests {
+    // what this catches: c5910be2 — ready intake must use the real decoder, keep
+    // both rooms, return promptly on an empty inbox, and retain source ownership
+    // if a drive drops its snapshot before submitting another request.
+    #[tokio::test]
+    async fn ready_room_input_is_shared_and_retained_for_later_attention() {
+        use super::*;
+        use crate::persona::airc_citizen::StubAircCitizen;
+        let own = Uuid::new_v4();
+        let peer = Uuid::new_v4();
+        let rooms = vec![Uuid::new_v4(), Uuid::new_v4()];
+        let runtime = Arc::new(StubAircCitizen::new(own).with_rooms(rooms.clone()));
+        let mut conversation = AircPersonaConversation::new(runtime);
+        // Lease the existing in-process inbox at the pump/consumer boundary;
+        // no daemon or transport owner is started by this regression.
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        conversation.rooms = Some(rooms.clone());
+        conversation.inbox = Some(rx);
+        let mut ids = Vec::new();
+        for (index, room) in rooms.iter().enumerate() {
+            let id = Uuid::new_v4();
+            ids.push(id);
+            let event = event_from_row(
+                *room,
+                crate::persona::durable_history::RoomRow {
+                    id,
+                    sender: peer,
+                    occurred_at_ms: index as u64,
+                    text: format!("colleague input {index}"),
+                },
+            );
+            tx.send(Ok(Arc::new(event))).await.unwrap();
+        }
+        let snapshot = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            conversation.perceive_ready(),
+        )
+        .await
+        .expect("ready drain must not wait for another arrival")
+        .unwrap();
+        let snapshot = snapshot.clone();
+        assert_eq!(snapshot.len(), 2);
+        let repeated = conversation.perceive_ready().await.unwrap();
+        for (index, message) in snapshot.iter().enumerate() {
+            assert_eq!(message.event_id, ids[index]);
+            assert_eq!(message.room_id, rooms[index]);
+            assert_eq!(message.peer_id, peer);
+            assert!(
+                Arc::ptr_eq(message, &repeated[index]),
+                "snapshots lease the same input object"
+            );
+        }
+        drop(snapshot);
+        for id in ids {
+            assert_eq!(
+                conversation.next_message().await.unwrap().unwrap().event_id,
+                id
+            );
+        }
+        assert!(conversation.perceive_ready().await.unwrap().is_empty());
+    }
+
     /// what this catches: e0d64552 — the actual membership commands persisted
     /// their changes but bypassed the epoch that refreshes a living stream.
     /// This uses an isolated real scope, not a mocked membership notification.
@@ -1546,7 +1678,6 @@ impl AircPersonaConversation {
         }
         // Every non-chunk event advances the rejoin-replay watermark, so a
         // later reopen replays only what this stream genuinely never saw.
-        self.last_lamport = self.last_lamport.max(event.lamport);
         // #146 diagnostic: EVERY raw event this persona's subscribe
         // stream yields, before any filter. If this probe never fires
         // under a room burst, the stream is empty → airc-lib delivery
@@ -1573,6 +1704,7 @@ impl AircPersonaConversation {
         // event process-wide (the bridge dedups by event id); this is
         // the single emitter the grade-on-done subscriber hears.
         crate::modules::work::bridge_wire_work_event(&event).await;
+        self.last_lamport = self.last_lamport.max(event.lamport);
         // Recover a perceptual room turn. Two on-wire shapes
         // reach a persona's subscribe stream and both are
         // messages it must hear: a peer's plain-text `say()`

--- a/core/continuum-core/src/persona/scripted_conversation.rs
+++ b/core/continuum-core/src/persona/scripted_conversation.rs
@@ -59,12 +59,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
+/// Shared input queue: the conversation consumes events while its feed appends
+/// messages, stream endings, or explicit failures at controlled action boundaries.
+type ScriptedEventQueue = Arc<Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>>;
+
 /// System-level, configurable `PersonaConversation` impl. Public
 /// because every test in the substrate leases it; not behind
 /// `#[cfg(test)]`.
 pub struct ScriptedConversation {
     high_water: u64,
-    events: Arc<Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>>,
+    events: ScriptedEventQueue,
     perceived_backlog: VecDeque<Arc<IncomingMessage>>,
     /// Every reply the loop posted, WITH the room it was posted into.
     /// The room is recorded because "she answered" and "she answered
@@ -267,7 +271,7 @@ impl PersonaConversation for ScriptedConversation {
 /// The input side of a scripted conversation; the service remains its sole reader.
 #[derive(Clone)]
 #[cfg(any(test, feature = "test-fixtures"))]
-pub struct ScriptedConversationFeed(Arc<Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>>);
+pub struct ScriptedConversationFeed(ScriptedEventQueue);
 
 #[cfg(any(test, feature = "test-fixtures"))]
 impl ScriptedConversationFeed {

--- a/core/continuum-core/src/persona/scripted_conversation.rs
+++ b/core/continuum-core/src/persona/scripted_conversation.rs
@@ -278,8 +278,8 @@ impl ScriptedConversationFeed {
     pub fn push(&self, event: Result<Option<IncomingMessage>, String>) {
         self.0
             .lock()
-            .expect("scripted input lock poisoned")
-            .push_back(event); // A poisoned fixture cannot safely inject input; fail the simulation explicitly.
+            .expect("scripted input lock poisoned") // A poisoned fixture cannot safely inject input; fail the simulation explicitly.
+            .push_back(event);
     }
 }
 

--- a/core/continuum-core/src/persona/scripted_conversation.rs
+++ b/core/continuum-core/src/persona/scripted_conversation.rs
@@ -56,7 +56,7 @@ use crate::persona::service_loop::{IncomingMessage, PersonaConversation};
 use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 /// System-level, configurable `PersonaConversation` impl. Public
@@ -64,7 +64,8 @@ use uuid::Uuid;
 /// `#[cfg(test)]`.
 pub struct ScriptedConversation {
     high_water: u64,
-    events: Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>,
+    events: Arc<Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>>,
+    perceived_backlog: VecDeque<Arc<IncomingMessage>>,
     /// Every reply the loop posted, WITH the room it was posted into.
     /// The room is recorded because "she answered" and "she answered
     /// the room that asked" are different claims, and only the second
@@ -94,7 +95,8 @@ impl ScriptedConversation {
     pub fn new() -> Self {
         Self {
             high_water: 0,
-            events: Mutex::new(VecDeque::new()),
+            events: Arc::new(Mutex::new(VecDeque::new())),
+            perceived_backlog: VecDeque::new(),
             said: Mutex::new(Vec::new()),
             primed: AtomicUsize::new(0),
             prime_result: Mutex::new(Ok(())),
@@ -125,6 +127,13 @@ impl ScriptedConversation {
     pub fn with_events(self, events: Vec<Result<Option<IncomingMessage>, String>>) -> Self {
         *self.events.lock().unwrap() = VecDeque::from(events);
         self
+    }
+
+    /// Lease the scripted source so an in-flight tool can inject an arrival at
+    /// an exact boundary, without a sleep, second conversation, or live transport.
+    #[cfg(any(test, feature = "test-fixtures"))]
+    pub fn event_feed(&self) -> ScriptedConversationFeed {
+        ScriptedConversationFeed(Arc::clone(&self.events))
     }
 
     /// Set the pre-attach high-water mark — what `high_water_mark`
@@ -212,7 +221,35 @@ impl PersonaConversation for ScriptedConversation {
                 None => Ok(None),
             };
         }
+        if let Some(message) = self.perceived_backlog.pop_front() {
+            return Ok(Some(Arc::unwrap_or_clone(message)));
+        }
         self.events.lock().unwrap().pop_front().unwrap_or(Ok(None))
+    }
+
+    async fn perceive_ready(
+        &mut self,
+    ) -> Result<&std::collections::VecDeque<Arc<IncomingMessage>>, String> {
+        if self.require_prime && self.primed.load(Ordering::SeqCst) == 0 {
+            return Err("ScriptedConversation::perceive_ready called before prime()".into());
+        }
+        let mut events = self
+            .events
+            .lock()
+            .map_err(|_| "scripted conversation lock poisoned".to_string())?;
+        for _ in 0..super::airc_persona_conversation::CATCH_UP_PAGE {
+            if self.perceived_backlog.len() >= super::airc_persona_conversation::INBOX_CAPACITY {
+                return Err(
+                    "retained room attention reached inbox capacity; input remains queued".into(),
+                );
+            }
+            match events.pop_front() {
+                Some(Ok(Some(message))) => self.perceived_backlog.push_back(Arc::new(message)),
+                Some(Err(error)) => return Err(error),
+                Some(Ok(None)) | None => break,
+            }
+        }
+        Ok(&self.perceived_backlog)
     }
 
     async fn say_in(&self, room_id: Uuid, text: &str) -> Result<(), String> {
@@ -224,6 +261,21 @@ impl PersonaConversation for ScriptedConversation {
         &self,
     ) -> Option<std::sync::Arc<dyn crate::persona::airc_citizen::AircCitizen>> {
         self.citizen.clone()
+    }
+}
+
+/// The input side of a scripted conversation; the service remains its sole reader.
+#[derive(Clone)]
+#[cfg(any(test, feature = "test-fixtures"))]
+pub struct ScriptedConversationFeed(Arc<Mutex<VecDeque<Result<Option<IncomingMessage>, String>>>>);
+
+#[cfg(any(test, feature = "test-fixtures"))]
+impl ScriptedConversationFeed {
+    pub fn push(&self, event: Result<Option<IncomingMessage>, String>) {
+        self.0
+            .lock()
+            .expect("scripted input lock poisoned")
+            .push_back(event); // A poisoned fixture cannot safely inject input; fail the simulation explicitly.
     }
 }
 

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -55,7 +55,7 @@ use uuid::Uuid;
 /// full `TranscriptEvent` surface so the conversation abstraction
 /// stays compact and the trait remains stubbable without dragging
 /// every airc type into the test.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct IncomingMessage {
     /// The transcript event this turn came from — the row a `chat:heard`
     /// receipt points back at. Nil for scripted/synthetic turns.
@@ -82,6 +82,17 @@ pub struct IncomingMessage {
     /// RAG source (roster, doctrine, board, kanban) abstained — she heard the
     /// words but stood in no room (glass-boxed 2026-07-23, Anwen ACK test).
     pub room_id: Uuid,
+}
+
+impl IncomingMessage {
+    /// The same source-labelled input at inference, replay and teaching boundaries.
+    /// This is rendering, not a replacement for the typed event/room identity.
+    pub(crate) fn render_room_update(&self) -> String {
+        format!(
+            "[Room message received during this turn; room {}; peer {}; event {}]\n{}",
+            self.room_id, self.peer_id, self.event_id, self.text
+        )
+    }
 }
 
 /// Polymorphism rail for "talk to the grid as this persona". The
@@ -129,6 +140,14 @@ pub trait PersonaConversation: Send + Sync {
     /// backward compat) but the substrate's preferred path is
     /// eager priming so the round-trip lands off the hot path.
     async fn next_message(&mut self) -> Result<Option<IncomingMessage>, String>;
+
+    /// Perceive currently ready room input without waiting for a new arrival.
+    /// The conversation RETAINS ownership for subsequent room attention, including
+    /// if the active drive is cancelled or cannot fit these inputs. Repeated
+    /// snapshots may overlap: the drive uses the ordinary event-id deduper.
+    async fn perceive_ready(
+        &mut self,
+    ) -> Result<&std::collections::VecDeque<Arc<IncomingMessage>>, String>;
 
     /// Reply with text INTO A NAMED ROOM — normally the room the turn
     /// being answered arrived in ([`IncomingMessage::room_id`]).
@@ -553,7 +572,7 @@ async fn serve_persona_loop_inner(
                             std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_millis() as u64)
-                                .unwrap_or(0),  // unwrap_or: clock before the epoch = 0
+                                .unwrap_or(0), // unwrap_or: clock before the epoch = 0
                         )
                     {
                         crate::probe!(
@@ -680,15 +699,16 @@ async fn serve_persona_loop_inner(
         // Trigger = newest DIRECTED line in the backlog (a question put to her
         // outranks newer ambient chatter — she answers it WITH the newer
         // context visible in the transcript), else the newest overall.
-        let (msg, coalesced) = match crate::persona::wake_backlog::pick_trigger(qualifying, priority_line) {
-            Some(picked) => picked,
-            None => {
-                if stream_ended {
-                    break;
+        let (msg, coalesced) =
+            match crate::persona::wake_backlog::pick_trigger(qualifying, priority_line) {
+                Some(picked) => picked,
+                None => {
+                    if stream_ended {
+                        break;
+                    }
+                    continue; // everything drained was stale/self — no turn
                 }
-                continue; // everything drained was stale/self — no turn
-            }
-        };
+            };
         if coalesced > 0 {
             outcome.turns_skipped += coalesced;
             crate::probe!(
@@ -804,7 +824,7 @@ async fn serve_persona_loop_inner(
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
-                .unwrap_or_default(),  // unwrap_or: a pre-epoch clock reads 0, as every other now_ms here
+                .unwrap_or_default(), // unwrap_or: a pre-epoch clock reads 0, as every other now_ms here
         );
         crate::probe!(
             class = "persona.turn.start",
@@ -1019,22 +1039,21 @@ async fn serve_persona_loop_inner(
         // Carry the wake message's engram as this burst's cause, so the turn's acts
         // chain back to what triggered them (CAUSAL-MEMORY-GRAPH.md §3a). `None` when
         // the message was deduped/quarantined — an honest gap, never a made-up link.
-        let workspace_burst =
-            crate::cognition::workspace::Burst::from_turns_at(
-                // turn_room falls back to identity.default_room (A.6), which is minted
-                // v4 at identity creation — non-nil by construction.
-                crate::identity::ActivityRoom::from_uuid(turn_room)
-                    .expect("turn_room falls back to the identity's default_room, never nil"), // default_room is minted v4 at identity creation; never nil
-                ws_turns,
-                Some(now_ms),
-                // The arrival that woke this turn IS its cause. A dedup Drop or a
-                // Quarantine put nothing in the store, so those fall back to Ambient
-                // rather than pointing an edge at an engram that does not exist.
-                match wake_engram {
-                    Some(id) => crate::cognition::workspace::Cause::Stimulus(id),
-                    None => crate::cognition::workspace::Cause::Ambient,
-                },
-            );
+        let workspace_burst = crate::cognition::workspace::Burst::from_turns_at(
+            // turn_room falls back to identity.default_room (A.6), which is minted
+            // v4 at identity creation — non-nil by construction.
+            crate::identity::ActivityRoom::from_uuid(turn_room)
+                .expect("turn_room falls back to the identity's default_room, never nil"), // default_room is minted v4 at identity creation; never nil
+            ws_turns,
+            Some(now_ms),
+            // The arrival that woke this turn IS its cause. A dedup Drop or a
+            // Quarantine put nothing in the store, so those fall back to Ambient
+            // rather than pointing an edge at an engram that does not exist.
+            match wake_engram {
+                Some(id) => crate::cognition::workspace::Cause::Stimulus(id),
+                None => crate::cognition::workspace::Cause::Ambient,
+            },
+        );
         // Mark this world-state as just-deliberated so the next heartbeat tick doesn't
         // re-run the same burst (the message path and the self-tick share the gate;
         // own chat is excluded so this reply can't re-trigger a self-tick, while her
@@ -1244,11 +1263,12 @@ async fn serve_persona_loop_inner(
                 )
                 .await;
                 let (step, turn_metrics) = {
-                    let outcome = crate::cognition::act_observe::drive_to_settle(
+                    let outcome = crate::cognition::act_observe::drive_to_settle_with_input(
                         &cycle,
                         workspace_burst,
                         LIVE_MAX_ACTS,
                         framing,
+                        conversation,
                     )
                     .await;
                     // The lived-turn experience write (#319) is NOT here: it lives inside
@@ -1334,16 +1354,16 @@ async fn serve_persona_loop_inner(
                         // THE ACT-QUESTION. Asked here on the PASS path and again after a spoken reply,
                         // so holding work is what makes it fire — not declining to speak.
                         // `directed` is recomputed here rather than threaded: it is a pure function of
-        // (identity, msg.text) and the binding above lives inside the cycle branch.
-        let spoke_directed = ctx.identity.persona_identity().mentions(&msg.text);
-        crate::persona::act_question::ask_the_act_question(
-            ctx,
-            conversation,
-            msg.lamport,
-            turn_room,
-            spoke_directed,
-        )
-        .await;
+                        // (identity, msg.text) and the binding above lives inside the cycle branch.
+                        let spoke_directed = ctx.identity.persona_identity().mentions(&msg.text);
+                        crate::persona::act_question::ask_the_act_question(
+                            ctx,
+                            conversation,
+                            msg.lamport,
+                            turn_room,
+                            spoke_directed,
+                        )
+                        .await;
                         outcome.turns_skipped += 1;
                         continue;
                     }
@@ -1524,8 +1544,8 @@ async fn serve_persona_loop_inner(
             turn_duration_ms = turn_duration_ms,
             turns_replied = outcome.turns_replied,
             mean_ms = outcome.turn_latency.mean_ms().unwrap_or(0.0),
-            min_ms = outcome.turn_latency.min_ms.unwrap_or(0),  // unwrap_or: clock before the epoch = 0
-            max_ms = outcome.turn_latency.max_ms.unwrap_or(0),  // unwrap_or: clock before the epoch = 0
+            min_ms = outcome.turn_latency.min_ms.unwrap_or(0), // unwrap_or: clock before the epoch = 0
+            max_ms = outcome.turn_latency.max_ms.unwrap_or(0), // unwrap_or: clock before the epoch = 0
             recall_ms = phase_timings.recall_ms,
             admit_ms = phase_timings.admit_ms,
             compose_ms = phase_timings.compose_ms,
@@ -1878,10 +1898,6 @@ fn push_work_board_anchor(
     turns.push(crate::cognition::workspace::BurstTurn::perception(anchor));
 }
 
-
-
-
-
 pub(crate) fn build_workspace_turns(
     deliveries: &[crate::persona::rag_budget::RagDelivery],
     own_peer: &str,
@@ -2192,7 +2208,9 @@ pub(crate) fn build_workspace_turns(
         live_cards.truncate(5);
         lost_threads.truncate(3);
 
-        use crate::cognition::framing_echo::{WAKE_MID_WORK, WAKE_NO_WORK, WAKE_OPENING, WAKE_PRESENT, WAKE_QUIET, WAKE_TAG};
+        use crate::cognition::framing_echo::{
+            WAKE_MID_WORK, WAKE_NO_WORK, WAKE_OPENING, WAKE_PRESENT, WAKE_QUIET, WAKE_TAG,
+        };
         // The fixed sentences live in cognition::framing_echo — the gate that
         // silences a reflected wake prompt matches on the SAME constants.
         let mut b = format!("{WAKE_TAG} You are {agent_name}, {WAKE_OPENING}.");
@@ -2413,7 +2431,6 @@ fn spawn_token_forwarder(
     })
 }
 
-
 /// One intrinsic heartbeat. Returns `true` iff the cycle's INFERENCE tail (the
 /// musing turn) was starved of an ambient permit — the deterministic head (held-work
 /// act question, kanban pull) always runs.
@@ -2445,23 +2462,17 @@ async fn run_self_cycle(
     // falls back home — never a guess. Freshest = max claim_expires_at_ms,
     // i.e. the claim most recently taken or heartbeated.
     let focus_room = match conversation.stream_citizen() {
-        Some(citizen) => citizen
-            .active_claims()
-            .await
-            .ok()
-            .and_then(|cards| {
-                let mut live: Vec<_> = cards
-                    .iter()
-                    .filter_map(|c| {
-                        let room = crate::cognition::bench_round::room_for_card(
-                            c.card_id.as_uuid(),
-                        )?;
-                        Some((c.claim_expires_at_ms.unwrap_or(0), room)) // unknown expiry sorts LEAST-fresh: it can never win focus over a known-live lease, and a lone expiry-less claim still focuses (better than home)
-                    })
-                    .collect();
-                live.sort_by_key(|(exp, _)| *exp);
-                live.pop().map(|(_, room)| room)
-            }),
+        Some(citizen) => citizen.active_claims().await.ok().and_then(|cards| {
+            let mut live: Vec<_> = cards
+                .iter()
+                .filter_map(|c| {
+                    let room = crate::cognition::bench_round::room_for_card(c.card_id.as_uuid())?;
+                    Some((c.claim_expires_at_ms.unwrap_or(0), room)) // unknown expiry sorts LEAST-fresh: it can never win focus over a known-live lease, and a lone expiry-less claim still focuses (better than home)
+                })
+                .collect();
+            live.sort_by_key(|(exp, _)| *exp);
+            live.pop().map(|(_, room)| room)
+        }),
         None => None,
     };
     if let Some(room) = focus_room {
@@ -2486,7 +2497,7 @@ async fn run_self_cycle(
     // concludes it (`PASS: done`) — the autonomous loop the architecture always
     // promised ("the heartbeat advances my thread, not just reacts to pokes").
     // Returns early so she never ALSO spends a musing turn the same tick.
-    let work_room = focus_room.unwrap_or(ctx.identity.default_room);  // unwrap_or: no held claim = home room
+    let work_room = focus_room.unwrap_or(ctx.identity.default_room); // unwrap_or: no held claim = home room
     if crate::persona::act_question::ask_the_act_question(
         ctx,
         conversation,
@@ -2589,8 +2600,9 @@ async fn run_self_cycle(
         tick_room,
     );
     let burst = crate::cognition::workspace::Burst::from_turns_at(
-        crate::identity::ActivityRoom::from_uuid(tick_room)
-            .expect("focus room comes from a live claim's real room; default_room is minted v4 — never nil"), // claim rooms are spawned real; default_room minted v4 — nil unreachable
+        crate::identity::ActivityRoom::from_uuid(tick_room).expect(
+            "focus room comes from a live claim's real room; default_room is minted v4 — never nil",
+        ), // claim rooms are spawned real; default_room minted v4 — nil unreachable
         selftick_turns,
         Some(now_ms),
         // Ambient, and honestly so. The self-tick wakes on a CHANGE to a re-read
@@ -2629,7 +2641,7 @@ async fn run_self_cycle(
                 .get("peer_id")
                 .and_then(|v| v.as_str())
                 .map(|p| p != own_peer)
-                .unwrap_or(true)  // unwrap_or: an unreadable board counts as claimable so the pull tries, never silently skips
+                .unwrap_or(true) // unwrap_or: an unreadable board counts as claimable so the pull tries, never silently skips
         })
         .any(|item| identity.mentions(&item.content));
     crate::probe!(
@@ -2768,11 +2780,12 @@ async fn run_self_cycle(
     let forwarder =
         spawn_token_forwarder(tok_rx, None, ctx.identity.agent_name.clone(), None, None);
     let (step, _turn_metrics) = {
-        let outcome = crate::cognition::act_observe::drive_to_settle(
+        let outcome = crate::cognition::act_observe::drive_to_settle_with_input(
             &cycle,
             burst,
             LIVE_MAX_ACTS,
             crate::cognition::workspace::TurnFraming::self_thread(false),
+            conversation,
         )
         .await;
         crate::cognition::act_observe::SettleStep::from_settled(outcome)
@@ -2878,7 +2891,12 @@ mod tests {
     #[test]
     fn the_newest_thought_resumes_from_its_conclusion_not_its_orientation() {
         let me = Uuid::new_v4();
-        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow {
+            id: Uuid::new_v4(),
+            sender: me,
+            occurred_at_ms: ms,
+            text: text.to_string(),
+        };
         let long = format!(
             "💭 Let me carefully parse where I actually am right now. {} So the fix is: include the index in the label at checks.py:1040.",
             "First, the ground truth from my own board and workspace. ".repeat(6)
@@ -2886,8 +2904,14 @@ mod tests {
         let rows = vec![row(1, "💭 earlier orientation"), row(2, &long)];
         let state = own_recent_thoughts(&rows, me, 2, 80);
         assert_eq!(state.len(), 2);
-        assert!(state[1].ends_with("include the index in the label at checks.py:1040."), "{state:?}");
-        assert!(!state[1].contains("carefully parse"), "the orientation is what got dropped: {state:?}");
+        assert!(
+            state[1].ends_with("include the index in the label at checks.py:1040."),
+            "{state:?}"
+        );
+        assert!(
+            !state[1].contains("carefully parse"),
+            "the orientation is what got dropped: {state:?}"
+        );
     }
 
     // what this catches (card 7e3e8070): the no-deliverable notice narrating instead of
@@ -2895,25 +2919,55 @@ mod tests {
     // ways out; an edit receipt resets the count and the gate stays out of the way.
     #[test]
     fn six_acts_without_a_write_gate_the_work_turn_and_an_edit_resets_it() {
-        use crate::persona::work_burst::{acts_since_last_write, held_work_burst_gated, CardProgress, WRITE_OR_RELEASE_AFTER_ACTS};
+        use crate::persona::work_burst::{
+            acts_since_last_write, held_work_burst_gated, CardProgress, WRITE_OR_RELEASE_AFTER_ACTS,
+        };
         let me = Uuid::new_v4();
-        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow {
+            id: Uuid::new_v4(),
+            sender: me,
+            occurred_at_ms: ms,
+            text: text.to_string(),
+        };
         let looping = vec![
             row(1, "💭 reading ⚙ code/read a.py ✓ ⚙ code/search x ✓"),
             row(2, "💭 checking ⚙ code/run pytest ✓ ⚙ code/git/status ✓"),
             row(3, "💭 more ⚙ code/read b.py ✓ ⚙ code/shell ls ✓"),
         ];
         assert_eq!(acts_since_last_write(&looping, me), 6);
-        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&looping, me), &CardProgress::default());
+        let text = held_work_burst_gated(
+            &[],
+            &[],
+            acts_since_last_write(&looping, me),
+            &CardProgress::default(),
+        );
         assert!(text.contains("[write or release]"), "{text}");
         assert!(text.contains("PASS: blocked"), "{text}");
 
         let mut edited = looping.clone();
-        edited.push(row(4, "💭 fixing ⚙ code/write witness_report.txt ✓ ⚙ code/run pytest ✓"));
-        assert_eq!(acts_since_last_write(&edited, me), 1, "an edit resets the count");
-        let text = held_work_burst_gated(&[], &[], acts_since_last_write(&edited, me), &CardProgress::default());
-        assert!(!text.contains("[write or release]"), "no gate after an edit: {text}");
-        assert!(WRITE_OR_RELEASE_AFTER_ACTS >= 4, "the gate is not a hair trigger");
+        edited.push(row(
+            4,
+            "💭 fixing ⚙ code/write witness_report.txt ✓ ⚙ code/run pytest ✓",
+        ));
+        assert_eq!(
+            acts_since_last_write(&edited, me),
+            1,
+            "an edit resets the count"
+        );
+        let text = held_work_burst_gated(
+            &[],
+            &[],
+            acts_since_last_write(&edited, me),
+            &CardProgress::default(),
+        );
+        assert!(
+            !text.contains("[write or release]"),
+            "no gate after an edit: {text}"
+        );
+        assert!(
+            WRITE_OR_RELEASE_AFTER_ACTS >= 4,
+            "the gate is not a hair trigger"
+        );
     }
 
     // what this catches (card 516738b4): a work turn that re-reads what it read.
@@ -2921,9 +2975,16 @@ mod tests {
     // must lead with them, de-duplicated, newest last, and say nothing on a fresh card.
     #[test]
     fn a_held_card_carries_what_she_already_read_and_ran() {
-        use crate::persona::work_burst::{card_progress, held_work_burst_gated, progress_line, CardProgress};
+        use crate::persona::work_burst::{
+            card_progress, held_work_burst_gated, progress_line, CardProgress,
+        };
         let me = Uuid::new_v4();
-        let row = |ms, text: &str| crate::persona::durable_history::RoomRow { id: Uuid::new_v4(), sender: me, occurred_at_ms: ms, text: text.to_string() };
+        let row = |ms, text: &str| crate::persona::durable_history::RoomRow {
+            id: Uuid::new_v4(),
+            sender: me,
+            occurred_at_ms: ms,
+            text: text.to_string(),
+        };
         let rows = vec![
             row(2, "💭 looking ⚙ code/read django/forms/fields.py ✓ ⚙ code/search MultiValueField ✓"),
             row(1, "💭 first ⚙ work/get de33e1d6 ✓"),
@@ -2933,17 +2994,42 @@ mod tests {
         let p = card_progress(&rows, me);
         assert_eq!(p.acts, 7);
         assert_eq!(p.writes, 1);
-        assert_eq!(p.read, vec!["django/forms/fields.py".to_string()], "paths only, de-duplicated");
-        assert_eq!(p.searched, vec!["MultiValueField".to_string()], "a search term is not a read");
+        assert_eq!(
+            p.read,
+            vec!["django/forms/fields.py".to_string()],
+            "paths only, de-duplicated"
+        );
+        assert_eq!(
+            p.searched,
+            vec!["MultiValueField".to_string()],
+            "a search term is not a read"
+        );
         assert_eq!(p.ran.len(), 2);
         assert!(p.ran[1].ends_with('✓'), "{:?}", p.ran);
         let block = held_work_burst_gated(&[], &[], 0, &p);
-        assert!(block.contains("[progress] 7 acts so far (1 writes)"), "{block}");
-        assert!(block.contains("Already read: django/forms/fields.py."), "{block}");
-        assert!(block.contains("Already searched: MultiValueField."), "{block}");
-        assert!(block.find("[progress]").unwrap() < block.find("Your workspace holds").unwrap(), "the note leads");
-        assert!(progress_line(&CardProgress::default()).is_empty(), "a fresh card carries no note");
-        assert!(!held_work_burst_gated(&[], &[], 0, &CardProgress::default()).contains("[progress]"));
+        assert!(
+            block.contains("[progress] 7 acts so far (1 writes)"),
+            "{block}"
+        );
+        assert!(
+            block.contains("Already read: django/forms/fields.py."),
+            "{block}"
+        );
+        assert!(
+            block.contains("Already searched: MultiValueField."),
+            "{block}"
+        );
+        assert!(
+            block.find("[progress]").unwrap() < block.find("Your workspace holds").unwrap(),
+            "the note leads"
+        );
+        assert!(
+            progress_line(&CardProgress::default()).is_empty(),
+            "a fresh card carries no note"
+        );
+        assert!(
+            !held_work_burst_gated(&[], &[], 0, &CardProgress::default()).contains("[progress]")
+        );
     }
 
     #[test]
@@ -2951,19 +3037,35 @@ mod tests {
         use crate::persona::durable_history::RoomRow;
         let me = Uuid::new_v4();
         let other = Uuid::new_v4();
-        let row = |sender, ms, text: &str| RoomRow { id: Uuid::new_v4(), sender, occurred_at_ms: ms, text: text.to_string() };
+        let row = |sender, ms, text: &str| RoomRow {
+            id: Uuid::new_v4(),
+            sender,
+            occurred_at_ms: ms,
+            text: text.to_string(),
+        };
         let rows = vec![
-            row(me, 3, "💭 lines 107-152: the bug is the total_degree branch"),
+            row(
+                me,
+                3,
+                "💭 lines 107-152: the bug is the total_degree branch",
+            ),
             row(other, 4, "💭 not hers"),
             row(me, 1, "💭 let me look at itermonomials"),
             row(me, 2, "⚙ code/read ✓"),
-            row(me, 5, "💭 let me refocus and actually do work on this card now, really"),
+            row(
+                me,
+                5,
+                "💭 let me refocus and actually do work on this card now, really",
+            ),
         ];
         let state = own_recent_thoughts(&rows, me, 2, 40);
         assert_eq!(state.len(), 2);
         assert!(state[0].starts_with("💭 lines 107-152"), "{state:?}");
         // The newest thought keeps its TAIL — the conclusion — not its opening.
-        assert!(state[1].starts_with('…') && state[1].ends_with("on this card now, really"), "newest keeps its conclusion: {state:?}");
+        assert!(
+            state[1].starts_with('…') && state[1].ends_with("on this card now, really"),
+            "newest keeps its conclusion: {state:?}"
+        );
         let text = held_work_burst(&[], &state);
         assert!(text.contains("resume from them"));
         assert!(text.contains("lines 107-152"));
@@ -3001,7 +3103,10 @@ mod tests {
         // reason (done/blocked/nothing) the deterministic settle edge reads. A
         // burst that loses the pass-clause becomes a command; one that loses the
         // reason words leaves the edge unable to tell done from blocked.
-        assert!(burst.contains("PASS"), "the pass choice stays hers: {burst}");
+        assert!(
+            burst.contains("PASS"),
+            "the pass choice stays hers: {burst}"
+        );
         assert!(
             burst.contains("done") && burst.contains("blocked") && burst.contains("nothing"),
             "the pass must name its three reasons for the settle edge: {burst}"
@@ -3164,7 +3269,10 @@ mod tests {
             "the interior duplicate is suppressed entirely"
         );
         assert!(
-            out.last().unwrap().content.contains("aren't being returned"),
+            out.last()
+                .unwrap()
+                .content
+                .contains("aren't being returned"),
             "the trigger (last turn) is never suppressed, near-dup or not"
         );
         assert_eq!(out.iter().filter(|t| t.content == "thanks!").count(), 2);
@@ -4920,10 +5028,10 @@ mod tests {
         // Register her cognition cycle in the global registry the act-question
         // reads, wired to a canned adapter that answers "PASS: done" — so the
         // drive settles on a reasoned pass, not the heuristic echo (a Speak).
-        let recall_meta =
-            Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new());
-        let admission =
-            Arc::new(crate::persona::admission_state::AdmissionState::new(recall_meta));
+        let recall_meta = Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new());
+        let admission = Arc::new(crate::persona::admission_state::AdmissionState::new(
+            recall_meta,
+        ));
         let cfg = crate::cognition::persona_workspace::PersonaBrainConfig {
             persona_id: persona_peer,
             persona_name: "Paige".to_string(),
@@ -4945,7 +5053,7 @@ mod tests {
         // act-question resolves no staged checkout (no hands re-root needed).
         let card = airc_lib::WorkCard {
             card_id: WorkCardId::new(),
-            repo: RepoId::new("acme/continuum").expect("valid repo id"),  // test: a literal valid repo id
+            repo: RepoId::new("acme/continuum").expect("valid repo id"), // test: a literal valid repo id
             title: "a held work card".to_string(),
             body: None,
             priority: Priority::P1,
@@ -4978,9 +5086,16 @@ mod tests {
         )
         .await;
 
-        assert!(drove, "she held a card, so a held-work turn must have been driven");
-        let advanced = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();  // test: poisoned recorder lock still holds the pushes
-        assert_eq!(advanced.len(), 1, "exactly one card transition, got {advanced:?}");
+        assert!(
+            drove,
+            "she held a card, so a held-work turn must have been driven"
+        );
+        let advanced = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone(); // test: poisoned recorder lock still holds the pushes
+        assert_eq!(
+            advanced.len(),
+            1,
+            "exactly one card transition, got {advanced:?}"
+        );
         assert_eq!(advanced[0].0, card_id, "the HELD card is the one concluded");
         assert_eq!(
             advanced[0].1,
@@ -5000,7 +5115,7 @@ mod tests {
     fn held_card(owner: Uuid) -> airc_lib::WorkCard {
         airc_lib::WorkCard {
             card_id: airc_lib::WorkCardId::new(),
-            repo: airc_lib::RepoId::new("acme/continuum").expect("valid repo id"),  // test: a literal valid repo id
+            repo: airc_lib::RepoId::new("acme/continuum").expect("valid repo id"), // test: a literal valid repo id
             title: "a held work card".to_string(),
             body: None,
             priority: airc_lib::Priority::P1,
@@ -5050,7 +5165,7 @@ mod tests {
         let hosted = hosted_with_heuristic(peer);
         let held_elsewhere = StubAircCitizen::new(peer).with_rooms(vec![round_id]);
         let conversation = ScriptedConversation::new().with_citizen(
-            Arc::new(held_elsewhere) as Arc<dyn crate::persona::airc_citizen::AircCitizen>,
+            Arc::new(held_elsewhere) as Arc<dyn crate::persona::airc_citizen::AircCitizen>
         );
         assert!(
             try_pull_next_card(&hosted, &conversation).await != PullOutcome::Pulled,
@@ -5079,7 +5194,11 @@ mod tests {
             .with_citizen(Arc::new(stub) as Arc<dyn crate::persona::airc_citizen::AircCitizen>);
 
         let pulled = try_pull_next_card(&hosted, &conversation).await;
-        assert_eq!(pulled, PullOutcome::Pulled, "an idle member pulls the next Open card off the deck");
+        assert_eq!(
+            pulled,
+            PullOutcome::Pulled,
+            "an idle member pulls the next Open card off the deck"
+        );
         let claimed = recorder.lock().unwrap_or_else(|p| p.into_inner()).clone();
         assert_eq!(claimed.len(), 1, "exactly one pull, got {claimed:?}");
         assert_eq!(

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2599,10 +2599,11 @@ async fn run_self_cycle(
         ctx.identity.peer_id,
         tick_room,
     );
+    let room_invariant =
+        "focus room comes from a live claim's real room; default_room is minted v4 — never nil";
+    let activity_room = crate::identity::ActivityRoom::from_uuid(tick_room).expect(room_invariant); // claim rooms are spawned real; default_room minted v4 — nil unreachable
     let burst = crate::cognition::workspace::Burst::from_turns_at(
-        crate::identity::ActivityRoom::from_uuid(tick_room).expect(
-            "focus room comes from a live claim's real room; default_room is minted v4 — never nil",
-        ), // claim rooms are spawned real; default_room minted v4 — nil unreachable
+        activity_room,
         selftick_turns,
         Some(now_ms),
         // Ambient, and honestly so. The self-tick wakes on a CHANGE to a re-read

--- a/core/continuum-core/src/persona/wake_backlog.rs
+++ b/core/continuum-core/src/persona/wake_backlog.rs
@@ -12,7 +12,7 @@
 //! (a ring), the trigger is the newest priority line (human opportunity or a
 //! mention), and every priority line drained earns its heard receipt.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 use uuid::Uuid;
 
@@ -22,22 +22,33 @@ use super::service_loop::IncomingMessage;
 /// pump already dedupes the store catch-up; this catches re-open replays.
 pub(crate) struct SeenIds {
     ring: VecDeque<Uuid>,
+    ids: HashSet<Uuid>,
     cap: usize,
 }
 
 impl SeenIds {
     pub(crate) fn new(cap: usize) -> Self {
-        Self { ring: VecDeque::with_capacity(cap), cap }
+        Self {
+            ring: VecDeque::with_capacity(cap),
+            ids: HashSet::with_capacity(cap),
+            cap,
+        }
     }
 
     /// Note an id; `true` when it is NEW (first sight), `false` on a repeat.
     pub(crate) fn note(&mut self, id: Uuid) -> bool {
-        if self.ring.contains(&id) {
+        if self.ids.contains(&id) {
             return false;
         }
-        if self.ring.len() == self.cap {
-            self.ring.pop_front();
+        if self.cap == 0 {
+            return true;
         }
+        if self.ring.len() == self.cap {
+            if let Some(evicted) = self.ring.pop_front() {
+                self.ids.remove(&evicted);
+            }
+        }
+        self.ids.insert(id);
         self.ring.push_back(id);
         true
     }
@@ -119,9 +130,15 @@ mod tests {
     // trigger; a citizen's ambient line and any directed line still are.
     #[test]
     fn an_undirected_agent_line_never_triggers_a_turn() {
-        assert!(!triggers_a_turn(false, false), "agent wall, no mention: perceived only");
+        assert!(
+            !triggers_a_turn(false, false),
+            "agent wall, no mention: perceived only"
+        );
         assert!(triggers_a_turn(true, false), "agent naming her: a turn");
-        assert!(triggers_a_turn(false, true), "citizen chatter: conversation, a turn");
+        assert!(
+            triggers_a_turn(false, true),
+            "citizen chatter: conversation, a turn"
+        );
         assert!(triggers_a_turn(true, true));
     }
 
@@ -143,24 +160,42 @@ mod tests {
         assert!(is_stale(&m, &mut seen, 0));
     }
 
+    // The index must evict with the ordered ring; retained snapshots do not
+    // refresh recency or grow the bounded set on duplicate admission.
+    #[test]
+    fn seen_id_index_evicts_with_the_ring() {
+        let mut seen = SeenIds::new(2);
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        assert!(seen.note(a));
+        assert!(seen.note(b));
+        assert!(!seen.note(a));
+        assert!(seen.note(c));
+        assert!(seen.note(a));
+        assert!(!seen.note(c));
+        assert_eq!(seen.ids.len(), 2);
+        assert_eq!(seen.ring.len(), 2);
+        let mut empty = SeenIds::new(0);
+        assert!(empty.note(a));
+        assert!(empty.note(a));
+        assert!(empty.ids.is_empty());
+        assert!(empty.ring.is_empty());
+    }
+
     // what this catches: a human line without an @mention losing the turn to a
     // newer citizen work receipt.
     #[test]
     fn a_human_opportunity_wins_over_newer_citizen_chatter_without_a_mention() {
         use crate::cognition::workspace::TurnAttention;
-        let identity = crate::persona::persona_identity::PersonaIdentity::new(
-            Uuid::new_v4(),
-            "Kimi",
-        );
+        let identity =
+            crate::persona::persona_identity::PersonaIdentity::new(Uuid::new_v4(), "Kimi");
         let human = line(1, 3, "Joel here — which card do you hold?");
         let human_id = human.event_id;
         let receipt = line(2, 900, "💭 Let me get my bearings.");
         let (picked, coalesced) = pick_trigger(vec![human, receipt], |m| {
-            TurnAttention::for_message(
-                identity.mentions(&m.text),
-                m.peer_id == Uuid::from_u128(1),
-            )
-            .requires_priority()
+            TurnAttention::for_message(identity.mentions(&m.text), m.peer_id == Uuid::from_u128(1))
+                .requires_priority()
         })
         .unwrap();
         assert_eq!(picked.event_id, human_id);

--- a/docs/architecture/PERSONA-COGNITION-PIPELINE.md
+++ b/docs/architecture/PERSONA-COGNITION-PIPELINE.md
@@ -75,6 +75,17 @@ path — reuse it when the capability returns, do not write a parallel one.
 
 `service_loop` does NOT compose RAG itself. Does NOT call inference itself. Does NOT decide silence itself. Those are brain concerns. service_loop just feeds messages in and posts what comes out.
 
+While an action sequence is underway, the same driver leases
+`PersonaConversation::perceive_ready` between completed steps. It reads the
+existing membership-aware inbox without waiting for a new arrival. Room messages
+remain owned by the conversation for later room attention and enter the active
+request as separate, attributed inputs; they do not replace its task, action
+result, room, or causal root. The complete inputs share the required prompt budget:
+insufficient capacity is a substrate fault, not a silently clipped message.
+An input that earns priority can promote the next serving request without
+asserting that the original trigger named the persona. Deciding whether to speak,
+continue working, or act in another room remains the persona's decision.
+
 ---
 
 ## 4. The Bypass — REMOVED (was live 2026-06-03, gone by 2026-09-06)
@@ -209,6 +220,8 @@ The persona that talks to her host in three months and recalls things from today
 |---------|----------|----------|
 | Brain state + composition | `persona/unified.rs` (`PersonaCognition`) | Single struct, single lock, cache-local, the per-persona state. |
 | Per-turn orchestration | `persona/service_loop.rs` (driver) + `persona/unified.rs` (a thin orchestration method on the brain) | Drive turns through the verbs. No new pipeline. |
+| Input during active work | `PersonaConversation::perceive_ready` → `cognition/act_observe` → `Burst.room_updates` | Same inbox and driver; retained ownership, explicit room attribution, complete prompt accounting. |
+| Supplemental input provenance | `WorkspaceTrace` / `SettleOutcome` → `ExperienceRecord.room_updates` | Shared event handles on the live path; typed, defaulted capture fields preserve the full source-labelled input for replay and curriculum. |
 | Inference verb | `cognition/generate_response.rs::evaluate_response` | The substrate's agent inference. Provider-routed, typed errors. |
 | Shared analysis | `cognition/shared_analysis/mod.rs::analyze` | Single-flight cache + base model. ONE inference per message across personas. |
 | Specialty match | `cognition/response_orchestrator.rs::score_persona` | Per-persona relevance + lead election. |


### PR DESCRIPTION
Live persona action sequences now perceive ready teammate messages between completed steps, so coaching reaches the next model request while the original task, active room, causal root and action receipts remain intact. Same-room and cross-room inputs retain their source identities and remain available for later ordinary room attention; input priority grants attention without claiming the original trigger addressed the persona.

The implementation reuses the membership-aware conversation, bounded intake and indexed seen-ID ring. Borrowed message views and shared leases avoid copying full inputs at each step. Complete room inputs participate in required prompt capacity checks and travel through the existing capture, replay, lived-experience and curriculum projections. Perception occurs at existing step boundaries; it does not interrupt a running tool or inference call.

Regression coverage exercises actual tool-time arrivals and adapter requests, addressed and held-work framing, capture-to-replayed-request reconstruction, retained source ownership, explicit capacity failure, and rejection of an invalid activity room before an evaluation fork. The combined native validation passed124 selected library tests and37 CLI tests. Current-head Linux library/doc tests, Windows compilation, and binding drift CI pass. Normal combined Clippy passes; strict combined Clippy still reports775 distinct existing diagnostics, with the introduced warnings fixed. Source hygiene remains enforced without baseline changes.

No benchmark or trained-model improvement is claimed. The implementation is in the frozen release candidate awaiting live handoff validation. Based on canary after #3909; its merged membership implementation is a prerequisite.

AIRC card: c5910be2-a9af-4632-aefb-cd93b410475d.