### PR TITLE
feat(benchmark): a Multilingual instance runs its own harness — every language through one round (S5)

### DIFF
--- a/core/continuum-core/src/cognition/swe_bench.rs
+++ b/core/continuum-core/src/cognition/swe_bench.rs
@@ -77,6 +77,14 @@ pub struct SweInstance {
         deserialize_with = "test_list_string"
     )]
     pub pass_to_pass: String,
+    /// SWE-bench Multilingual ships its harness AS DATA per instance: an eval script
+    /// (test files at base, test patch applied, ONE marked test command, restore)
+    /// and the name of the log parser that reads that command's output. Absent on
+    /// the Python family, which runs through our own venv + pytest runner.
+    #[serde(default)]
+    pub eval_script: Option<String>,
+    #[serde(default)]
+    pub log_parser: Option<String>,
 }
 
 /// The SWE-instance family speaks THREE dialects for the same two fields
@@ -1912,6 +1920,12 @@ async fn assert_harness_floor(uv: &str, py: &str) -> Result<(), String> {
 }
 
 pub async fn ensure_env(instance: &SweInstance, repo_dir: &Path) -> Result<PathBuf, String> {
+    if let Some(name) = instance.log_parser.as_deref() {
+        let Some(parser) = LogParser::from_name(name) else {
+            return Err(unsupported_harness(instance, name));
+        };
+        return toolchain_on_path(parser.toolchain()).await;
+    }
     // PER-INSTANCE SERIALIZATION — this function used to rely on "solve/grade
     // run serially per instance"; the dispatch-time env PRE-WARM broke that
     // assumption, and two concurrent builders writing one venv is a corrupt
@@ -2603,6 +2617,223 @@ pub fn runner_for_repo(repo: &str) -> TestRunner {
     match repo {
         "django/django" => TestRunner::DjangoRuntests,
         _ => TestRunner::Pytest,
+    }
+}
+
+/// A named log parser from SWE-bench Multilingual's `log_parser` column. Each
+/// variant reads ONE test framework's output into (test id → passed). The 19
+/// names in the dataset map to languages below; the two that run here are the
+/// Rust and Go slices (85 of 300 instances) — the rest refuse BY NAME until their
+/// parser lands, never by a silent zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogParser {
+    Cargo,
+    GoTest,
+}
+
+impl LogParser {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "parse_log_cargo" => Some(Self::Cargo),
+            "parse_log_gotest" => Some(Self::GoTest),
+            _ => None,
+        }
+    }
+
+    /// The toolchain binary the marked command needs on PATH.
+    pub fn toolchain(self) -> &'static str {
+        match self {
+            Self::Cargo => "cargo",
+            Self::GoTest => "go",
+        }
+    }
+
+    pub fn parse(self, log: &str) -> HashMap<String, bool> {
+        match self {
+            Self::Cargo => parse_log_cargo(log),
+            Self::GoTest => parse_log_gotest(log),
+        }
+    }
+}
+
+/// The language a parser name implies — the `language` filter on `benchmark/import`
+/// reads this, so a round asks for `rust` without knowing parser names. Names this
+/// grader does not run yet still map: the filter is catalogue knowledge, and the
+/// grader refuses those instances by name.
+pub fn language_of_parser(name: &str) -> &'static str {
+    match name {
+        "parse_log_cargo" => "rust",
+        "parse_log_gotest" => "go",
+        "parse_log_phpunit" => "php",
+        "parse_log_rspec_transformed_json" | "parse_log_ruby_unit" | "parse_log_jekyll" => "ruby",
+        "parse_log_karma" | "parse_log_jest" | "parse_log_tap" | "parse_log_vitest"
+        | "parse_log_immutable_js" => "javascript",
+        "parse_log_ant" | "parse_log_maven" | "parse_log_gradle_custom" => "java",
+        "parse_log_googletest" | "parse_log_doctest" | "parse_log_redis" | "parse_log_jq"
+        | "parse_log_micropython_test" => "c",
+        _ => "unknown",
+    }
+}
+
+impl SweInstance {
+    /// `python` for the SWE-bench family; the parser's language for Multilingual.
+    pub fn language(&self) -> &'static str {
+        self.log_parser.as_deref().map_or("python", language_of_parser)
+    }
+}
+
+/// The ONE test command inside an eval script: the line between the
+/// `>>>>> Start Test Output` and `>>>>> End Test Output` markers, minus the
+/// `( … ) | cat` wrapper the docker harness adds. Everything else the script does
+/// (checkout at base, test-patch apply, restore) `grade()` already does itself.
+pub fn test_command_from_eval_script(script: &str) -> Option<String> {
+    let start = script.find(">>>>> Start Test Output")?;
+    let end = script[start..].find(">>>>> End Test Output")? + start;
+    let line = script[start..end]
+        .lines()
+        .skip(1)
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with(':'))?;
+    let line = line.strip_suffix("| cat").map(str::trim).unwrap_or(line);
+    let line = line
+        .strip_prefix('(')
+        .and_then(|l| l.strip_suffix(')'))
+        .unwrap_or(line);
+    Some(line.trim().to_string())
+}
+
+/// How an instance's tests run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Harness {
+    /// Our venv + the repo era's runner (the Python SWE-bench family).
+    Native { venv_py: PathBuf, runner: TestRunner },
+    /// The instance's own marked command and named parser (SWE-bench Multilingual).
+    Script { command: String, parser: LogParser },
+}
+
+impl Harness {
+    /// Script when the instance carries a harness, Native otherwise. A script
+    /// harness this grader cannot read refuses by parser name and language.
+    pub fn for_instance(
+        instance: &SweInstance,
+        venv_py: PathBuf,
+        runner: TestRunner,
+    ) -> Result<Self, String> {
+        let Some(script) = instance.eval_script.as_deref() else {
+            return Ok(Self::Native { venv_py, runner });
+        };
+        let name = instance.log_parser.as_deref().unwrap_or("");
+        let parser = LogParser::from_name(name).ok_or_else(|| unsupported_harness(instance, name))?;
+        let command = test_command_from_eval_script(script).ok_or_else(|| {
+            format!(
+                "MALFORMED HARNESS — {}'s eval script has no marked test command",
+                instance.instance_id
+            )
+        })?;
+        Ok(Self::Script { command, parser })
+    }
+}
+
+fn unsupported_harness(instance: &SweInstance, name: &str) -> String {
+    format!(
+        "UNSUPPORTED HARNESS — {} ships log parser '{name}' ({}); this grader reads \
+         parse_log_cargo (rust) and parse_log_gotest (go) so far",
+        instance.instance_id,
+        language_of_parser(name)
+    )
+}
+
+/// `run_tests` for either harness. A script harness runs the marked command in the
+/// checkout (bounded by `SUBPROCESS_CEILING`) and reads stdout+stderr with the
+/// named parser; an id the log never names reads as failed.
+pub async fn run_harness(
+    repo_dir: &Path,
+    harness: &Harness,
+    ids: &[String],
+    test_files: &[String],
+) -> (HashMap<String, bool>, String) {
+    match harness {
+        Harness::Native { venv_py, runner } => {
+            run_tests(repo_dir, venv_py, ids, test_files, *runner).await
+        }
+        Harness::Script { command, parser } => {
+            if ids.is_empty() {
+                return (HashMap::new(), String::new());
+            }
+            let Ok(out) = run("bash", &["-c", command.as_str()], Some(repo_dir)).await else {
+                return (
+                    ids.iter().map(|i| (i.clone(), false)).collect(),
+                    String::new(),
+                );
+            };
+            let report = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            let seen = parser.parse(&report);
+            (
+                ids.iter()
+                    .map(|i| (i.clone(), seen.get(i).copied().unwrap_or(false)))
+                    .collect(),
+                report,
+            )
+        }
+    }
+}
+
+/// `test <name> ... ok|FAILED|ignored` — cargo's libtest lines. A `- should panic`
+/// suffix is the name's display, not its id; `ignored` is neither pass nor fail.
+pub fn parse_log_cargo(log: &str) -> HashMap<String, bool> {
+    let mut out = HashMap::new();
+    for line in log.lines() {
+        let Some(rest) = line.trim_start().strip_prefix("test ") else {
+            continue;
+        };
+        let Some((name, status)) = rest.rsplit_once(" ... ") else {
+            continue;
+        };
+        let name = name.split(" - ").next().unwrap_or(name).trim();
+        let status = status.trim();
+        let passed = status.starts_with("ok");
+        if passed || status.starts_with("FAILED") {
+            out.insert(name.to_string(), passed);
+        }
+    }
+    out
+}
+
+/// `--- PASS: TestName (0.01s)` / `--- FAIL: TestName` — go test's verbose lines,
+/// subtests included (`TestA/sub`).
+pub fn parse_log_gotest(log: &str) -> HashMap<String, bool> {
+    let mut out = HashMap::new();
+    for line in log.lines() {
+        let l = line.trim_start();
+        let (passed, rest) = if let Some(r) = l.strip_prefix("--- PASS: ") {
+            (true, r)
+        } else if let Some(r) = l.strip_prefix("--- FAIL: ") {
+            (false, r)
+        } else {
+            continue;
+        };
+        if let Some(name) = rest.split_whitespace().next() {
+            out.insert(name.to_string(), passed);
+        }
+    }
+    out
+}
+
+/// A script-harness instance has no venv: its "env" is the language toolchain the
+/// marked command needs. Absent = COULD_NOT_LOOK by name, never a python venv.
+async fn toolchain_on_path(tool: &str) -> Result<PathBuf, String> {
+    match run("which", &[tool], None).await {
+        Ok(out) if out.status.success() => {
+            Ok(PathBuf::from(String::from_utf8_lossy(&out.stdout).trim()))
+        }
+        _ => Err(format!(
+            "TOOLCHAIN ABSENT — `{tool}` is not on PATH on this node; install it or route \
+             this card to a node that has it"
+        )),
     }
 }
 
@@ -3464,6 +3695,13 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
             return verdict;
         }
     };
+    let harness = match Harness::for_instance(instance, venv_py, runner) {
+        Ok(h) => h,
+        Err(e) => {
+            verdict.error = Some(e);
+            return verdict;
+        }
+    };
 
     // THE GATE, on a pristine tree: FAIL_TO_PASS must FAIL. That failure IS the bug. If it
     // passes here the checkout does not contain the bug, and nothing measured against it can
@@ -3472,7 +3710,7 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
         verdict.error = Some(e);
         return verdict;
     }
-    let (pre, _) = run_tests(repo_dir, &venv_py, &f2p, &test_files, runner).await;
+    let (pre, _) = run_harness(repo_dir, &harness, &f2p, &test_files).await;
     // Sorted so the receipt names tests in one order run after run.
     let pre_sorted: Vec<(String, bool)> = {
         let mut v: Vec<(String, bool)> = pre.iter().map(|(id, ok)| (id.clone(), *ok)).collect();
@@ -3541,8 +3779,8 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
         return verdict;
     }
 
-    let (f2p_res, f2p_report) = run_tests(repo_dir, &venv_py, &f2p, &test_files, runner).await;
-    let (p2p_res, p2p_report) = run_tests(repo_dir, &venv_py, &p2p, &test_files, runner).await;
+    let (f2p_res, f2p_report) = run_harness(repo_dir, &harness, &f2p, &test_files).await;
+    let (p2p_res, p2p_report) = run_harness(repo_dir, &harness, &p2p, &test_files).await;
     verdict.f2p_passed = f2p_res.values().filter(|ok| **ok).count();
     verdict.p2p_passed = p2p_res.values().filter(|ok| **ok).count();
 
@@ -3563,7 +3801,7 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
             return verdict;
         }
         let (pristine_p2p, pristine_report) =
-            run_tests(repo_dir, &venv_py, &p2p, &test_files, runner).await;
+            run_harness(repo_dir, &harness, &p2p, &test_files).await;
         if pristine_p2p.values().filter(|ok| **ok).count() == 0 {
             verdict.gate_ok = false;
             // CARRY THE REPORT. This verdict is the ONLY artifact of the pristine run, and
@@ -3624,6 +3862,68 @@ pub async fn grade(instance: &SweInstance, model_patch: Option<&str>) -> SweVerd
 
 #[cfg(test)]
 mod tests {
+    // what this catches: the Multilingual harness misread — the marked command not
+    // lifted (wrapper kept, the marker comment taken as the command), a cargo/go log
+    // read into the wrong verdict, or a Python-family instance routed through a
+    // script it does not have. Fixtures are the real ruff-15309 / tokio-4384 tails.
+    #[test]
+    fn a_multilingual_instance_runs_its_own_harness_and_the_python_family_stays_native() {
+        use super::{
+            language_of_parser, parse_log_cargo, parse_log_gotest,
+            test_command_from_eval_script, Harness, LogParser, TestRunner,
+        };
+        let ruff = "git apply -v - <<'EOF_1'\n+x\nEOF_1\n: '>>>>> Start Test Output'\n(cargo test --package ruff_linter 'f52') | cat\n: '>>>>> End Test Output'\ngit checkout 75a2 a.py\n";
+        assert_eq!(
+            test_command_from_eval_script(ruff).as_deref(),
+            Some("cargo test --package ruff_linter 'f52'")
+        );
+        let tokio = ": '>>>>> Start Test Output'\n(RUSTFLAGS=-Awarnings cargo test --package tokio --test net_types_unwind --features full --no-fail-fast) | cat\n: '>>>>> End Test Output'\n";
+        assert_eq!(
+            test_command_from_eval_script(tokio).as_deref(),
+            Some("RUSTFLAGS=-Awarnings cargo test --package tokio --test net_types_unwind --features full --no-fail-fast")
+        );
+        assert_eq!(test_command_from_eval_script("no markers here"), None);
+
+        let cargo_log = "running 3 tests\ntest rules::pyflakes::tests::rule_f523 ... ok\ntest io::write_all_buf_vectored ... FAILED\ntest slow::one - should panic ... ok\ntest skipped::x ... ignored\n\nfailures:\n";
+        let seen = parse_log_cargo(cargo_log);
+        assert_eq!(seen.get("rules::pyflakes::tests::rule_f523"), Some(&true));
+        assert_eq!(seen.get("io::write_all_buf_vectored"), Some(&false));
+        assert_eq!(seen.get("slow::one"), Some(&true), "the display suffix is not the id");
+        assert_eq!(seen.get("skipped::x"), None, "ignored is neither verdict");
+
+        let go_log = "=== RUN   TestServer\n--- PASS: TestServer (0.01s)\n=== RUN   TestRoute/sub\n    --- FAIL: TestRoute/sub (0.00s)\nFAIL\n";
+        let seen = parse_log_gotest(go_log);
+        assert_eq!(seen.get("TestServer"), Some(&true));
+        assert_eq!(seen.get("TestRoute/sub"), Some(&false));
+
+        let mut inst: super::SweInstance = serde_json::from_value(serde_json::json!({
+            "instance_id": "tokio-rs__tokio-4384", "repo": "tokio-rs/tokio", "base_commit": "abc",
+            "patch": "", "test_patch": "", "problem_statement": "",
+            "FAIL_TO_PASS": "[\"net_types_are_unwind_safe\"]", "PASS_TO_PASS": "[]",
+            "eval_script": tokio, "log_parser": "parse_log_cargo"
+        }))
+        .expect("a multilingual row decodes");
+        assert_eq!(inst.language(), "rust");
+        match Harness::for_instance(&inst, "unused".into(), TestRunner::Pytest) {
+            Ok(Harness::Script { parser: LogParser::Cargo, command }) => {
+                assert!(command.starts_with("RUSTFLAGS="), "{command}")
+            }
+            other => panic!("expected the script harness, got {other:?}"),
+        }
+        inst.log_parser = Some("parse_log_phpunit".into());
+        let err = Harness::for_instance(&inst, "unused".into(), TestRunner::Pytest).unwrap_err();
+        assert!(err.contains("UNSUPPORTED HARNESS") && err.contains("php"), "{err}");
+        assert_eq!(language_of_parser("parse_log_rspec_transformed_json"), "ruby");
+
+        inst.eval_script = None;
+        inst.log_parser = None;
+        assert_eq!(inst.language(), "python");
+        assert_eq!(
+            Harness::for_instance(&inst, "venv/bin/python".into(), TestRunner::Pytest),
+            Ok(Harness::Native { venv_py: "venv/bin/python".into(), runner: TestRunner::Pytest })
+        );
+    }
+
     // what this catches: a verdict that cannot say which harness scored it.
     // Measured 2026-08-28 — 19 of 32 verdicts on this box had been written
     // across ten days by three different harness builds, and regrading ONE from
@@ -3717,6 +4017,8 @@ mod tests {
             pass_to_pass: serde_json::json!(["[", "[100%]", "testing/test_x.py::test_real"])
                 .to_string(),
             fail_to_pass: serde_json::json!(["testing/test_x.py::test_target"]).to_string(),
+            eval_script: None,
+            log_parser: None,
         };
         assert_eq!(inst.p2p(), vec!["testing/test_x.py::test_real".to_string()]);
         assert_eq!(inst.f2p(), vec!["testing/test_x.py::test_target".to_string()]);
@@ -4608,6 +4910,8 @@ diff --git a/sympy/solvers/tests/test_other.py b/sympy/solvers/tests/test_other.
             created_at: "2021-05-01T00:00:00Z".into(),
             fail_to_pass: "[\"test_a\", \"test_b\"]".into(),
             pass_to_pass: String::new(),
+            eval_script: None,
+            log_parser: None,
         };
         assert_eq!(inst.f2p(), vec!["test_a".to_string(), "test_b".to_string()]);
         assert!(inst.p2p().is_empty(), "a blank list must not panic the run");

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -68,7 +68,10 @@ impl BenchmarkSpec {
     pub fn swe_dataset(&self) -> Option<&'static str> {
         if !matches!(
             self.name,
-            "swe-bench-lite" | "swe-bench-verified" | "swe-bench-verified-mini"
+            "swe-bench-lite"
+                | "swe-bench-verified"
+                | "swe-bench-verified-mini"
+                | "swe-bench-multilingual"
         ) {
             return None;
         }
@@ -1301,6 +1304,11 @@ pub(crate) struct CardSelection {
     pub(crate) instances: Option<Vec<String>>,
     pub(crate) sample: Option<u32>,
     pub(crate) seed: Option<u64>,
+    /// Keep only instances whose harness speaks this language (`rust`, `go`, `php`,
+    /// `ruby`, `javascript`, `java`, `c`; `python` for the SWE-bench family) — the
+    /// Multilingual dataset mixes nine, and a round is one language's board.
+    /// `None`/empty = every language.
+    pub(crate) language: Option<String>,
 }
 
 /// THE ONE WRITER of benchmark cards: task + oracle only, projected into the
@@ -1322,6 +1330,17 @@ pub(crate) async fn prepare_cards(
             .map_err(|e| {
                 CommandError::Internal(format!("swe dataset '{dataset}' load failed: {e}"))
             })?;
+        if let Some(lang) = selection.language.as_deref().filter(|l| !l.is_empty()) {
+            let before = instances.len();
+            instances.retain(|i| i.language() == lang);
+            if instances.is_empty() {
+                return Err(CommandError::Invalid(format!(
+                    "no instance in '{dataset}' is `{lang}` (of {before}) — a language is \
+                     what an instance's harness speaks: rust, go, php, ruby, javascript, \
+                     java, c; python for the SWE-bench family"
+                )));
+            }
+        }
         // Deterministic sample: (dataset, seed, n) → the same list on every
         // machine. Fisher-Yates over the dataset order with the shared LCG —
         // the command IS the replication recipe (no operator-side scripts).
@@ -1799,6 +1818,7 @@ impl ActionCommand for BenchmarkDispatch {
                 instances: p.instances.clone(),
                 sample: p.sample,
                 seed: p.seed,
+                language: None,
             },
         )
         .await?;
@@ -4187,6 +4207,8 @@ mod swe_setup_tests {
             created_at: "2023-01-01".into(),
             fail_to_pass: "[\"tests/test_widget.py::test_single_frob\"]".into(),
             pass_to_pass: "[]".into(),
+            eval_script: None,
+            log_parser: None,
         };
         // Mirror the run() format string's data flow: only these fields enter.
         let body = format!(

--- a/core/continuum-core/src/commands/benchmark_import.rs
+++ b/core/continuum-core/src/commands/benchmark_import.rs
@@ -59,6 +59,12 @@ pub struct BenchmarkImportParams {
     #[serde(default)]
     #[ts(optional)]
     pub limit: Option<u32>,
+    /// Keep only instances whose harness speaks this language (`rust`, `go`, `php`,
+    /// `ruby`, `javascript`, `java`, `c`; `python` for the SWE-bench family). The
+    /// Multilingual suite mixes nine; a round is one language's board. Empty = all.
+    #[serde(default)]
+    #[ts(optional)]
+    pub language: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -139,6 +145,7 @@ impl ActionCommand for BenchmarkImport {
                 instances: p.instances.filter(|w| !w.is_empty()),
                 sample: p.sample.filter(|n| *n > 0),
                 seed: p.seed,
+                language: p.language.clone(),
             },
         )
         .await?;
@@ -317,6 +324,8 @@ mod tests {
             created_at: "2023-01-01".into(),
             fail_to_pass: "[\"tests/test_widget.py::test_single_frob\"]".into(),
             pass_to_pass: "[]".into(),
+            eval_script: None,
+            log_parser: None,
         };
         let pc = PreparedCard {
             title: dispatch_card_title("swe-bench-verified", &inst.instance_id, &inst.problem_statement),

--- a/core/continuum-core/src/experience/recipes/benchmark-round.json
+++ b/core/continuum-core/src/experience/recipes/benchmark-round.json
@@ -165,6 +165,10 @@
     "limit": {
       "default": 0,
       "doc": "cap on cards offered after the already-resolved gate; 0 = all. The gym suites do not sample, so this is how a round takes the first N of hard-rs"
+    },
+    "language": {
+      "default": "",
+      "doc": "keep only instances whose harness speaks this language (rust, go, php, ruby, javascript, java, c; python for the SWE-bench family) \u2014 the Multilingual suite mixes nine; empty = all"
     }
   },
   "pipeline": [
@@ -176,7 +180,8 @@
         "sample": "$args.sample",
         "seed": "$args.seed",
         "limit": "$args.limit",
-        "skipAlreadyResolved": true
+        "skipAlreadyResolved": true,
+        "language": "$args.language"
       },
       "outputTo": "imported"
     },

--- a/docs/planning/RECIPE-CONVERGENCE-PLAN.md
+++ b/docs/planning/RECIPE-CONVERGENCE-PLAN.md
@@ -237,6 +237,23 @@ and `limit` (the gym suites do not sample; dispatch's cap, kept). Then `suite: h
 same recipe → room 70fab522, 8 gym cards — every suite, one recipe. The recipe is renamed
 **`benchmark/round`** (`suite` is a param; `benchmark/swe` was never the right name).
 
+**S5 — every language through the same round (2026-09-12, Joel: "a series of benchmarks of
+various languages must work through this collaborative recipe").** Sweep receipt: 15 of the 34
+catalogued suites import through the recipe's first step (every Rust gym, mirrorcode, ds-1000,
+terminal-bench, the three SWE variants); super-masked/algotune want a local eval set; 16 catalogue
+rows have no adapter — including both multi-language suites. SWE-bench Multilingual ships its
+harness AS DATA per instance (`eval_script`, `log_parser`, `image`, `eval_type`; 300 instances,
+41 repos, 19 parser names, 43 Rust rows across ruff/tokio/axum/bat/nushell/coreutils/ripgrep), so
+the adapter is one generic path, not per-repo knowledge: `Harness::Script { command, parser }` is
+chosen from the instance's own columns (the marked test command between the script's
+`>>>>> Start/End Test Output` markers; everything else the script does, `grade()` already does),
+`ensure_env` answers with the language toolchain or an honest `TOOLCHAIN ABSENT`, and
+`parse_log_cargo` + `parse_log_gotest` read the Rust and Go slices (85/300); the other 17 parsers
+refuse BY NAME. `benchmark/import` and the `benchmark/round` recipe take `language` (derived from
+the parser; `python` for the SWE-bench family). Owed: the remaining parsers as their toolchains
+arrive on nodes; aider-polyglot (Exercism, 6 languages) as a gym-shaped adapter; the docker
+`image` path for nodes that lack a toolchain.
+
 **Still owed for S4 (S4b, remaining):** the side-by-side run itself — `activity/spawn --recipe
 benchmark/swe` and `benchmark/dispatch` on the same `(suite, seed, sample)` after a deploy,
 asserting the same board, card rooms and verdicts (a live acceptance, not a unit test); kickoff

--- a/docs/planning/RECIPE-CONVERGENCE-PLAN.md
+++ b/docs/planning/RECIPE-CONVERGENCE-PLAN.md
@@ -251,8 +251,13 @@ chosen from the instance's own columns (the marked test command between the scri
 `parse_log_cargo` + `parse_log_gotest` read the Rust and Go slices (85/300); the other 17 parsers
 refuse BY NAME. `benchmark/import` and the `benchmark/round` recipe take `language` (derived from
 the parser; `python` for the SWE-bench family). Owed: the remaining parsers as their toolchains
-arrive on nodes; aider-polyglot (Exercism, 6 languages) as a gym-shaped adapter; the docker
-`image` path for nodes that lack a toolchain.
+arrive on nodes; aider-polyglot as a gym-shaped adapter — read 2026-09-12: `<lang>/exercises/practice/<name>/`
+for cpp/go/java/javascript/python/rust (rust 30, go 39, python 34 …), each with
+`.docs/instructions.md` (the task), `.meta/config.json` (solution/test file lists),
+`.meta/example.<ext>` (the oracle) and the language's own tests (`cargo test`, `go test`,
+`pytest`, …) — i.e. an eval-set importer that materializes each exercise as a task + oracle,
+graded by the per-language `LogParser` this slice introduced; the docker `image` path for nodes
+that lack a toolchain.
 
 **Still owed for S4 (S4b, remaining):** the side-by-side run itself — `activity/spawn --recipe
 benchmark/swe` and `benchmark/dispatch` on the same `(suite, seed, sample)` after a deploy,

--- a/protocol/typescript/benchmark/BenchmarkImportParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkImportParams.ts
@@ -27,4 +27,10 @@ skipAlreadyResolved: boolean,
  * drew. The gym suites do not sample (a suite IS its task list), so this is how a
  * round takes the first N of `hard-rs` — dispatch's `limit`, kept.
  */
-limit?: number, };
+limit?: number, 
+/**
+ * Keep only instances whose harness speaks this language (`rust`, `go`, `php`,
+ * `ruby`, `javascript`, `java`, `c`; `python` for the SWE-bench family). The
+ * Multilingual suite mixes nine; a round is one language's board. Empty = all.
+ */
+language?: string, };


### PR DESCRIPTION
Stacked on #3965. Joel: *"a series of benchmarks of various languages must work through this collaborative recipe."*

Sweep on the M5: **15 of 34** catalogued suites import through the recipe's first step (every Rust gym, mirrorcode, ds-1000, terminal-bench, the three SWE variants); super-masked/algotune want a local eval set; 16 rows have no adapter — including both multi-language suites.

SWE-bench Multilingual ships its harness **as data** per instance (`eval_script`, `log_parser`, `image`, `eval_type`; 300 instances, 41 repos, 19 parser names, 43 Rust rows). So the adapter is one generic path:

- `Harness::{Native, Script}` chosen from the instance's own columns; Script = the one marked test command in the script + the named parser (everything else the script does, `grade()` already does).
- `ensure_env` answers a script instance with its toolchain on PATH or **TOOLCHAIN ABSENT** by name.
- `parse_log_cargo` + `parse_log_gotest` read the Rust and Go slices (85/300); the other 17 parsers refuse **UNSUPPORTED HARNESS** with their language.
- `swe-bench-multilingual` is runnable; `benchmark/import` and the `benchmark/round` recipe take `language`.

Test: the real ruff-15309 / tokio-4384 script tails, cargo/go logs, a Multilingual row → script harness, a Python row → native. Acceptance after deploy: `activity/spawn --recipe benchmark/round --args '{"suite":"swe-bench-multilingual","language":"rust","limit":2}'` posts two Rust cards; a done card grades through the script harness with a cargo-parsed verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo