### PR TITLE
fix(activity): spawning a benchmark activity RUNS its round

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -777,13 +777,6 @@ pub struct BenchmarkDispatchParams {
     /// `O(claims × citizens)`, so the more work a citizen held, the less capacity
     /// it had to do any of it.
     ///
-    /// A fresh room per run makes the run's board its OWN denominator, lets the
-    /// round END, and puts the assignees somewhere they can hear each other. Pass
-    /// an explicit name to join an existing run (it must already exist — dispatch
-    /// spawns a room it names, and never silently adopts a stranger's).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[ts(optional)]
-    pub room: Option<String>,
     /// Also CLOSE this benchmark's redundant duplicate cards, converging the board
     /// to one live card per task. Off by default — a dispatch that silently closed
     /// cards would be a surprising verb.
@@ -846,6 +839,15 @@ pub struct BenchmarkDispatchResult {
     /// `ActivitySpawnResult::room_id`; this field is that value passed through.
     #[ts(type = "string")]
     pub room_id: airc_core::RoomId,
+    /// The wall post binding that room to the benchmark recipe — passed straight through
+    /// from the `spawn_activity_room` this dispatch performed.
+    ///
+    /// A run ROOTS AN ACTIVITY; this is the receipt that says so, and returning it is what
+    /// lets `activity/spawn` route a benchmark recipe here and still answer in its own
+    /// shape. Without it the two verbs could not report the same spawn, which is the seam
+    /// where "benchmarks are a parallel runner" creeps back in.
+    #[ts(type = "string")]
+    pub binding_post_id: uuid::Uuid,
     /// Cards actually posted to the board.
     #[ts(type = "number")]
     pub dispatched: u32,
@@ -1870,10 +1872,27 @@ impl ActionCommand for BenchmarkDispatch {
         // `create_work_card`, and every kickoff `say` are all current-room operations. That
         // pointer move is a documented gap for other callers (activity.rs) and the mechanism
         // for this one.
-        let room_name = match &p.room {
-            Some(r) => r.trim().to_string(),
-            None => default_run_room_name(spec.name, epoch_secs()),
-        };
+        // WE WORK ACTIVITIES. A dispatch ROOTS its own benchmark activity — always.
+        //
+        // This used to accept a room NAME, and that one optional string was enough to
+        // throw away the entire outcome: `--room continuum` put the cards on a plain
+        // CHAT room's board, where they carry no benchmark binding, so `review_gate`
+        // ("only the reviewer's done closes the card and fires its grade") has nothing
+        // to hang off and nothing ever grades them. Measured 2026-09-09: three correct,
+        // compiling citizen solutions produced exactly that way, `benchmark/runs` = 0,
+        // scoreboard `attempted=0 resolved=0`, and the round reported `settled=1` beside
+        // `graded_at_ms=None` without complaint.
+        //
+        // The knob is gone rather than validated. A verb that CAN post benchmark cards
+        // onto a non-benchmark board will eventually be used to do it — it is locally
+        // the shortest path to "a number" every single time, which is the parallel
+        // runner `BENCHMARKS-ARE-ADAPTERS-NOT-A-RUNNER.md` exists to forbid. Removing
+        // the option makes the wrong thing unreachable instead of merely discouraged.
+        //
+        // To add work to a run that already exists, dispatch again: the round tracker
+        // converges duplicates (`skipped_already_on_board`, `pruned_duplicates`) rather
+        // than needing a caller to aim at a board by hand.
+        let room_name = default_run_room_name(spec.name, epoch_secs());
         // The room binds to the SHIPPED benchmark recipe's declared purpose,
         // resolved from its constant — never a re-typed string. The old literal
         // here was "benchmark" while the recipe declares "benchmark/hard-rs",
@@ -2611,6 +2630,7 @@ impl ActionCommand for BenchmarkDispatch {
             benchmark: spec.name.to_string(),
             room: room.name,
             room_id: room.room_id,
+            binding_post_id: room.binding_post_id,
             dispatched: card_ids.len() as u32,
             card_ids,
             skipped_needs_setup,

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -88,6 +88,12 @@ fn caller_airc(
 /// Instantiate a recipe as a new room.
 pub struct ActivitySpawn {
     pub registry: PersonaAircRuntimeRegistry,
+    /// Late-bound substrate executor (the ChatModule pattern), so spawning a BENCHMARK
+    /// activity can run `benchmark/dispatch` through the universal primitive rather than
+    /// re-implementing the round it owns. Installed by `install_executor_on_all`.
+    pub executor_slot: std::sync::Arc<
+        crate::runtime::LateBound<crate::runtime::command_executor::CommandExecutor>,
+    >,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, JsonSchema)]
@@ -166,6 +172,107 @@ pub struct ActivitySpawnResult {
     pub binding_post_id: uuid::Uuid,
 }
 
+/// Translate a benchmark activity's OWN params into the `benchmark/dispatch` call that
+/// roots it. Pure, so the translation is assertable without an executor or a room — the
+/// half of the route that can silently drop a knob is exactly this one.
+///
+/// `suite` is REQUIRED: a benchmark activity with no suite has nothing to import, and the
+/// quiet version of that is what produced a spawned room with an empty board reading as a
+/// started run. Every other knob is passed through only when the caller SET it, so
+/// dispatch applies its own defaults — two defaulting layers that disagree is how a
+/// `driver` setting stops meaning anything.
+fn benchmark_dispatch_params(
+    recipe: &str,
+    params: &std::collections::BTreeMap<String, serde_json::Value>,
+) -> Result<serde_json::Map<String, serde_json::Value>, CommandError> {
+    let str_param = |k: &str| -> Option<String> {
+        params
+            .get(k)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+    };
+    let suite = str_param("suite").ok_or_else(|| {
+        CommandError::Invalid(format!(
+            "`{recipe}` is a benchmark activity and needs a `suite` to run — pass              `params.suite` (see `benchmark/list` for the names). Without it there is no              task collection to import, and the room would open with an empty board that              reads as a started run."
+        ))
+    })?;
+    let mut dispatch = serde_json::Map::new();
+    dispatch.insert("name".into(), serde_json::Value::String(suite));
+    dispatch.insert("recipe".into(), serde_json::Value::String(recipe.to_string()));
+    for (key, out) in [("instances", "instances"), ("team", "teammates")] {
+        if let Some(list) = params.get(key).and_then(|v| v.as_array()) {
+            let list: Vec<String> = list
+                .iter()
+                .filter_map(|e| e.as_str().map(str::to_string))
+                .collect();
+            dispatch.insert(out.into(), serde_json::json!(list));
+        }
+    }
+    for (key, out) in [("driver", "drive"), ("doctrine", "doctrine")] {
+        if let Some(v) = str_param(key) {
+            dispatch.insert(out.into(), serde_json::Value::String(v));
+        }
+    }
+    if let Some(v) = params.get("review_gate").and_then(serde_json::Value::as_bool) {
+        dispatch.insert("review_gate".into(), serde_json::Value::Bool(v));
+    }
+    Ok(dispatch)
+}
+
+impl ActivitySpawn {
+    /// Root a BENCHMARK activity by running its dispatch — the one verb that owns a round.
+    ///
+    /// Params are read from the recipe's own vocabulary (`suite`, `instances`, `team`,
+    /// `driver`, `doctrine`, `review_gate`) and passed on RICH, so nothing the caller set
+    /// is silently dropped on the way. `suite` is REQUIRED and its absence is a loud error
+    /// naming it: a benchmark activity with no suite has nothing to import, and the whole
+    /// reason this route exists is that the quiet version of that produced an empty board.
+    async fn dispatch_benchmark_activity(
+        &self,
+        p: ActivitySpawnParams,
+    ) -> Result<ActivitySpawnResult, CommandError> {
+        let exec = self.executor_slot.get().cloned().ok_or_else(|| {
+            CommandError::Internal(
+                "command executor not installed on activity/spawn — boot wiring gap".into(),
+            )
+        })?;
+        let dispatch = benchmark_dispatch_params(&p.recipe, &p.params)?;
+        let out = exec
+            .execute("benchmark/dispatch", serde_json::Value::Object(dispatch))
+            .await
+            .map_err(|e| CommandError::Internal(format!("benchmark/dispatch failed: {e}")))?;
+        let crate::runtime::CommandResult::Json(v) = out else {
+            return Err(CommandError::Internal(
+                "benchmark/dispatch returned a non-JSON result".into(),
+            ));
+        };
+        // The room dispatch ROOTED is the activity this call spawned — reported back in
+        // this verb's own shape so a caller never has to know which door ran.
+        let result: BenchmarkDispatchRoom = serde_json::from_value(v).map_err(|e| {
+            CommandError::Internal(format!(
+                "benchmark/dispatch result did not name the room it rooted: {e}"
+            ))
+        })?;
+        Ok(ActivitySpawnResult {
+            room_id: result.room_id,
+            name: result.room,
+            recipe: p.recipe,
+            binding_post_id: result.binding_post_id,
+        })
+    }
+}
+
+/// The half of `BenchmarkDispatchResult` this verb needs: WHICH ROOM the run rooted.
+/// Deserialized structurally rather than by importing the whole result so the two verbs
+/// stay decoupled — dispatch may grow counters forever without touching this path.
+#[derive(Debug, Deserialize)]
+struct BenchmarkDispatchRoom {
+    room: String,
+    room_id: RoomId,
+    binding_post_id: uuid::Uuid,
+}
+
 #[async_trait]
 impl ActionCommand for ActivitySpawn {
     const NAME: &'static str = "activity/spawn";
@@ -218,6 +325,25 @@ impl ActionCommand for ActivitySpawn {
         p: ActivitySpawnParams,
     ) -> Result<ActivitySpawnResult, CommandError> {
         let airc = caller_airc(&self.registry, ctx)?;
+        // A BENCHMARK ACTIVITY ROOTS ITSELF THROUGH ITS RUN.
+        //
+        // We work activities, period — so this verb does not get to hand back a
+        // benchmark-shaped room and call it spawned. The benchmark recipe declares
+        // `suite`, `instances`, `team`, `driver`, `doctrine`, `review_gate`, and the plain
+        // spawn path consumes NONE of them: measured 2026-09-09, spawning with
+        // `{"suite":"coder-write-eval","instances":["sum_evens"]}` created the room, posted
+        // 0 cards and imported 0 tasks, while the knobs read as if they had. An empty
+        // benchmark room is worse than an error, because it looks like a started run.
+        //
+        // `benchmark/dispatch` is the verb that owns the whole round — resolve the roster,
+        // import the suite (task + oracle only), root the activity FROM THIS SAME RECIPE
+        // with the params bound, post the cards, send the kickoffs, track the round. So
+        // this path RUNS it, through the universal primitive, instead of refusing and
+        // making the caller know which of two doors to use. One door; the recipe decides
+        // what walking through it means.
+        if p.recipe.starts_with("benchmark/") {
+            return self.dispatch_benchmark_activity(p).await;
+        }
         spawn_activity_room(&airc, &p.name, &p.recipe, p.parent, &p.params).await
     }
 }
@@ -862,11 +988,21 @@ crate::register_command!(ActivityProtect);
 /// Hosts the `activity/*` verbs.
 pub struct ActivityModule {
     registry: PersonaAircRuntimeRegistry,
+    /// See [`ActivitySpawn::executor_slot`] — this module owns the slot and hands a clone
+    /// to the verb, exactly as `WorkModule` does for `benchmark/dispatch`.
+    executor_slot: std::sync::Arc<
+        crate::runtime::LateBound<crate::runtime::command_executor::CommandExecutor>,
+    >,
 }
 
 impl ActivityModule {
     pub fn new(registry: PersonaAircRuntimeRegistry) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            executor_slot: std::sync::Arc::new(crate::runtime::LateBound::new(
+                "activity::executor",
+            )),
+        }
     }
 }
 
@@ -903,6 +1039,7 @@ impl ServiceModule for ActivityModule {
         vec![
             Arc::new(ActivitySpawn {
                 registry: self.registry.clone(),
+                executor_slot: self.executor_slot.clone(),
             }),
             Arc::new(ActivityRecipes),
             Arc::new(ActivityInvite {
@@ -915,6 +1052,13 @@ impl ServiceModule for ActivityModule {
                 registry: self.registry.clone(),
             }),
         ]
+    }
+
+    fn install_executor(
+        &self,
+        executor: std::sync::Arc<crate::runtime::command_executor::CommandExecutor>,
+    ) {
+        self.executor_slot.install(executor);
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -1239,6 +1383,84 @@ mod tests {
                 serde_json::json!("4h"),
                 "unset budget rides the declared default onto the binding"
             );
+        }
+    }
+
+    /// `activity/spawn` on a benchmark recipe RUNS the round rather than handing back an
+    /// empty benchmark-shaped room. Nested per the one-mod rule.
+    mod benchmark_activities_route_to_their_run {
+        use super::*;
+        use std::collections::BTreeMap;
+
+        fn params(pairs: &[(&str, serde_json::Value)]) -> BTreeMap<String, serde_json::Value> {
+            pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+        }
+
+        // what this catches: every knob the benchmark recipe declares must reach dispatch
+        // under the name dispatch reads. A rename on either side silently drops the knob —
+        // the caller sets `driver` or `team`, the run ignores it, and the round reads as if
+        // it had honoured them. That is the failure this whole route exists to end.
+        #[test]
+        fn every_recipe_knob_reaches_the_dispatch_that_reads_it() {
+            let out = benchmark_dispatch_params(
+                "benchmark/hard-rs",
+                &params(&[
+                    ("suite", serde_json::json!("coder-write-eval")),
+                    ("instances", serde_json::json!(["sum_evens", "conway_step"])),
+                    ("team", serde_json::json!(["Sahar", "Kimi"])),
+                    ("driver", serde_json::json!("citizen")),
+                    ("doctrine", serde_json::json!("work it with your own hands")),
+                    ("review_gate", serde_json::json!(true)),
+                ]),
+            )
+            .expect("a suite is present, so the translation succeeds");
+            assert_eq!(out["name"], serde_json::json!("coder-write-eval"), "suite names the run");
+            assert_eq!(out["recipe"], serde_json::json!("benchmark/hard-rs"), "the recipe rides along");
+            assert_eq!(out["instances"], serde_json::json!(["sum_evens", "conway_step"]));
+            assert_eq!(out["teammates"], serde_json::json!(["Sahar", "Kimi"]), "`team` is dispatch's `teammates`");
+            assert_eq!(out["drive"], serde_json::json!("citizen"), "`driver` is dispatch's `drive`");
+            assert_eq!(out["doctrine"], serde_json::json!("work it with your own hands"));
+            assert_eq!(out["review_gate"], serde_json::json!(true));
+        }
+
+        // what this catches: an unset knob must stay ABSENT so dispatch applies its own
+        // default. If this path inserted nulls or its own defaults there would be two
+        // defaulting layers, and the day they disagree the recipe's declared default
+        // silently stops being the one that runs.
+        #[test]
+        fn an_unset_knob_stays_absent_so_dispatch_owns_its_defaults() {
+            let out = benchmark_dispatch_params(
+                "benchmark/hard-rs",
+                &params(&[("suite", serde_json::json!("games-rs"))]),
+            )
+            .expect("suite alone is enough");
+            for absent in ["instances", "teammates", "drive", "doctrine", "review_gate"] {
+                assert!(
+                    !out.contains_key(absent),
+                    "`{absent}` was never set by the caller and must not be invented here"
+                );
+            }
+        }
+
+        // what this catches: a benchmark activity with no suite must FAIL, loudly, naming
+        // the missing param. Spawning it quietly is what produced a room with a scoreboard
+        // region, an empty board and zero imported tasks — indistinguishable from a run
+        // that started and found nothing to do.
+        #[test]
+        fn a_benchmark_activity_without_a_suite_refuses_and_says_which_param() {
+            let err = benchmark_dispatch_params(
+                "benchmark/hard-rs",
+                &params(&[("instances", serde_json::json!(["sum_evens"]))]),
+            )
+            .expect_err("no suite — there is nothing to import");
+            let msg = format!("{err:?}");
+            assert!(msg.contains("suite"), "the error names the missing param: {msg}");
+            // A blank string is the same absence, not a suite named "".
+            let blank = benchmark_dispatch_params(
+                "benchmark/hard-rs",
+                &params(&[("suite", serde_json::json!("   "))]),
+            );
+            assert!(blank.is_err(), "whitespace is not a suite name");
         }
     }
 }

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -199,7 +199,10 @@ fn benchmark_dispatch_params(
     })?;
     let mut dispatch = serde_json::Map::new();
     dispatch.insert("name".into(), serde_json::Value::String(suite));
-    dispatch.insert("recipe".into(), serde_json::Value::String(recipe.to_string()));
+    dispatch.insert(
+        "recipe".into(),
+        serde_json::Value::String(recipe.to_string()),
+    );
     for (key, out) in [("instances", "instances"), ("team", "teammates")] {
         if let Some(list) = params.get(key).and_then(|v| v.as_array()) {
             let list: Vec<String> = list
@@ -214,53 +217,61 @@ fn benchmark_dispatch_params(
             dispatch.insert(out.into(), serde_json::Value::String(v));
         }
     }
-    if let Some(v) = params.get("review_gate").and_then(serde_json::Value::as_bool) {
+    if let Some(v) = params
+        .get("review_gate")
+        .and_then(serde_json::Value::as_bool)
+    {
         dispatch.insert("review_gate".into(), serde_json::Value::Bool(v));
     }
     Ok(dispatch)
 }
 
-impl ActivitySpawn {
-    /// Root a BENCHMARK activity by running its dispatch — the one verb that owns a round.
-    ///
-    /// Params are read from the recipe's own vocabulary (`suite`, `instances`, `team`,
-    /// `driver`, `doctrine`, `review_gate`) and passed on RICH, so nothing the caller set
-    /// is silently dropped on the way. `suite` is REQUIRED and its absence is a loud error
-    /// naming it: a benchmark activity with no suite has nothing to import, and the whole
-    /// reason this route exists is that the quiet version of that produced an empty board.
-    async fn dispatch_benchmark_activity(
-        &self,
-        p: ActivitySpawnParams,
-    ) -> Result<ActivitySpawnResult, CommandError> {
-        let exec = self.executor_slot.get().cloned().ok_or_else(|| {
-            CommandError::Internal(
-                "command executor not installed on activity/spawn — boot wiring gap".into(),
-            )
-        })?;
-        let dispatch = benchmark_dispatch_params(&p.recipe, &p.params)?;
-        let out = exec
-            .execute("benchmark/dispatch", serde_json::Value::Object(dispatch))
-            .await
-            .map_err(|e| CommandError::Internal(format!("benchmark/dispatch failed: {e}")))?;
-        let crate::runtime::CommandResult::Json(v) = out else {
-            return Err(CommandError::Internal(
-                "benchmark/dispatch returned a non-JSON result".into(),
-            ));
-        };
-        // The room dispatch ROOTED is the activity this call spawned — reported back in
-        // this verb's own shape so a caller never has to know which door ran.
-        let result: BenchmarkDispatchRoom = serde_json::from_value(v).map_err(|e| {
-            CommandError::Internal(format!(
-                "benchmark/dispatch result did not name the room it rooted: {e}"
-            ))
-        })?;
-        Ok(ActivitySpawnResult {
-            room_id: result.room_id,
-            name: result.room,
-            recipe: p.recipe,
-            binding_post_id: result.binding_post_id,
-        })
-    }
+/// Root a BENCHMARK activity by running its dispatch — the one verb that owns a round.
+///
+/// Params are read from the recipe's own vocabulary (`suite`, `instances`, `team`,
+/// `driver`, `doctrine`, `review_gate`) and passed on RICH, so nothing the caller set
+/// is silently dropped on the way. `suite` is REQUIRED and its absence is a loud error
+/// naming it: a benchmark activity with no suite has nothing to import, and the whole
+/// reason this route exists is that the quiet version of that produced an empty board.
+///
+/// A FREE function, not an inherent method, and deliberately so: an `impl ActivitySpawn`
+/// would make the command struct read as "machinery" to
+/// `source_hygiene::production_reachability` — a pub type with an inherent impl and a
+/// constructor — and a command is only ever constructed by its own module's `commands()`,
+/// so it would count as unwired forever. The guard is right about the shape it checks;
+/// this code has no need of the shape.
+async fn dispatch_benchmark_activity(
+    executor_slot: &crate::runtime::LateBound<crate::runtime::command_executor::CommandExecutor>,
+    p: ActivitySpawnParams,
+) -> Result<ActivitySpawnResult, CommandError> {
+    let exec = executor_slot.get().cloned().ok_or_else(|| {
+        CommandError::Internal(
+            "command executor not installed on activity/spawn — boot wiring gap".into(),
+        )
+    })?;
+    let dispatch = benchmark_dispatch_params(&p.recipe, &p.params)?;
+    let out = exec
+        .execute("benchmark/dispatch", serde_json::Value::Object(dispatch))
+        .await
+        .map_err(|e| CommandError::Internal(format!("benchmark/dispatch failed: {e}")))?;
+    let crate::runtime::CommandResult::Json(v) = out else {
+        return Err(CommandError::Internal(
+            "benchmark/dispatch returned a non-JSON result".into(),
+        ));
+    };
+    // The room dispatch ROOTED is the activity this call spawned — reported back in
+    // this verb's own shape so a caller never has to know which door ran.
+    let result: BenchmarkDispatchRoom = serde_json::from_value(v).map_err(|e| {
+        CommandError::Internal(format!(
+            "benchmark/dispatch result did not name the room it rooted: {e}"
+        ))
+    })?;
+    Ok(ActivitySpawnResult {
+        room_id: result.room_id,
+        name: result.room,
+        recipe: p.recipe,
+        binding_post_id: result.binding_post_id,
+    })
 }
 
 /// The half of `BenchmarkDispatchResult` this verb needs: WHICH ROOM the run rooted.
@@ -342,7 +353,7 @@ impl ActionCommand for ActivitySpawn {
         // making the caller know which of two doors to use. One door; the recipe decides
         // what walking through it means.
         if p.recipe.starts_with("benchmark/") {
-            return self.dispatch_benchmark_activity(p).await;
+            return dispatch_benchmark_activity(&self.executor_slot, p).await;
         }
         spawn_activity_room(&airc, &p.name, &p.recipe, p.parent, &p.params).await
     }
@@ -634,8 +645,14 @@ pub async fn spawn_activity_room(
     )?;
     let resolved_params = resolve_params(&recipe_def, params)?;
     // Read before `resolved_params` moves into the binding below.
-    let child_driver = resolved_params.get("driver").and_then(|v| v.as_str()).map(|s| s.to_string());
-    let child_suite = resolved_params.get("suite").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let child_driver = resolved_params
+        .get("driver")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let child_suite = resolved_params
+        .get("suite")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
     // WHERE IT ROOTS: an explicit parent wins (a sub-activity nests under the activity
     // that spawned it); else the recipe's declared BASE (a benchmark round is learning →
     // `academy`, by what it is); else nowhere in particular (the spawner's context). The
@@ -706,9 +723,8 @@ pub async fn spawn_activity_room(
             parent,
             params: resolved_params,
         };
-        let body = serde_json::to_string(&binding).map_err(|source| {
-            CommandError::Internal(format!("encode recipe binding: {source}"))
-        })?;
+        let body = serde_json::to_string(&binding)
+            .map_err(|source| CommandError::Internal(format!("encode recipe binding: {source}")))?;
         let post_id = airc
             .publish_wall_post(RECIPE_WALL_CATEGORY.to_string(), body, None)
             .await
@@ -728,11 +744,11 @@ pub async fn spawn_activity_room(
         if let Some(parent_id) = parent {
             let parent_room = match parent_room.take() {
                 Some(r) => Some(r),
-                None => airc
-                    .subscription_set()
-                    .await
-                    .ok()
-                    .and_then(|set| set.all().map(|sub| sub.as_room()).find(|r| r.channel == parent_id)),
+                None => airc.subscription_set().await.ok().and_then(|set| {
+                    set.all()
+                        .map(|sub| sub.as_room())
+                        .find(|r| r.channel == parent_id)
+                }),
             };
             match parent_room {
                 Some(parent_room) => {
@@ -772,7 +788,9 @@ pub async fn spawn_activity_room(
                                 "the room exists but its parent never heard of it — remote nodes cannot seat into it until a re-spawn"
                             ),
                         },
-                        Err(source) => tracing::warn!(%source, room = %name, "child record could not be encoded"),
+                        Err(source) => {
+                            tracing::warn!(%source, room = %name, "child record could not be encoded")
+                        }
                     }
                 }
                 None => crate::probe!(
@@ -794,7 +812,6 @@ pub async fn spawn_activity_room(
 }
 
 // ─────────────────────────── standing ───────────────────────────
-
 
 /// The standing of ONE room the caller named — never "whatever room the
 /// scope's pointer happens to be on".
@@ -836,7 +853,6 @@ async fn publish_standing_in(
             ))
         })
 }
-
 
 #[derive(Debug, Clone, Serialize, TS)]
 pub struct StandingResult {
@@ -1215,10 +1231,10 @@ mod tests {
         // stood. Losing this line would drop every round to a flat top-level room again.
         #[test]
         fn the_benchmark_recipe_roots_in_the_academy() {
-            let recipe = crate::experience::recipe::ExperienceRecipe::from_json(
-                include_str!("../experience/recipes/benchmark.json"),
-            )
-            .expect("shipped recipe parses");  // test: the embedded recipe is authored JSON
+            let recipe = crate::experience::recipe::ExperienceRecipe::from_json(include_str!(
+                "../experience/recipes/benchmark.json"
+            ))
+            .expect("shipped recipe parses"); // test: the embedded recipe is authored JSON
             assert_eq!(recipe.base.as_deref(), Some("academy"));
         }
 
@@ -1258,8 +1274,7 @@ mod tests {
         #[test]
         fn an_override_merges_over_the_remaining_defaults() {
             let given = BTreeMap::from([("instances".to_string(), serde_json::json!(5))]);
-            let resolved =
-                resolve_params(&recipe_with_params(), &given).expect("valid override");
+            let resolved = resolve_params(&recipe_with_params(), &given).expect("valid override");
             assert_eq!(resolved["instances"], serde_json::json!(5));
             assert_eq!(resolved["suite"], serde_json::json!("swe-lite"));
         }
@@ -1306,11 +1321,9 @@ mod tests {
                 r#"{ "purpose": "bench/bare", "regions": [], "affordances": [] }"#,
             )
             .expect("bare recipe parses");
-            assert!(
-                resolve_params(&bare, &BTreeMap::new())
-                    .expect("no params, no overrides — fine")
-                    .is_empty()
-            );
+            assert!(resolve_params(&bare, &BTreeMap::new())
+                .expect("no params, no overrides — fine")
+                .is_empty());
             let err = resolve_params(
                 &bare,
                 &BTreeMap::from([("anything".to_string(), serde_json::json!(1))]),
@@ -1339,8 +1352,8 @@ mod tests {
                 }"#,
             )
             .expect("write overlay chat");
-            let resolved = resolve_recipe("chat", overlay.path())
-                .expect("shipped purpose still resolves");
+            let resolved =
+                resolve_recipe("chat", overlay.path()).expect("shipped purpose still resolves");
             assert!(
                 resolved.params.contains_key("topic"),
                 "the OVERLAY copy (with its param decls) must win, got params: {:?}",
@@ -1393,7 +1406,10 @@ mod tests {
         use std::collections::BTreeMap;
 
         fn params(pairs: &[(&str, serde_json::Value)]) -> BTreeMap<String, serde_json::Value> {
-            pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect()
         }
 
         // what this catches: every knob the benchmark recipe declares must reach dispatch
@@ -1414,12 +1430,34 @@ mod tests {
                 ]),
             )
             .expect("a suite is present, so the translation succeeds");
-            assert_eq!(out["name"], serde_json::json!("coder-write-eval"), "suite names the run");
-            assert_eq!(out["recipe"], serde_json::json!("benchmark/hard-rs"), "the recipe rides along");
-            assert_eq!(out["instances"], serde_json::json!(["sum_evens", "conway_step"]));
-            assert_eq!(out["teammates"], serde_json::json!(["Sahar", "Kimi"]), "`team` is dispatch's `teammates`");
-            assert_eq!(out["drive"], serde_json::json!("citizen"), "`driver` is dispatch's `drive`");
-            assert_eq!(out["doctrine"], serde_json::json!("work it with your own hands"));
+            assert_eq!(
+                out["name"],
+                serde_json::json!("coder-write-eval"),
+                "suite names the run"
+            );
+            assert_eq!(
+                out["recipe"],
+                serde_json::json!("benchmark/hard-rs"),
+                "the recipe rides along"
+            );
+            assert_eq!(
+                out["instances"],
+                serde_json::json!(["sum_evens", "conway_step"])
+            );
+            assert_eq!(
+                out["teammates"],
+                serde_json::json!(["Sahar", "Kimi"]),
+                "`team` is dispatch's `teammates`"
+            );
+            assert_eq!(
+                out["drive"],
+                serde_json::json!("citizen"),
+                "`driver` is dispatch's `drive`"
+            );
+            assert_eq!(
+                out["doctrine"],
+                serde_json::json!("work it with your own hands")
+            );
             assert_eq!(out["review_gate"], serde_json::json!(true));
         }
 
@@ -1454,7 +1492,10 @@ mod tests {
             )
             .expect_err("no suite — there is nothing to import");
             let msg = format!("{err:?}");
-            assert!(msg.contains("suite"), "the error names the missing param: {msg}");
+            assert!(
+                msg.contains("suite"),
+                "the error names the missing param: {msg}"
+            );
             // A blank string is the same absence, not a suite named "".
             let blank = benchmark_dispatch_params(
                 "benchmark/hard-rs",

--- a/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchParams.ts
@@ -86,13 +86,6 @@ seed?: number,
  * `O(claims × citizens)`, so the more work a citizen held, the less capacity
  * it had to do any of it.
  *
- * A fresh room per run makes the run's board its OWN denominator, lets the
- * round END, and puts the assignees somewhere they can hear each other. Pass
- * an explicit name to join an existing run (it must already exist — dispatch
- * spawns a room it names, and never silently adopts a stranger's).
- */
-room?: string, 
-/**
  * Also CLOSE this benchmark's redundant duplicate cards, converging the board
  * to one live card per task. Off by default — a dispatch that silently closed
  * cards would be a surprising verb.

--- a/protocol/typescript/benchmark/BenchmarkDispatchResult.ts
+++ b/protocol/typescript/benchmark/BenchmarkDispatchResult.ts
@@ -12,6 +12,16 @@ room: string,
  */
 room_id: string, 
 /**
+ * The wall post binding that room to the benchmark recipe — passed straight through
+ * from the `spawn_activity_room` this dispatch performed.
+ *
+ * A run ROOTS AN ACTIVITY; this is the receipt that says so, and returning it is what
+ * lets `activity/spawn` route a benchmark recipe here and still answer in its own
+ * shape. Without it the two verbs could not report the same spawn, which is the seam
+ * where "benchmarks are a parallel runner" creeps back in.
+ */
+binding_post_id: string, 
+/**
  * Cards actually posted to the board.
  */
 dispatched: number, 


### PR DESCRIPTION
Closes #3951.

## What was wrong

`activity/spawn` on a benchmark recipe created the room and stopped.

The benchmark recipe declares `suite`, `instances`, `team`, `driver`, `doctrine`, `review_gate`. The spawn path consumed **none** of them. Measured today: spawning with `{"suite":"coder-write-eval","instances":["sum_evens"]}` created the room, imported 0 tasks, posted 0 cards — while the knobs read as if they had been honoured.

An empty benchmark room is worse than an error, because it looks like a run that started and found nothing to do.

## What it does now

`benchmark/dispatch` is the verb that owns a round: resolve the roster, import the suite (task + oracle only), root the activity **from this same recipe** with the params bound, post the cards, send the kickoffs, track the round.

So `activity/spawn` **runs it**, through the substrate executor — rather than refusing and making the caller know which of two doors to use. One door; the recipe decides what walking through it means.

- Knobs are passed rich and by name (`team` → `teammates`, `driver` → `drive`).
- An **unset** knob stays absent, so dispatch applies its own default. Two defaulting layers that disagree is how a `driver` setting silently stops meaning anything.
- `suite` is **required**; its absence is a loud error naming it.

`benchmark/dispatch` now returns the `binding_post_id` of the activity it rooted, passed through from its own `spawn_activity_room`, so both doors report the same spawn in the same shape. A run ROOTS AN ACTIVITY — that field is the receipt saying so, and its absence was the seam where "benchmarks are a parallel runner" creeps back in.

## Also

Drops `benchmark/dispatch --room`. A bare room NAME was ambiguous with any chat room, so a dispatch could seed cards into a room with no citizens and no recipe binding (#3945). A dispatch roots its own benchmark activity — always.

## Tests

The param translation is extracted pure, so what actually reaches dispatch is assertable without an executor:

- every knob arrives under the name dispatch reads
- an unset knob stays absent so dispatch owns its defaults
- a benchmark activity with no suite refuses and names the missing param (whitespace is not a suite name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4NU4VNiELPQfBpCacDZGc