### PR TITLE
fix(ci): a vendor apt repo we never install from cannot fail every Rust run

### DIFF
--- a/.github/workflows/carl-install-smoke.yml
+++ b/.github/workflows/carl-install-smoke.yml
@@ -82,8 +82,19 @@ jobs:
         # it would be on a hardware-GPU host. vulkan-tools provides vulkaninfo
         # for the slice probes (test-slices.sh).
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+          # A THIRD-PARTY REPO WE NEVER INSTALL FROM MUST NOT FAIL OUR BUILD.
+          # The GitHub runner image ships vendor apt repos (Chrome, Microsoft, …).
+          # `apt-get update` exits 100 if ANY index fails, so on 2026-09-09 a Hash Sum
+          # mismatch on dl.google.com/linux/chrome-stable failed this step — and with it
+          # every Rust run on every branch — for a package list nothing here reads.
+          # Drop the vendor lists first, then update only the archives we install from,
+          # with retries for genuinely transient mirror errors. A real failure to fetch
+          # OUR packages still fails the step, loudly.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/*azure-cli* 2>/dev/null || true
+          sudo apt-get update -o Acquire::Retries=3 -y
+          sudo apt-get install -y -o Acquire::Retries=3 mesa-vulkan-drivers vulkan-tools
           echo "vulkaninfo summary:"
           vulkaninfo --summary 2>&1 | head -20 || true
 

--- a/.github/workflows/continuum-rust-tests.yml
+++ b/.github/workflows/continuum-rust-tests.yml
@@ -141,8 +141,19 @@ jobs:
       - name: System deps (mirrors docker/continuum-core.Dockerfile builder stage)
         if: github.event_name != 'pull_request' || steps.gate.outputs.relevant == 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # A THIRD-PARTY REPO WE NEVER INSTALL FROM MUST NOT FAIL OUR BUILD.
+          # The GitHub runner image ships vendor apt repos (Chrome, Microsoft, …).
+          # `apt-get update` exits 100 if ANY index fails, so on 2026-09-09 a Hash Sum
+          # mismatch on dl.google.com/linux/chrome-stable failed this step — and with it
+          # every Rust run on every branch — for a package list nothing here reads.
+          # Drop the vendor lists first, then update only the archives we install from,
+          # with retries for genuinely transient mirror errors. A real failure to fetch
+          # OUR packages still fails the step, loudly.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/*azure-cli* 2>/dev/null || true
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 --no-install-recommends \
             cmake pkg-config libssl-dev libpq-dev protobuf-compiler \
             libclang-dev clang build-essential \
             libglib2.0-dev libasound2-dev libva-dev


### PR DESCRIPTION
fix(ci): a vendor apt repo we never install from cannot fail every Rust run

2026-09-09: `Continuum Rust Tests` failed on every branch with exit 100 from
`sudo apt-get update`, and the reason was a package list nothing in this repository
reads:

  E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/
     binary-amd64/Packages.gz  Hash Sum mismatch
  E: Some index files failed to download.

The GitHub runner image ships third-party apt repos (Chrome, Microsoft, Azure CLI).
`apt-get update` exits non-zero if ANY index fails, so a transient corruption in a
vendor's mirror takes down our whole Rust matrix — for cmake, clang, protobuf and
libssl, none of which come from those repos. It presented as a code failure on
unrelated PRs, including a docs-only one, which is the worst shape for a red check:
it teaches everyone to merge past red.

Both workflows that install system packages now drop the vendor lists before updating
and retry genuinely transient mirror errors:

  sudo rm -f /etc/apt/sources.list.d/{google-chrome,microsoft-prod}.list …
  sudo apt-get update  -o Acquire::Retries=3
  sudo apt-get install -o Acquire::Retries=3 …

A real failure to fetch OUR packages still fails the step, loudly — this narrows what
can break us to what we actually depend on, rather than suppressing errors.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo