### PR TITLE
fix(cognition): preserve history corrections and result provenance

### DIFF
--- a/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
+++ b/core/continuum-core/src/cognition/llm_deliberation_faculty.rs
@@ -2196,31 +2196,12 @@ impl LlmDeliberationFaculty {
             field(&mut input, update.room_id.as_bytes());
             field(&mut input, update.text.as_bytes());
         }
-        // Collapse consecutive same-role turns into one message each (chronological).
-        // Her OWN near-duplicate turns are DROPPED after the first: replaying
-        // `assistant: X` three times teaches the model that repeating X is its
-        // established behavior — glass-boxed 2026-07-10, the courtesy spiral's
-        // strongest fuel was up to 3 byte-identical assistant turns in one thread.
-        // Dropped, not replaced with a marker: the first cut rendered
-        // "(you sent this same message again, verbatim)" in her assistant history,
-        // and the same law fired again — words in assistant turns are words the
-        // model says, and Anwen BROADCAST the marker to the room that night.
-        // Perception-side repetition awareness is the repetition brick's job
-        // (structural fact in the world channel, #121), never assistant-voice
-        // text we author ([[no-hardcoded-heuristics-to-steer-cognition]]).
-        //
-        // The drop is NEAR-DUP (jaccard ≥ NEAR_DUP_JACCARD), not byte equality —
-        // reversing the first cut's "byte equality only, never similarity"
-        // (glass-boxed 2026-07-11): temperature varies each re-emission by a few
-        // words ("for the repetition" / "for the repetition earlier"), so byte
-        // dedup never fired while four apology variants rendered in one thread
-        // and the loop survived even a direct, personally-addressed peer
-        // instruction. Same calibrated geometry as the [repetition] fact
-        // (deliberation_budget) — identical-enough to count as loop evidence ≡
-        // identical-enough to not re-teach. Detection for the fact stays on the
-        // RAW turns, so dropped copies still count as evidence there.
+        // Coalesce consecutive same-role turns in chronological order. Content
+        // similarity cannot establish event identity: "tests passed" and "tests
+        // failed" can be near-identical, and a later identical statement can
+        // report another change of state. Preserve that history for the citizen;
+        // the existing fitter bounds it and perception facts describe repetition.
         let mut groups: Vec<(&'static str, Vec<String>)> = Vec::new();
-        let mut kept_self: Vec<String> = Vec::new();
         // Preserve the newest external SPEECH as activity context, even when an
         // own receipt or perception fact follows it. This says what was heard,
         // never what the citizen must obey. Keep the typed boundary before
@@ -2260,15 +2241,6 @@ impl LlmDeliberationFaculty {
                 stimulus = Some(ChatMessage::text(role, line));
                 after_stimulus = true;
                 continue;
-            }
-            if turn.is_self {
-                if kept_self.iter().any(|k| {
-                    super::deliberation_budget::jaccard(k, &line)
-                        >= super::deliberation_budget::NEAR_DUP_JACCARD
-                }) {
-                    continue;
-                }
-                kept_self.push(line.clone());
             }
             match groups.last_mut() {
                 Some((r, lines)) if *r == role && !after_stimulus => lines.push(line),
@@ -2433,11 +2405,11 @@ impl LlmDeliberationFaculty {
         input.update(b"active_result");
         let latest_result = self.working_memory.as_ref().and_then(|wm| {
             wm.active_action_full().map(|(seq, full)| {
-                field(&mut input, full.as_bytes());
-                ChatMessage::text(
-                    "user",
-                    format!("Full result of your most recent action (#{seq}):\n{full}"),
-                )
+                let message = wm.full_result_message(seq, &full);
+                // Provenance is required input too. Hash the rendered allocation
+                // once, then move it into the request without a second encoding.
+                field(&mut input, message.as_bytes());
+                ChatMessage::text("user", message)
             })
         });
 
@@ -3941,55 +3913,100 @@ mod tests {
             ))
         }
 
-        // what this catches: a persona's VERBATIM-duplicate turns are DROPPED
-        // after the first in her thread projection — replaying `assistant: X`
-        // three times teaches the model that repeating X is its established
-        // behavior (the courtesy spiral's strongest fuel, glass-boxed 2026-07-10:
-        // up to 3 byte-identical assistant turns per thread). Dropped, NOT
-        // replaced with marker text: the marker cut put authored words in her
-        // assistant voice and Anwen broadcast "(you sent this same message
-        // again, verbatim)" to the live room the same night — assistant-turn
-        // content IS the model's speech repertoire. Byte equality only; distinct
-        // messages and peers' repeats are untouched.
-        #[test]
-        fn own_verbatim_duplicates_collapse_in_the_thread() {
+        // what this catches: e731576c — fuzzy and verbatim history dedupe both
+        // lose real state changes. Inspect the actual adapter request at each
+        // step: passed -> failed -> passed must remain three distinct events.
+        #[tokio::test]
+        async fn own_history_preserves_corrections_at_each_inference_step() {
+            use crate::ai::types::{ToolCall, ToolResult};
+            use crate::cognition::act_observe::{ActStatus, Observation, ToolOutput, ToolVerb};
+            use crate::cognition::working_memory::WorkingMemory;
+
+            let home = tempfile::tempdir().expect("isolated demand and emission storage");
+            let _native = crate::paths::NativeHomeOverride::install(home.path());
             let persona = Uuid::new_v4();
+            let calls = Arc::new(Mutex::new(Vec::new()));
+            let wm = Arc::new(WorkingMemory::new(16));
+            wm.set_served_window(32_768);
             let faculty = LlmDeliberationFaculty::new(
                 persona,
                 "Anwen",
                 "You are Anwen.",
-                Arc::new(HeuristicInferenceAdapter::new()),
+                Arc::new(
+                    HeuristicInferenceAdapter::new().with_request_recorder(Arc::clone(&calls)),
+                ),
             )
-            .with_context_window(32_768);
-            let same = "I apologize for any repetition. Is there something specific?";
-            let ws = Workspace::new(crate::cognition::workspace::Burst::from_turns(
-                crate::identity::ActivityRoom::mint(),
-                vec![
-                    BurstTurn::attributed(false, "Asha", "hello!", None),
-                    BurstTurn::attributed(true, "Anwen", same, None),
-                    BurstTurn::attributed(false, "Asha", "still here", None),
-                    BurstTurn::attributed(true, "Anwen", same, None),
-                    BurstTurn::attributed(false, "Asha", "ok", None),
-                    BurstTurn::attributed(true, "Anwen", same, None),
-                ],
-            ));
-            let msgs = faculty.messages_within(&ws, 8_192);
-            let thread: String = msgs
-                .iter()
-                .filter(|m| m.role == "assistant")
-                .map(|m| m.content_text())
-                .collect::<Vec<_>>()
-                .join("\n");
-            assert_eq!(
-                thread.matches(same).count(),
-                1,
-                "only the FIRST verbatim occurrence renders at all: {thread}"
-            );
-            assert!(
-                !thread.contains("same message again"),
-                "no authored marker text in her assistant voice — duplicates \
-                 drop silently (the marker got broadcast to the live room): {thread}"
-            );
+            .with_context_window(32_768)
+            .with_working_memory(Arc::clone(&wm));
+            let own_reports = [
+                "I verified the build and the tests passed.",
+                "I verified the build and the tests failed.",
+                "I verified the build and the tests passed.",
+            ];
+            let peer_updates = [
+                "The initial candidate is ready for review.",
+                "The regression test exposed a failure in that candidate.",
+                "The corrected candidate is ready for another review.",
+            ];
+            let room = crate::identity::ActivityRoom::mint();
+            let result_rooms = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+            let mut turns = Vec::new();
+            for (step, (report, update)) in own_reports.iter().zip(peer_updates).enumerate() {
+                turns.push(BurstTurn::attributed(false, "Asha", update, None));
+                turns.push(BurstTurn::attributed(true, "Anwen", *report, None));
+                let call_id = format!("verify-{step}");
+                wm.record_receipt_typed(
+                    &[Observation {
+                        call: ToolCall {
+                            id: call_id.clone(),
+                            name: "code/run".into(),
+                            input: serde_json::json!({"attempt": step}),
+                        },
+                        output: ToolOutput {
+                            result: ToolResult {
+                                tool_use_id: call_id,
+                                content: (*report).into(),
+                                is_error: None,
+                                spill_handle: None,
+                            },
+                            verb: ToolVerb::classify("code/run"),
+                            paths: Vec::new(),
+                        },
+                        status: ActStatus::Executed,
+                    }],
+                    report,
+                    Some(result_rooms[step]),
+                );
+                let ws = Workspace::new(crate::cognition::workspace::Burst::from_turns(
+                    room,
+                    turns.clone(),
+                ));
+                let outcome = faculty.contribute(&ws).await.expect("deliberation outcome");
+                assert!(outcome.fault.is_none());
+                let recorded = calls.lock().expect("actual request recorder");
+                assert_eq!(recorded.len(), step + 1);
+                let request = recorded.last().expect("submitted request");
+                let history: Vec<_> = request
+                    .messages
+                    .iter()
+                    .filter(|message| message.role == "assistant")
+                    .map(|message| message.content_text())
+                    .collect();
+                assert_eq!(history, own_reports[..=step]);
+                for update in &peer_updates[..=step] {
+                    assert!(request.messages.iter().any(|message| {
+                        message.role == "user"
+                            && message.content_text().contains(&format!("Asha: {update}"))
+                    }));
+                }
+                for (index, result_room) in result_rooms[..=step].iter().enumerate() {
+                    let provenance =
+                        format!("#{}; room {result_room}; operation code/run", index + 1);
+                    assert!(request.messages.iter().any(|message| {
+                        message.role == "user" && message.content_text().contains(&provenance)
+                    }));
+                }
+            }
         }
 
         // what this catches: end-to-end through a REAL adapter (the deterministic
@@ -5894,7 +5911,7 @@ mod tests {
             assert!(
                 view.messages
                     .iter()
-                    .any(|m| matches!(&m.content, crate::ai::types::MessageContent::Text(t) if t.contains("[context] you can currently see the last 3 messages"))),
+                    .any(|m| matches!(&m.content, crate::ai::types::MessageContent::Text(t) if t.contains("[context] 3 input turns were available before prompt fitting"))),
                 "the [context] bounds fact states the visible window"
             );
 
@@ -6098,16 +6115,11 @@ mod tests {
             );
         }
 
-        // what this catches: the near-dup render drop (live specimen 2026-07-11 —
-        // Casper's ask-permission loop). Temperature varies each re-emission by a
-        // few words, so byte dedup never fires while N apology VARIANTS render as
-        // assistant turns and in-context-teach the model that repeating is its
-        // established behavior; the loop then survives even a direct peer
-        // instruction. Later near-dups (jaccard ≥ NEAR_DUP_JACCARD vs any kept own
-        // line) must DROP from the render, while the [repetition] fact — detected
-        // on the RAW turns — still reports the true count.
+        // what this catches: e731576c — repetition remains observable without
+        // deleting distinct speech events or replacing them with authored words
+        // in the citizen's own voice.
         #[test]
-        fn near_duplicate_own_turns_drop_from_render_but_still_count_as_evidence() {
+        fn near_duplicate_own_turns_remain_visible_with_repetition_evidence() {
             use crate::cognition::workspace::Burst;
             let persona = Uuid::new_v4();
             let adapter: Arc<dyn AIProviderAdapter> = Arc::new(HeuristicInferenceAdapter::new());
@@ -6142,19 +6154,25 @@ mod tests {
             ));
             let view = faculty.prompt_view(&ws);
 
-            // Exactly ONE assistant rendering of the template survives.
+            // All three actual statements survive in their original order.
             let apology_renders = view
                 .messages
                 .iter()
                 .filter(|m| m.role == "assistant" && m.content_text().contains("I apologize"))
                 .count();
             assert_eq!(
-                apology_renders, 1,
-                "later near-dup own turns must drop from the render: {view:?}"
+                apology_renders, 3,
+                "similarity must not erase actual speech: {view:?}"
             );
+            let own: Vec<_> = view
+                .messages
+                .iter()
+                .filter(|message| message.role == "assistant")
+                .map(|message| message.content_text())
+                .collect();
+            assert_eq!(own, vec![v1, v2, v3]);
 
-            // The dropped copies still count as evidence: the [repetition] fact
-            // (raw-turn detection) rides the newest user content.
+            // The same raw history still supports the repetition observation.
             let all_user: String = view
                 .messages
                 .iter()
@@ -6164,7 +6182,7 @@ mod tests {
                 .join("\n");
             assert!(
                 all_user.contains("[repetition] 3 of your recent messages were nearly identical"),
-                "raw-turn fact must survive the render drop: {all_user}"
+                "raw-turn repetition fact must remain available: {all_user}"
             );
         }
 

--- a/core/continuum-core/src/cognition/perception_facts.rs
+++ b/core/continuum-core/src/cognition/perception_facts.rs
@@ -154,8 +154,8 @@ impl PerceptionFact for InboundRestates {
     }
 }
 
-/// How much history is actually visible (#152): "as discussed earlier"
-/// claims become checkable against her own senses instead of assumed.
+/// Input available before prompt fitting. These are source turns, including
+/// perception, rather than a count of conversation messages actually submitted.
 struct ContextBounds;
 
 impl PerceptionFact for ContextBounds {
@@ -164,10 +164,10 @@ impl PerceptionFact for ContextBounds {
     }
 
     fn render(&self, cx: &FactContext) -> Option<String> {
-        let visible = cx.turns.len();
+        let available = cx.turns.len();
         Some(format!(
-            "[context] you can currently see the last {visible} message{} of this conversation — anything earlier is not in view unless you recall it from memory",
-            if visible == 1 { "" } else { "s" }
+            "[context] {available} input turn{} available before prompt fitting; this request may retain only part of that history",
+            if available == 1 { " was" } else { "s were" }
         ))
     }
 }
@@ -216,8 +216,8 @@ impl PerceptionFact for StepsLedger {
         let mut used = 0usize;
         for (head_room, line) in archive.iter().rev() {
             let in_scope = match (cx.room_id, head_room) {
-                (None, _) => true,          // no scope to partition by — render all
-                (Some(_), None) => true,    // unscoped head — never hidden
+                (None, _) => true,       // no scope to partition by — render all
+                (Some(_), None) => true, // unscoped head — never hidden
                 (Some(r), Some(h)) => *h == r,
             };
             if !in_scope {
@@ -393,6 +393,7 @@ mod tests {
                 false,
             ),
             turn("Asha", "sounds good, starting now", true),
+            BurstTurn::perception("The current room is available."),
         ];
         let own = vec!["sounds good, starting now".to_string()];
         let cx = FactContext {
@@ -405,7 +406,7 @@ mod tests {
         };
         let facts = render_facts(&cx, &FactPolicy::default());
         assert_eq!(facts.len(), 1, "quiet room: only the bounds fact renders");
-        assert!(facts[0].starts_with("[context] you can currently see the last 2 messages"));
+        assert_eq!(facts[0], "[context] 3 input turns were available before prompt fitting; this request may retain only part of that history");
     }
 
     // what this catches: FactPolicy::disable actually silences a fact — the

--- a/core/continuum-core/src/cognition/working_memory.rs
+++ b/core/continuum-core/src/cognition/working_memory.rs
@@ -112,6 +112,33 @@ pub fn clip_action_full<'a>(full: &'a str, budget: &ContextBudget) -> std::borro
 /// oldest-updated finished handle is evicted first (a still-running one is never dropped).
 const MAX_DISPATCHED: usize = 16;
 
+/// Borrowed provenance already carried by the result ring. Displaying a result
+/// in another activity must not erase where it came from or which operation ran.
+struct ResultAttribution<'a> {
+    seq: u64,
+    room: Option<Uuid>,
+    operation: Option<&'a str>,
+    spill_handle: Option<&'a str>,
+}
+
+impl std::fmt::Display for ResultAttribution<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{}; room ", self.seq)?;
+        match self.room {
+            Some(room) => write!(f, "{room}")?,
+            None => f.write_str("unrecorded")?,
+        }
+        match self.operation {
+            Some(operation) => write!(f, "; operation {operation}")?,
+            None => f.write_str("; operation unrecorded")?,
+        }
+        if let Some(handle) = self.spill_handle {
+            write!(f, "; output handle: tool/output {handle}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Lifecycle of a dispatched (background) command the persona sent away — a sentinel,
 /// a compile, a debugger. Streams continuously: `Running` updates arrive in place, then a
 /// terminal `Done`/`Failed`. The handle (a UUID) is reusable — the mind can pass it to
@@ -545,11 +572,21 @@ impl WorkingMemory {
                 let start = chars.len().saturating_sub(per_entry);
                 chars[start..].iter().collect()
             };
-            let label = acts
-                .first()
-                .map(|o| o.call.name.clone())
-                .unwrap_or_else(|| "act".to_string());
-            let handle = acts.iter().find_map(|o| o.output.result.spill_handle.clone());
+            // A receipt can contain several operations. Retain their typed names
+            // in order instead of attributing the whole batch to its first call.
+            let mut label = String::new();
+            for act in &acts {
+                if !label.is_empty() {
+                    label.push_str(", ");
+                }
+                label.push_str(&act.call.name);
+            }
+            if label.is_empty() {
+                label.push_str("unrecorded");
+            }
+            let handle = acts
+                .iter()
+                .find_map(|o| o.output.result.spill_handle.clone());
             let mut rr = self.recent_results.lock();
             rr.push_back((seq, room, tail, label, handle));
             // NO mid-settle eviction (2026-08-24, the third head-rotation): evicting
@@ -695,7 +732,11 @@ impl WorkingMemory {
             slot.text = t.to_string();
             slot.turns_left = turns;
         } else {
-            p.push(TurnPinnedFact { key: key.to_string(), text: t.to_string(), turns_left: turns });
+            p.push(TurnPinnedFact {
+                key: key.to_string(),
+                text: t.to_string(),
+                turns_left: turns,
+            });
         }
     }
 
@@ -970,6 +1011,21 @@ impl WorkingMemory {
         (action.0 >= active_from).then_some(action)
     }
 
+    /// Render the complete active payload with its recorded provenance. The
+    /// caller retains the same raw bytes for request identity; this introduces
+    /// no second payload clone, serialization, or inferred current-room label.
+    pub(crate) fn full_result_message(&self, seq: u64, full: &str) -> String {
+        let results = self.recent_results.lock();
+        let recorded = results.iter().rev().find(|(id, _, _, _, _)| *id == seq);
+        let attribution = ResultAttribution {
+            seq,
+            room: recorded.and_then(|(_, room, _, _, _)| *room),
+            operation: recorded.map(|(_, _, _, operation, _)| operation.as_str()),
+            spill_handle: recorded.and_then(|(_, _, _, _, handle)| handle.as_deref()),
+        };
+        format!("Full result of your most recent action ({attribution}):\n{full}")
+    }
+
     /// The FULL result of the just-executed act, ready to render as a **pinned**
     /// trailing prompt block — the run-18057-f1 fix.
     ///
@@ -993,10 +1049,7 @@ impl WorkingMemory {
         if full.chars().count() <= budget.trail_head_chars() {
             return None;
         }
-        Some(format!(
-            "Full result of your most recent action (#{seq}):\n{}",
-            clip_action_full(&full, &budget)
-        ))
+        Some(self.full_result_message(seq, &clip_action_full(&full, &budget)))
     }
 
     /// The RECENT-RESULTS feedback block: the last few acts' result tails, kept
@@ -1030,7 +1083,15 @@ impl WorkingMemory {
             "Recent results of your own actions (oldest first; #n matches the action ledger):"
                 .to_string(),
         );
-        out.extend(rr.iter().map(|(seq, _, tail, _, _)| format!("[result #{seq}] {tail}")));
+        out.extend(rr.iter().map(|(seq, room, tail, operation, handle)| {
+            let attribution = ResultAttribution {
+                seq: *seq,
+                room: *room,
+                operation: Some(operation),
+                spill_handle: handle.as_deref(),
+            };
+            format!("[result {attribution}] {tail}")
+        }));
         // Collapsed-results index LAST — it CHANGES on every eviction, and
         // message order is MONOTONE IN STABILITY (the KV law this same night
         // established): the banner + surviving entries ahead of it stay a
@@ -1054,7 +1115,15 @@ impl WorkingMemory {
         }
         let lines: Vec<String> = rr
             .iter()
-            .map(|(seq, _, tail, _, _)| format!("[result #{seq}] {tail}"))
+            .map(|(seq, room, tail, operation, handle)| {
+                let attribution = ResultAttribution {
+                    seq: *seq,
+                    room: *room,
+                    operation: Some(operation),
+                    spill_handle: handle.as_deref(),
+                };
+                format!("[result {attribution}] {tail}")
+            })
             .collect();
         Some(format!(
             "Recent results of your own actions (oldest first; #n matches the \
@@ -1151,18 +1220,22 @@ impl WorkingMemory {
         let mut rr = self.recent_results.lock();
         let mut total: usize = rr.iter().map(|(_, _, t, _, _)| t.chars().count() + 1).sum();
         while total > cap && rr.len() > 1 {
-            if let Some((eseq, _, evicted, elabel, ehandle)) = rr.pop_front() {
+            if let Some((eseq, room, evicted, elabel, ehandle)) = rr.pop_front() {
                 total -= evicted.chars().count() + 1;
                 // COLLAPSE, never delete: the evicted result leaves a queryable
                 // one-line pointer so she can expand or re-run deliberately
                 // instead of forgetting it ever happened.
                 let mut ptrs = self.evicted_pointers.lock();
+                let attribution = ResultAttribution {
+                    seq: eseq,
+                    room,
+                    operation: Some(&elabel),
+                    spill_handle: ehandle.as_deref(),
+                };
                 ptrs.push_back(match &ehandle {
-                    Some(h) => format!(
-                        "[result #{eseq} ({elabel}) — collapsed; full output: tool/output {h}]"
-                    ),
+                    Some(_) => format!("[result {attribution} — collapsed]"),
                     None => format!(
-                        "[result #{eseq} ({elabel}, {} chars) — collapsed from view; re-run if needed]",
+                        "[result {attribution}, {} chars — collapsed from view; re-run if needed]",
                         evicted.chars().count()
                     ),
                 });
@@ -1230,37 +1303,18 @@ impl WorkingMemory {
     }
 }
 
-/// Render the rolling trail, collapsing near-duplicate ANSWERED receipts
-/// (glass-boxed 2026-07-31, #264): a looping persona's trail rendered N full
-/// verbatim copies of her own repeated answer at the prompt TAIL — the
-/// maximum-recency position — an N-shot demonstration of the exact behavior
-/// the repetition facts (which render EARLIER in the prompt) told her to stop.
-/// Recency won; she complied with the demonstration, not the fact. Each
-/// receipt is compared against EARLIER receipts only, so a line's rendering
-/// never changes after it first appears (append-only KV property preserved);
-/// same near-identical geometry as the detectors — one definition of "repeat".
+/// Render the already-budgeted trail in order. A later settlement may correct
+/// or repeat an earlier report; similarity cannot replace that event's content.
 fn render_trail(recent: &[String]) -> String {
-    let mut prior_answers: Vec<&str> = Vec::new();
-    recent
-        .iter()
-        .map(|r| {
-            if let Some(ans) = r.strip_prefix(WM_SETTLEMENT_PREFIX) {
-                let ans = ans.trim();
-                if prior_answers
-                    .iter()
-                    .any(|p| super::deliberation_budget::near_identical_substantial(p, ans))
-                {
-                    return format!(
-                        "- {WM_SETTLEMENT_PREFIX} (a near-identical repeat of your answer \
-                         above — not re-shown)"
-                    );
-                }
-                prior_answers.push(ans);
-            }
-            format!("- {r}")
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+    let mut out = String::new();
+    for entry in recent {
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("- ");
+        out.push_str(entry);
+    }
+    out
 }
 
 /// Perception-tier faculty that bids the persona's recent reasoning into the
@@ -1327,8 +1381,11 @@ impl Faculty for WorkingMemoryFaculty {
                 .map(|(i, _)| i)
                 .collect();
             if non_fact.len() > WORK_TURN_RECENT_KEEP {
-                let drop: std::collections::HashSet<usize> =
-                    non_fact[..non_fact.len() - WORK_TURN_RECENT_KEEP].iter().copied().collect();
+                let drop: std::collections::HashSet<usize> = non_fact
+                    [..non_fact.len() - WORK_TURN_RECENT_KEEP]
+                    .iter()
+                    .copied()
+                    .collect();
                 collapsed_older = drop.len();
                 entries = entries
                     .into_iter()
@@ -1350,7 +1407,10 @@ impl Faculty for WorkingMemoryFaculty {
                 t.to_string()
             } else {
                 let kept: String = t.chars().take(head).collect();
-                format!("{kept} …[{} more chars — my full thought, collapsed]", t.chars().count() - head)
+                format!(
+                    "{kept} …[{} more chars — my full thought, collapsed]",
+                    t.chars().count() - head
+                )
             }
         };
         let recent: Vec<String> = entries
@@ -1408,7 +1468,8 @@ impl Faculty for WorkingMemoryFaculty {
         // of THIS 0.5-salience bid it rode `arbiter.focus()` top-k and was silently evicted
         // under capacity pressure (the run-18057-f1 0-byte patch). It is now PINNED by the
         // message builder as its own durable trailing turn — see
-        // [`WorkingMemory::pinned_active_result_block`] — so no attention pass can drop it.
+        // [`WorkingMemory::active_action_full`] and [`WorkingMemory::full_result_message`]
+        // — so no attention pass can drop it.
         // This contribution keeps only the append-only trail + notices + dispatched status,
         // which are proprioceptive summary, not the just-fetched result.
         // Substrate notices AFTER the trail: nearest generation (the [resumed]
@@ -1556,10 +1617,16 @@ mod tests {
         wm.record_receipt("[action #2] cat django/db/models/sql/compiler.py");
         let seen: Vec<String> = wm.recent_entries().into_iter().map(|e| e.text).collect();
         assert!(seen.iter().any(|t| t.contains("compiler.py")), "{seen:?}");
-        assert!(!seen.iter().any(|t| t.contains("tests/ordering")), "{seen:?}");
+        assert!(
+            !seen.iter().any(|t| t.contains("tests/ordering")),
+            "{seen:?}"
+        );
         wm.set_scope(Some("/peers/x/workspace/swe/django-16899".into()));
         let back: Vec<String> = wm.recent_entries().into_iter().map(|e| e.text).collect();
-        assert!(back.iter().any(|t| t.contains("tests/ordering")), "{back:?}");
+        assert!(
+            back.iter().any(|t| t.contains("tests/ordering")),
+            "{back:?}"
+        );
     }
 
     // what this catches: the Anwen regression (2026-08-16). Act results used to
@@ -1590,18 +1657,26 @@ mod tests {
             wm.record_receipt(&"x".repeat(cap));
         }
         assert!(
-            wm.recent_results_block().unwrap_or_default().contains("E0601"),
+            wm.recent_results_block()
+                .unwrap_or_default()
+                .contains("E0601"),
             "mid-settle the ring is append-only — no head rotation before settlement"
         );
         // …and SETTLEMENT collapses over-cap tails to pointers, restoring the bound.
         wm.record_settlement("done");
-        let total: usize = wm.recent_results_block().unwrap_or_default().chars().count();
+        let total: usize = wm
+            .recent_results_block()
+            .unwrap_or_default()
+            .chars()
+            .count();
         assert!(
             total <= cap + 256,
             "settlement must restore the window-derived bound: {total} > {cap}"
         );
         assert!(
-            !wm.recent_results_block().unwrap_or_default().contains("E0601"),
+            !wm.recent_results_block()
+                .unwrap_or_default()
+                .contains("E0601"),
             "oldest tails collapse to pointers at settlement — bounded, not immortal"
         );
     }
@@ -1647,52 +1722,53 @@ mod tests {
         );
     }
 
-    // what this catches: the WM loop re-teacher (#264, glass-boxed 2026-07-31 —
-    // Anwen's prompt TAIL carried two full verbatim copies of her looped
-    // template as receipts, out-shouting the repetition facts rendered earlier).
-    // A near-dup ANSWERED receipt renders as a stub, never full text; the FIRST
-    // copy stays full (append-only — its rendering must not change when the dup
-    // lands later); distinct answers and non-receipt traces render untouched.
-    #[test]
-    fn render_trail_collapses_near_dup_answered_receipts() {
-        let template = "It seems like we've been exploring various areas without making \
-                        much progress. Let's try a different approach by focusing on a \
-                        specific aspect of the Continuum system that could benefit from \
-                        our attention. Maintenance Protocols: investigate how maintenance \
-                        tasks are performed within the Continuum system.";
-        let trail = vec![
-            format!("{WM_SETTLEMENT_PREFIX} {template}"),
-            "[action #4] I ran code/read(...) Result: ok".to_string(),
-            format!("{WM_SETTLEMENT_PREFIX} {template}"),
-        ];
-        let out = render_trail(&trail);
+    // what this catches: e731576c — actual settlement records must reach the
+    // memory contribution even when a one-word correction resembles an older
+    // answer, or a later answer repeats the original state.
+    #[tokio::test]
+    async fn settlement_trail_preserves_corrections_and_later_repeated_reports() {
+        let passed = "I verified the candidate build and all regression tests passed \
+                      after checking the shared workspace changes against the review requirements.";
+        let failed = "I verified the candidate build and all regression tests failed \
+                      after checking the shared workspace changes against the review requirements.";
+        assert!(super::super::deliberation_budget::near_identical_substantial(passed, failed));
+        let wm = Arc::new(WorkingMemory::new(8));
+        wm.set_served_window(32_768);
+        wm.record_settlement(passed);
+        wm.record_receipt("code/read found the regression");
+        wm.record_settlement(failed);
+        wm.record_settlement(passed);
+        let entries = wm.recent_entries();
         assert_eq!(
-            out.matches("exploring various areas").count(),
-            1,
-            "the repeat must not re-show the full answer:\n{out}"
+            entries.iter().map(|entry| &entry.kind).collect::<Vec<_>>(),
+            vec![
+                &WmKind::Settlement,
+                &WmKind::Receipt { n: 1 },
+                &WmKind::Settlement,
+                &WmKind::Settlement
+            ]
         );
-        assert!(
-            out.contains("not re-shown"),
-            "stub names the collapse:\n{out}"
+        assert!(entries
+            .iter()
+            .all(|entry| entry.text.chars().count() <= wm.budget().trail_head_chars()));
+        let expected: Vec<_> = entries
+            .iter()
+            .map(|entry| format!("- {}", entry.text))
+            .collect();
+        let contribution = WorkingMemoryFaculty::new(wm)
+            .contribute(&Workspace::new("What changed in the latest review?"))
+            .await
+            .expect("test: recorded working memory contributes");
+        let actual: Vec<_> = contribution
+            .content
+            .lines()
+            .filter(|line| line.starts_with("- "))
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "the rendered trail must preserve every recorded entry in order"
         );
-        assert!(
-            out.contains("[action #4]"),
-            "non-receipt traces are untouched:\n{out}"
-        );
-        // Distinct answers both render in full — collapse is repetition-only.
-        let varied = vec![
-            format!(
-                "{WM_SETTLEMENT_PREFIX} the sha256 digest of the sample file is \
-                     abc123, computed with the standard tool over the exact bytes"
-            ),
-            format!(
-                "{WM_SETTLEMENT_PREFIX} the benchmark run finished green with twelve \
-                     passing cases and no failures across the entire suite tonight"
-            ),
-        ];
-        let out = render_trail(&varied);
-        assert!(out.contains("sha256") && out.contains("benchmark run finished green"));
-        assert!(!out.contains("not re-shown"));
+        assert!(!contribution.content.contains("not re-shown"));
     }
 
     // what this catches: loop-awareness — `note_action_fingerprint` counts repeats of the
@@ -1843,7 +1919,7 @@ mod tests {
                     tool_use_id: "call-42".into(),
                     content: "match at foo.rs:42".into(),
                     is_error: None,
-                spill_handle: None,
+                    spill_handle: None,
                 },
                 verb: ToolVerb::Search,
                 paths: Vec::new(),
@@ -1881,6 +1957,115 @@ mod tests {
         assert!(
             legacy.active_act().is_none(),
             "a legacy string receipt carries no typed act — the two channels are distinct"
+        );
+    }
+
+    // e731: identical result text from different activities must retain its
+    // actual room and every operation in its batch, including after restart.
+    #[test]
+    fn result_provenance_survives_cross_activity_render_and_checkpoint() {
+        use crate::ai::types::{ToolCall, ToolResult};
+        use crate::cognition::act_observe::{ActStatus, Observation, ToolOutput, ToolVerb};
+
+        let observation = |id: &str, name: &str, handle: Option<&str>| Observation {
+            call: ToolCall {
+                id: id.into(),
+                name: name.into(),
+                input: serde_json::json!({}),
+            },
+            output: ToolOutput {
+                result: ToolResult {
+                    tool_use_id: id.into(),
+                    content: "same result".into(),
+                    is_error: None,
+                    spill_handle: handle.map(str::to_owned),
+                },
+                verb: ToolVerb::classify(name),
+                paths: Vec::new(),
+            },
+            status: ActStatus::Executed,
+        };
+        let wm = WorkingMemory::new(8);
+        wm.set_served_window(16_384);
+        let room_a = Uuid::new_v4();
+        let room_b = Uuid::new_v4();
+        wm.record_receipt_typed(
+            &[
+                observation("a1", "code/search", Some("search-output")),
+                observation("a2", "code/read", None),
+            ],
+            "same result",
+            Some(room_a),
+        );
+        wm.record_receipt_typed(
+            &[observation("b1", "code/run", None)],
+            "same result",
+            Some(room_b),
+        );
+        let expected = vec![
+            format!("[result #1; room {room_a}; operation code/search, code/read; output handle: tool/output search-output] same result"),
+            format!("[result #2; room {room_b}; operation code/run] same result"),
+        ];
+        let messages = wm.recent_results_messages();
+        assert_eq!(
+            messages.len(),
+            3,
+            "banner plus two separately attributed results"
+        );
+        assert_eq!(&messages[1..], expected.as_slice());
+        let (seq, full) = wm
+            .active_action_full()
+            .expect("test: latest receipt is active");
+        assert_eq!(
+            wm.full_result_message(seq, &full),
+            format!("Full result of your most recent action (#2; room {room_b}; operation code/run):\nsame result")
+        );
+
+        let encoded = serde_json::to_value(wm.snapshot()).expect("test: snapshot serializes");
+        assert_eq!(
+            encoded["recent_results"][0]
+                .as_array()
+                .expect("test: persisted result tuple")
+                .len(),
+            5,
+            "the existing checkpoint tuple format must remain compatible"
+        );
+        let restored = WorkingMemory::new(8);
+        restored.set_served_window(16_384);
+        restored.restore(serde_json::from_value(encoded).expect("test: recorded snapshot decodes"));
+        assert_eq!(restored.recent_results_messages(), messages);
+        assert_eq!(
+            restored.full_result_message(seq, &full),
+            wm.full_result_message(seq, &full)
+        );
+
+        // Actual settlement collapses old tails; its pointers must still tell
+        // the mind which activity and operation the retained handle belongs to.
+        for _ in 0..4 {
+            restored.record_receipt(&"x".repeat(restored.budget().recent_results_chars()));
+        }
+        restored.record_settlement("reported");
+        assert!(restored.recent_results_messages().join("\n").contains(
+            &format!("[result #1; room {room_a}; operation code/search, code/read; output handle: tool/output search-output — collapsed]")
+        ));
+    }
+
+    // e731: pre-result-ring snapshots have a full body but no room/operation
+    // attribution. Rendering must expose that absence instead of inventing it.
+    #[test]
+    fn legacy_full_result_without_metadata_stays_explicitly_unattributed() {
+        let wm = WorkingMemory::new(8);
+        wm.record_receipt("legacy body");
+        let mut snapshot = wm.snapshot();
+        snapshot.recent_results.clear();
+        let restored = WorkingMemory::new(8);
+        restored.restore(snapshot);
+        let (seq, full) = restored
+            .active_action_full()
+            .expect("test: legacy body restored");
+        assert_eq!(
+            restored.full_result_message(seq, &full),
+            "Full result of your most recent action (#1; room unrecorded; operation unrecorded):\nlegacy body"
         );
     }
 
@@ -2077,7 +2262,7 @@ mod tests {
             .pinned_active_result_block()
             .expect("the whole result is pinned for the mind");
         assert!(
-            pinned.contains("Full result of your most recent action (#1):"),
+            pinned.contains("Full result of your most recent action (#1; room unrecorded; operation unrecorded):"),
             "the whole result reaches the mind"
         );
         assert!(
@@ -2142,7 +2327,7 @@ mod tests {
             .pinned_active_result_block()
             .expect("the oversized result still surfaces, clipped");
         assert!(
-            pinned.contains("Full result of your most recent action (#1):"),
+            pinned.contains("Full result of your most recent action (#1; room unrecorded; operation unrecorded):"),
             "the block still surfaces"
         );
         assert!(
@@ -2209,7 +2394,7 @@ mod tests {
         assert!(
             wm.pinned_active_result_block()
                 .expect("the fresh act's result is pinned")
-                .contains("Full result of your most recent action (#2):"),
+                .contains("Full result of your most recent action (#2; room unrecorded; operation unrecorded):"),
             "the new act's result is surfaced whole for its own what-next decision"
         );
     }
@@ -2473,13 +2658,24 @@ mod tests {
         for i in 0..12 {
             wm.record_fact(&format!("chatty fact {i}"));
         }
-        assert_eq!(wm.entries.lock().len(), 3, "the FIFO still ages out at capacity");
+        assert_eq!(
+            wm.entries.lock().len(),
+            3,
+            "the FIFO still ages out at capacity"
+        );
         assert_eq!(
             wm.pinned_facts(),
-            vec!["[hands] rooted at /a".to_string(), "[env] python at /a/env/bin/python".to_string()]
+            vec![
+                "[hands] rooted at /a".to_string(),
+                "[env] python at /a/env/bin/python".to_string()
+            ]
         );
         wm.pin_fact("hands", "[hands] rooted at /b");
-        assert_eq!(wm.pinned_facts()[0], "[hands] rooted at /b", "replaced by key, never duplicated");
+        assert_eq!(
+            wm.pinned_facts()[0],
+            "[hands] rooted at /b",
+            "replaced by key, never duplicated"
+        );
         assert_eq!(wm.pinned_facts().len(), 2);
         wm.unpin_fact("hands");
         wm.unpin_fact("env");
@@ -2488,7 +2684,11 @@ mod tests {
         wm.pin_fact("hands", "[hands] rooted at /c");
         wm.pin_fact_for_turns("released", "[released] card x", 2);
         wm.end_of_work_turn();
-        assert_eq!(wm.pinned_facts(), vec!["[released] card x".to_string()], "the release reaches the next turn");
+        assert_eq!(
+            wm.pinned_facts(),
+            vec!["[released] card x".to_string()],
+            "the release reaches the next turn"
+        );
         wm.end_of_work_turn();
         assert!(wm.pinned_facts().is_empty(), "and leaves after it");
     }

--- a/core/continuum-core/src/persona/act_question.rs
+++ b/core/continuum-core/src/persona/act_question.rs
@@ -475,7 +475,14 @@ pub(crate) async fn ask_the_act_question(
                             // is the A.6 arrival room already resolved
                             // for this turn, so the report lands in the
                             // room whose work it reports on.
-                            if let Err(e) = conversation.say_in(turn_room, &text).await {
+                            if let Err(e) = crate::persona::service_loop::publish_own_speech(
+                                conversation,
+                                ctx.identity.peer_id,
+                                turn_room,
+                                &text,
+                            )
+                            .await
+                            {
                                 tracing::warn!(
                                     error = %e,
                                     "work-turn report failed to send"

--- a/core/continuum-core/src/persona/scripted_conversation.rs
+++ b/core/continuum-core/src/persona/scripted_conversation.rs
@@ -75,6 +75,8 @@ pub struct ScriptedConversation {
     /// the room that asked" are different claims, and only the second
     /// one is the contract — see `said_in`.
     said: Mutex<Vec<(Uuid, String)>>,
+    /// Explicit transport refusal; failed attempts never enter `said`.
+    say_failure: Option<String>,
     primed: AtomicUsize,
     prime_result: Mutex<Result<(), String>>,
     /// When set, `next_message` returns Err if called before `prime`
@@ -102,6 +104,7 @@ impl ScriptedConversation {
             events: Arc::new(Mutex::new(VecDeque::new())),
             perceived_backlog: VecDeque::new(),
             said: Mutex::new(Vec::new()),
+            say_failure: None,
             primed: AtomicUsize::new(0),
             prime_result: Mutex::new(Ok(())),
             require_prime: false,
@@ -153,6 +156,12 @@ impl ScriptedConversation {
     /// `BootSlotFailure`).
     pub fn with_prime_failure(self, reason: impl Into<String>) -> Self {
         *self.prime_result.lock().unwrap() = Err(reason.into());
+        self
+    }
+
+    /// Refuse publication without pretending a message reached the room.
+    pub fn with_say_failure(mut self, reason: impl Into<String>) -> Self {
+        self.say_failure = Some(reason.into());
         self
     }
 
@@ -257,6 +266,9 @@ impl PersonaConversation for ScriptedConversation {
     }
 
     async fn say_in(&self, room_id: Uuid, text: &str) -> Result<(), String> {
+        if let Some(reason) = &self.say_failure {
+            return Err(reason.clone());
+        }
         self.said.lock().unwrap().push((room_id, text.to_string()));
         Ok(())
     }

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -173,6 +173,21 @@ pub trait PersonaConversation: Send + Sync {
     }
 }
 
+/// Publish an utterance and record it before subsequent work can begin.
+/// All resident speech paths share this boundary; refused publications never
+/// enter the own-speech repetition-observation ring. Assistant history still
+/// comes from the attributed room timeline. The conversation owns transport.
+pub(crate) async fn publish_own_speech(
+    conversation: &dyn PersonaConversation,
+    peer: crate::identity::PeerId,
+    room: Uuid,
+    text: &str,
+) -> Result<(), String> {
+    conversation.say_in(room, text).await?;
+    crate::cognition::deliberation_budget::record_own_speech(peer, room, text);
+    Ok(())
+}
+
 /// Behavioral knobs for the service loop. Keep small — substrate-
 /// resolved defaults handle the common case so callers don't need to
 /// thread state through.
@@ -1438,7 +1453,13 @@ async fn serve_persona_loop_inner(
         // Into the room the trigger arrived in (A.6 `turn_room`), which is the
         // same room whose context this turn reasoned over — never her ambient
         // default, or she answers one room's question to a different audience.
-        let say_result = conversation.say_in(turn_room, &response_text).await;
+        let say_result = publish_own_speech(
+            conversation,
+            ctx.identity.peer_id,
+            turn_room,
+            &response_text,
+        )
+        .await;
         phase_timings.say_ms = say_started.elapsed().as_millis() as u64;
         if let Err(e) = say_result {
             tracing::warn!(
@@ -1482,17 +1503,6 @@ async fn serve_persona_loop_inner(
 
         let turn_duration_ms = turn_started.elapsed().as_millis() as u64;
         outcome.turn_latency.record(turn_duration_ms);
-
-        // #148: record the utterance into her own-speech ring AFTER the publish
-        // succeeded (only REAL utterances are self-history). This is what keeps
-        // the repetition detector sighted when the burst window is too small to
-        // carry her own turns — her knowledge of what she said must never
-        // depend on the room's context budget.
-        crate::cognition::deliberation_budget::record_own_speech(
-            ctx.identity.peer_id,
-            turn_room,
-            &response_text,
-        );
 
         // RTOS-debugger breakpoint: turn completed successfully.
         // The phase fields below are the per-phase decomposition
@@ -1716,53 +1726,6 @@ pub(crate) fn project_room_roster(
         room_roster,
         other_persona_names,
     }
-}
-
-/// Collapse near-identical substantial turns by SUPPRESSING later copies —
-/// the OLDEST copy stays, byte-untouched, at its original position. Same-
-/// `is_self` only (role attribution stays intact), authorless opaque turns
-/// pass through untouched, and the geometry is [`near_identical_substantial`]'s
-/// — one definition of "nearly identical" shared with the perception facts.
-/// See the call site in [`build_workspace_turns`] for the why (repetition ≈
-/// bad RAG).
-///
-/// ## Why oldest-survivor, unannotated (2026-09-01, the KV-prefix churn)
-///
-/// The first cut kept the NEWEST copy and stamped the survivor's author with
-/// "(×N near-identical)". Both choices rewrite EARLY bytes of the rendered
-/// conversation whenever a fresh duplicate arrives — the representative
-/// relocates and the count increments — and a mutation at 1% depth of an 80k
-/// prompt invalidates the entire KV tail behind it (measured live: Benchy's
-/// consecutive prompts diverging at char ~660 on exactly this annotation,
-/// hit_rate 0.0 while his peers cached 0.38–0.50). Suppression is prefix-
-/// stable by construction: a new duplicate simply never renders, so the bytes
-/// already prefilled stay bytes. The repetition EVIDENCE still reaches her —
-/// the `[pattern]`/`[repetition]` perception facts detect on the RAW turns
-/// and render in the volatile facts phase, where flicker belongs.
-///
-/// The LAST turn is never suppressed: it is the burst's trigger/ask, and the
-/// reply anchor must always see it even when it near-duplicates history.
-pub(crate) fn collapse_near_duplicate_turns(
-    turns: Vec<crate::cognition::workspace::BurstTurn>,
-) -> Vec<crate::cognition::workspace::BurstTurn> {
-    use crate::cognition::deliberation_budget::near_identical_substantial;
-    let last_idx = turns.len().saturating_sub(1);
-    let mut kept: Vec<crate::cognition::workspace::BurstTurn> = Vec::with_capacity(turns.len());
-    for (i, t) in turns.into_iter().enumerate() {
-        if t.author.trim().is_empty() || i == last_idx {
-            kept.push(t);
-            continue;
-        }
-        let already_represented = kept.iter().any(|k| {
-            !k.author.trim().is_empty()
-                && k.is_self == t.is_self
-                && near_identical_substantial(&k.content, &t.content)
-        });
-        if !already_represented {
-            kept.push(t);
-        }
-    }
-    kept
 }
 
 /// How many CONSECUTIVE repetition-detector fires (without the pattern
@@ -2160,16 +2123,9 @@ pub(crate) fn build_workspace_turns(
         }
     }
 
-    // NEAR-DUP COLLAPSE (Joel 2026-07-12: "repetition almost always bad RAG").
-    // The 4-way mirror-halls fed each mind 4-8 copies of one message — her
-    // context WAS the loop, and continuation-completion reproduced it no matter
-    // what perception flagged. Compress at the source: near-identical
-    // substantial turns collapse to their NEWEST copy, author annotated
-    // "(×N near-identical)" so the repetition stays perceptible as a FACT
-    // while the copies stop being reading material. Runs AFTER the [pattern]
-    // detectors (they need the raw evidence) and never touches opaque
-    // (authorless) observation turns.
-    turns = collapse_near_duplicate_turns(turns);
+    // Content similarity does not identify a duplicate event. Preserve each
+    // speaker's updates and later repetitions in order; the perception facts
+    // above report repetition without deleting the history they describe.
 
     // WAKE BRIEFING (#147): when a wake carries NO conversation at all — fresh
     // spawn, post-restart, a quiet room — her first perception is ORIENTATION
@@ -2804,20 +2760,12 @@ async fn run_self_cycle(
             // A self-cycle answers no one — the audience is the room the tick
             // ran IN (her claim's focus room when working, else her default) —
             // the same room the cycle framed its context against.
-            if let Err(e) = conversation.say_in(tick_room, &text).await {
+            if let Err(e) =
+                publish_own_speech(conversation, ctx.identity.peer_id, tick_room, &text).await
+            {
                 tracing::warn!(persona = %ctx.identity.agent_name, error = %e, "self-cycle say failed");
                 return false;
             }
-            // #148: self-tick utterances are self-history too — the live
-            // repeat loops are mostly idle-tick re-announcements, and the
-            // first ring deploy missed THIS say path entirely (4 verbatim
-            // repeats, no [repetition], caught live 2026-07-12 10:20).
-            // Every successful say records, whichever path spoke.
-            crate::cognition::deliberation_budget::record_own_speech(
-                ctx.identity.peer_id,
-                ctx.identity.default_room,
-                &text,
-            );
             crate::probe!(
                 class = "persona.selftick.spoke",
                 persona = %ctx.identity.agent_name,
@@ -2882,6 +2830,55 @@ async fn next_event(
 mod tests {
     use super::*;
     use airc_core::PeerId;
+
+    // What this catches (e731576c): publication, not a later work-turn return,
+    // owns the speech ring; failures and other rooms cannot become its history.
+    #[tokio::test]
+    async fn successful_publication_records_speech_once_in_the_actual_room() {
+        use crate::cognition::deliberation_budget::recent_own_speech;
+        use crate::persona::scripted_conversation::ScriptedConversation;
+
+        let peer = crate::identity::PeerId::from_uuid(Uuid::new_v4());
+        let room = Uuid::new_v4();
+        let other_room = Uuid::new_v4();
+        let conversation = ScriptedConversation::new();
+        publish_own_speech(&conversation, peer, room, "The tests passed.")
+            .await
+            .expect("scripted publication succeeds");
+        assert_eq!(recent_own_speech(peer, room), ["The tests passed."]);
+        assert!(recent_own_speech(peer, other_room).is_empty());
+
+        let refused = ScriptedConversation::new().with_say_failure("room unavailable");
+        assert_eq!(
+            publish_own_speech(&refused, peer, room, "This was never delivered.").await,
+            Err("room unavailable".to_string())
+        );
+        assert!(refused.said_in().is_empty());
+        assert_eq!(recent_own_speech(peer, room), ["The tests passed."]);
+
+        publish_own_speech(&conversation, peer, other_room, "Other activity report.")
+            .await
+            .expect("scripted publication succeeds");
+        publish_own_speech(&conversation, peer, room, "The tests failed.")
+            .await
+            .expect("scripted correction succeeds");
+        assert_eq!(
+            recent_own_speech(peer, room),
+            ["The tests passed.", "The tests failed."]
+        );
+        assert_eq!(
+            recent_own_speech(peer, other_room),
+            ["Other activity report."]
+        );
+        assert_eq!(
+            conversation.said_in(),
+            vec![
+                (room, "The tests passed.".to_string()),
+                (other_room, "Other activity report.".to_string()),
+                (room, "The tests failed.".to_string()),
+            ]
+        );
+    }
 
     // what this catches: the resume block carries HER newest thoughts only, oldest
     // first, clipped — never another citizen's line, never a receipt.
@@ -3218,68 +3215,6 @@ mod tests {
         );
     }
 
-    // what this catches: the RAG-side mirror-hall cure (Joel 2026-07-12,
-    // "repetition almost always bad RAG") in its KV-STABLE form (2026-09-01):
-    // near-identical substantial turns are SUPPRESSED — the OLDEST copy stays
-    // at its position, byte-untouched (no relocating representative, no
-    // mutating "(×N)" author annotation; both rewrote early prompt bytes and
-    // killed the whole KV tail — Benchy's consecutive prompts diverged at
-    // char ~660 on exactly the annotation). The LAST turn (the trigger/ask)
-    // is never suppressed even when it near-duplicates history. Distinct
-    // turns, short acks (token floor), and opaque observation turns pass
-    // through untouched.
-    #[test]
-    fn near_dup_turns_suppress_later_copies_and_never_the_trigger() {
-        use crate::cognition::workspace::BurstTurn;
-        let loop_msg = "I see that we're all trying to find Rust files in the workspace. \
-                        Let me use file_tree with a deeper recursion limit to explore the \
-                        layout before drilling deeper: file_tree(max_depth=5)";
-        let turns = vec![
-            BurstTurn::attributed(false, "Anwen", loop_msg, Some(1)),
-            BurstTurn::attributed(false, "Asha", loop_msg, Some(2)),
-            BurstTurn::attributed(false, "Atlas", "thanks!", Some(3)),
-            BurstTurn::attributed(false, "Casper", "thanks!", Some(4)),
-            BurstTurn::opaque("[pattern] the room is cycling"),
-            BurstTurn::attributed(
-                false,
-                "Atlas",
-                &format!("{loop_msg} — and honestly the results aren't being returned"),
-                Some(5),
-            ),
-        ];
-        let out = collapse_near_duplicate_turns(turns);
-        // Asha's mid-window copy suppressed; Anwen's OLDEST copy survives
-        // untouched; Atlas's trigger variant survives because the LAST turn is
-        // sacred; acks + opaque pass through.
-        assert_eq!(
-            out.len(),
-            5,
-            "{:?}",
-            out.iter().map(|t| &t.author).collect::<Vec<_>>()
-        );
-        let survivor = out
-            .iter()
-            .find(|t| t.content.contains("find Rust files"))
-            .expect("the oldest representative survives");
-        assert_eq!(
-            survivor.author, "Anwen",
-            "oldest copy survives with its author BYTE-UNTOUCHED (no ×N annotation)"
-        );
-        assert!(
-            !out.iter().any(|t| t.author.contains("Asha")),
-            "the interior duplicate is suppressed entirely"
-        );
-        assert!(
-            out.last()
-                .unwrap()
-                .content
-                .contains("aren't being returned"),
-            "the trigger (last turn) is never suppressed, near-dup or not"
-        );
-        assert_eq!(out.iter().filter(|t| t.content == "thanks!").count(), 2);
-        assert!(out.iter().any(|t| t.content.starts_with("[pattern]")));
-    }
-
     // what this catches: #147 — a wake with NO conversation must carry the
     // orientation briefing, not a void (the void gets filled with imagined
     // history / generic-assistant masks, observed all morning 2026-07-12).
@@ -3493,6 +3428,69 @@ mod tests {
                 metadata: json!({ "peer_id": peer_id, "display_name": name }),
             }
         }
+
+        // what this catches: e731576c — source-side similarity suppression
+        // erased corrections, identical later reports, and even another peer's
+        // contribution before the inference fitter could see them.
+        #[test]
+        fn workspace_history_preserves_authors_corrections_and_repeated_events() {
+            use crate::cognition::workspace::TurnVoice;
+            let passed = "I verified the candidate build and all regression tests passed \
+                          after checking the shared workspace changes against the review requirements.";
+            let failed = "I verified the candidate build and all regression tests failed \
+                          after checking the shared workspace changes against the review requirements.";
+            assert!(
+                crate::cognition::deliberation_budget::near_identical_substantial(passed, failed),
+                "the fixture must exercise the former destructive similarity threshold"
+            );
+            let reports = [
+                ("peer-a", "Anwen", passed),
+                ("peer-b", "Benchy", failed),
+                ("peer-a", "Anwen", passed),
+                ("me", "Asha", failed),
+                ("me", "Asha", passed),
+                ("me", "Asha", failed),
+                ("peer-b", "Benchy", "The next review can begin now."),
+            ];
+            let items = reports
+                .iter()
+                .enumerate()
+                .map(|(index, (peer, _, text))| {
+                    let mut item = chat(peer, text);
+                    item.metadata["occurred_at_ms"] = json!((index + 1) as u64);
+                    item
+                })
+                .collect();
+            let deliveries = [
+                delivery("airc", items),
+                delivery(
+                    "room-roster",
+                    vec![roster("peer-a", "Anwen"), roster("peer-b", "Benchy")],
+                ),
+            ];
+            let turns = build_workspace_turns(&deliveries, "me", "Asha", None);
+            let speech: Vec<_> = turns
+                .iter()
+                .filter(|turn| turn.voice == TurnVoice::Speech)
+                .map(|turn| {
+                    (
+                        turn.is_self,
+                        turn.author.as_str(),
+                        turn.content.as_str(),
+                        turn.occurred_at_ms,
+                    )
+                })
+                .collect();
+            let expected: Vec<_> = reports
+                .iter()
+                .enumerate()
+                .map(|(index, (peer, author, text))| {
+                    (*peer == "me", *author, *text, Some((index + 1) as u64))
+                })
+                .collect();
+            assert_eq!(speech, expected, "every source event must retain its author, body, timestamp and chronological position");
+        }
+
         /// A `room-kanban` delivery item exactly as `RoomBoardSource::render`
         /// ships it (content line + card_id/state/owner metadata) — the stub
         /// board read the anchor escalation is built from.
@@ -5103,6 +5101,84 @@ mod tests {
             CardState::Closed,
             "a reasoned 'PASS: done' concludes the card (Closed)"
         );
+    }
+
+    // e731: the actual held-card path must use the same successful-publication
+    // boundary as replies/self-ticks. A refused send is not an observed utterance.
+    #[tokio::test(flavor = "current_thread")]
+    async fn held_work_reports_record_own_speech_only_after_publication() {
+        let native = tempfile::tempdir().expect("test: isolated cognition storage");
+        let _native_home = crate::paths::NativeHomeOverride::install(native.path());
+        for refuse_publication in [false, true] {
+            let peer = Uuid::new_v4();
+            let hosted = hosted_with_heuristic(peer);
+            let room = Uuid::new_v4();
+            assert_ne!(room, hosted.identity.default_room);
+            let cfg = crate::cognition::persona_workspace::PersonaBrainConfig {
+                persona_id: peer,
+                persona_name: "Paige".into(),
+                system_prompt: "You are Paige.".into(),
+                admission: Arc::new(crate::persona::admission_state::AdmissionState::new(
+                    Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new()),
+                )),
+                adapter: Arc::new(
+                    HeuristicInferenceAdapter::new()
+                        .with_canned_response("The tests failed after the latest change."),
+                ),
+                capacity: None,
+                grounding_sources: Vec::new(),
+                embedder: None,
+                tool_executor: None,
+                context_window: crate::cognition::serving_plan::MIN_SERVE_CTX,
+                defer_recall: false,
+                defer_grounding: false,
+                suppress_recall: false,
+            };
+            crate::cognition::persona_workspace::global().register_from_cfg(cfg);
+            let stub = StubAircCitizen::new(peer).with_claims(vec![held_card(peer)]);
+            let mut conversation = ScriptedConversation::new().with_citizen(Arc::new(stub));
+            if refuse_publication {
+                conversation = conversation.with_say_failure("room unavailable");
+            }
+            assert!(
+                crate::persona::act_question::ask_the_act_question(
+                    &hosted,
+                    &mut conversation,
+                    1,
+                    room,
+                    false,
+                )
+                .await
+            );
+            let speech = crate::cognition::deliberation_budget::recent_own_speech(
+                crate::identity::PeerId::from_uuid(peer),
+                room,
+            );
+            if refuse_publication {
+                assert!(conversation.said_in().is_empty());
+                assert!(
+                    speech.is_empty(),
+                    "failed publication must not enter the ring"
+                );
+            } else {
+                assert_eq!(
+                    conversation.said_in(),
+                    vec![(room, "The tests failed after the latest change.".into())]
+                );
+                assert_eq!(
+                    speech,
+                    vec!["The tests failed after the latest change.".to_string()]
+                );
+            }
+            assert!(
+                crate::cognition::deliberation_budget::recent_own_speech(
+                    crate::identity::PeerId::from_uuid(peer),
+                    hosted.identity.default_room,
+                )
+                .is_empty(),
+                "the hosted default room must not receive another activity's report"
+            );
+        }
     }
 
     // what this catches: kanban PULL — an idle team member grabs the next Open


### PR DESCRIPTION
A later report that tests failed could disappear because history filtering considered it too similar to an earlier report that tests passed. The upstream filter could also suppress a different teammate's statement, and settlement history independently substituted repeat markers. Preserve these distinct events through source projection, prompt fitting and working-memory rendering; existing window and memory budgets remain responsible for capacity.

Successful room replies, self-tick speech and held-work reports now share one publication boundary that records the utterance immediately in its actual room. Result projections retain recorded room, operation names, sequence and available output handle using a borrowed view of the existing checkpoint tuples. Context bounds describe input before fitting rather than claiming every input turn reached the model.

Validation at d7bc5e8ae9faed2ff2840b443618e316e74357db:

- Linux CI: 7,839 passed, 0 failed, 44 ignored, 42 filtered; two compile-fail guards passed. Generated bindings check passed.
- Windows MSVC library and test harness check passed.
- Native Windows Clippy with --lib --tests --features stress-tests exited 0. 1,351 warning emissions including duplicates; no primary diagnostic spans intersect this PR's changed hunks. No warning allowances added.
- Independent source reviews, rustfmt and git diff --check passed.

Regressions exercise actual source-to-Burst projection, the faculty's submitted adapter requests at successive passed/failed/passed steps, cross-room tool-result attribution, successful/refused held-work publication, and checkpoint compatibility. These use the existing test adapters and establish substrate behavior; live Persona performance and learning gains still need runtime evidence.

Dependency #3922 is merged into canary at 83b238948. This head is rebased onto it; its complete source tree is identical to the previously tested 87a18bf34 tree. Card e731576c-038d-47bc-85dc-2cc9792ef445.

Not deployed. Existing settlement markers represent a completed cognition step and are not yet durable transport-delivery receipts; this change does not claim all settlements reached an audience.
