### PR TITLE
fix(llama): resolve vendor source from the invoking checkout

### DIFF
--- a/core/llama/build.rs
+++ b/core/llama/build.rs
@@ -22,13 +22,11 @@ fn main() {
     // each build-script invocation, so env::var tracks whichever checkout is
     // actually building. (env! was a no-op optimization here — the path was
     // only ever used at run time.)
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect(
-        "CARGO_MANIFEST_DIR must be set when cargo runs this build script",
-    ));
-    let submodule = manifest_dir
-        .join("..")
-        .join("vendor")
-        .join("llama.cpp");
+    let manifest_dir = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR")
+            .expect("CARGO_MANIFEST_DIR must be set when cargo runs this build script"),
+    );
+    let submodule = manifest_dir.join("..").join("vendor").join("llama.cpp");
     println!("cargo:rerun-if-changed={}", submodule.display());
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/core/llama/build.rs
+++ b/core/llama/build.rs
@@ -13,11 +13,22 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let submodule = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    // Resolve the manifest dir AT RUNTIME, not compile time. `env!(...)
+    // expands when build.rs itself is compiled and bakes ONE checkout's
+    // absolute path into the cached build-script binary — with our shared
+    // target dir that poisons every other worktree (a sibling checkout
+    // reusing the fingerprinted script would point at this tree's vendor/
+    // llama.cpp, or fail to find its own). Cargo sets CARGO_MANIFEST_DIR for
+    // each build-script invocation, so env::var tracks whichever checkout is
+    // actually building. (env! was a no-op optimization here — the path was
+    // only ever used at run time.)
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect(
+        "CARGO_MANIFEST_DIR must be set when cargo runs this build script",
+    ));
+    let submodule = manifest_dir
         .join("..")
         .join("vendor")
         .join("llama.cpp");
-
     println!("cargo:rerun-if-changed={}", submodule.display());
     println!("cargo:rerun-if-changed=build.rs");
 


### PR DESCRIPTION
Resolve CARGO_MANIFEST_DIR when Cargo invokes the llama build script, so a reused executable selects the invoking checkout's vendor source for CMake and bindgen. This fixes source selection; CMake still rebuilds when the canonical source directory changes.

Kimi's contribution eb5a2606b981e5776e1514393cc6e32ec52ca03e was imported with cherry-pick -x and original authorship preserved. Only core/llama/build.rs changes; a separate commit formats the expression.

Validation at 3943ad04a160c8c88b4a91e112a4a098f1e464e5:
- CI34292283857: 7,839 library tests, two compile-fail doctests, Windows checks and binding validation passed. Independent source review, rustfmt and diff checks passed.
- Executed the exact build script compiled once under fixture A, then invoked A -> B -> B with one isolated output directory. Real CMake, bindgen and installed-archive linking selected B: the archive consumer changed from111 to222 and header/include markers followed B.
- The unchanged parent build script, compiled under A and invoked under B, still selected A and returned111. This is an executed negative control.
- Repeating B took0.568s, with zero native compile/archive steps and unchanged hashes and modification times for eight objects and eight archives.

The native exercise uses tiny CMake/header fixtures to test this boundary. It does not establish a full vendored llama.cpp build, Cargo's own decision to reuse a script, or general native rebuild performance. No shared build target or live runtime was modified by the probe.

Work card d2cda466-214d-4386-a94a-c3f3c3521cc8; contribution review8b9bc348-9bca-4c31-9efc-cab9b8e66fed.
