### PR TITLE
fix(persona): a claim is a hold boundary — the write-or-release count restarts there

### DIFF
--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -15,10 +15,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-use crate::cognition::competitor::{
-    classify, optional_arms, run_competition, ArmClass, ArmTaskResult, DEFAULT_ENDPOINT,
-};
-use crate::cognition::eval::{CognitionEval, CognitionEvalParams};
 use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx};
 
 /// How a benchmark's solutions are scored.
@@ -1676,7 +1672,6 @@ impl ActionCommand for BenchmarkDispatch {
         ctx: &Ctx,
         p: BenchmarkDispatchParams,
     ) -> Result<BenchmarkDispatchResult, CommandError> {
-        use crate::cognition::eval::EvalTask;
         use crate::modules::work::curator_airc;
         use airc_lib::{CreateWorkCard, Priority, RepoId};
 

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2999,6 +2999,16 @@ mod tests {
             1,
             "an edit resets the count"
         );
+        // regression for the 2026-09-11 pull→release loop: a claim (the pull) after a
+        // governor release starts a fresh count, so the new hold is not released at once.
+        let mut reclaimed = looping.clone();
+        reclaimed.push(row(4, "💭 next ⚙ work/release abcd ✓"));
+        reclaimed.push(row(5, "💭 pulled ⚙ work/claim ef01 ✓ ⚙ code/read c.py ✓"));
+        assert_eq!(
+            acts_since_last_write(&reclaimed, me),
+            1,
+            "a claim is a hold boundary: only the act after it counts"
+        );
         let text = held_work_burst_gated(
             &[],
             &[],

--- a/core/continuum-core/src/persona/work_burst.rs
+++ b/core/continuum-core/src/persona/work_burst.rs
@@ -41,7 +41,11 @@ pub(crate) fn acts_since_last_write(rows: &[crate::persona::durable_history::Roo
             // the acceptance verb reads `persona.act.observed wrote=true`. If the
             // receipt shape moves, this counter reads zero and the gate silently
             // stops — read the act probe stream here when it is queryable per card.
-            if is_write_verb(verb) {
+            // A claim or a release is a HOLD BOUNDARY and resets the count too
+            // (measured 2026-09-11 23:55Z: 7 pulls / 6 governor releases in 25 min —
+            // a citizen released at 12 write-less acts pulled a fresh card and was
+            // released again at once, because the count spanned her previous hold).
+            if is_write_verb(verb) || is_hold_boundary(verb) {
                 n = 0;
             } else {
                 n += 1;
@@ -162,6 +166,13 @@ pub(crate) fn progress_line(p: &CardProgress) -> String {
 /// The one list of write-capable hands, shared by the write-or-release count and
 /// the progress note (review on #3790: `code/write` finished the only card
 /// completion that night and was not on the list).
+/// A claim or a release starts or ends a hold; the write-or-release count is a
+/// per-hold number, so either verb restarts it. The pull rides `work/claim` (one
+/// claim path), so a governor release followed by a pull reads as a fresh hold.
+fn is_hold_boundary(verb: &str) -> bool {
+    verb.starts_with("work/claim") || verb.starts_with("work/release")
+}
+
 fn is_write_verb(verb: &str) -> bool {
     verb.starts_with("code/edit")
         || verb.starts_with("code/write")


### PR DESCRIPTION
Measured 2026-09-11 23:55Z on c5b566a58 (five coders, 25 warm minutes): **7 pulls, 7 acts, 6 `persona.work.released_by_governor`**. The governor counts a citizen's acts since her last WRITE across the room page — never since her claim — so a citizen released at twelve write-less acts pulled a fresh card and was released again at once. The board read as busy; nothing moved.

`work/claim` and `work/release` receipts now reset the count like a write does. The pull rides `work/claim` (one claim path), so a release followed by a pull begins a fresh hold with a fresh count. Regression test beside the gate's own (`six_acts_without_a_write_gate_the_work_turn_and_an_edit_resets_it`).

Also drops three imports S4a's `prepare_cards` extraction left unused in `commands/benchmark.rs` (rustc warnings on canary).

Acceptance after deploy: `persona.work.released_by_governor` per pull ≪ 1; pulls hold for ≥12 acts before any release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo