### PR TITLE
fix(resources): disable unsafe citizen workspace eviction

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1510,22 +1510,9 @@ pub fn start_server(
         // boot path wasn't even rotating. Eviction is safe by
         // construction here (rotated `.N` generations only, never the
         // live file), so this class is OWNED rather than deferred.
-        // The citizens' workspaces get their owner (card 58c27b0c): dormant, non-resident
-        // workspaces only, and only after every uncommitted thing in one is archived and
-        // read back. A persona's memory is never evicted.
-        if let Some(citizens_dir) = crate::system_resources::tracked_dir("citizens") {
-            broker.register(Arc::new(
-                crate::system_resources::citizen_workspace_pool::CitizenWorkspacePool::new(
-                    citizens_dir,
-                    crate::system_resources::citizen_workspace_pool::DEFAULT_CITIZENS_BUDGET_BYTES,
-                ),
-            ) as Arc<dyn crate::paging::pool::ResourcePool>);
-            log_info!(
-                "ipc",
-                "server",
-                "CitizenWorkspacePool registered with PressureBroker (dormant workspaces only; memory never evicted)"
-            );
-        }
+        // Citizen workspace eviction remains unregistered until preservation can
+        // restore local commits and refs as well as dirty files. A clean checkout
+        // can contain the only copy of a citizen's autosaved work (#3920).
 
         for class in ["logs", "probes"] {
             // The pool governs ONE writer's ledger (live file + its `.N` generations)


### PR DESCRIPTION
The citizen workspace pool added in #3920 can delete the only copy of clean, unpushed Persona autosaves: preservation checks git status, skips clean repositories, and does not preserve local commit objects or refs. Its synchronous snapshot also recursively scans citizen trees during broker status reads.

Remove the pool's production registration until preservation and accounting are repaired. The generic disk-pressure monitor only reports pressure; it cannot delete files. Existing pool implementation and its repair work remain available; this change stops the broker from invoking it.

Validation: independent source review audited all CitizenWorkspacePool references and the non-deleting generic disk-pressure monitor; the removed registration was its only production construction. Diff checks pass. This containment does not claim to repair archival or recover already-deleted data. No live processes were changed.

AIRC card af44428c-fda2-4405-878a-dbaa85af311a. Blocking review: https://github.com/CambrianTech/continuum/pull/3920#issuecomment-5590678636

