### PR TITLE
fix(persona): a reseat pass must not re-open every citizen's stream — the fd leak that darkened the M5

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3044,6 +3044,18 @@ pub fn start_server(
                         );
                     } else if !booted {
                         attempt += 1;
+                        if attempt > 1 {
+                            // Every attempt draws from the ONE provider built at boot; a
+                            // failed attempt leaves its cursor at the end. Nothing was hosted
+                            // (booted is false), so start the draw over.
+                            provider.rewind();
+                            crate::probe!(
+                                class = "persona.host.provider_rewound",
+                                attempt,
+                                population = provider.identities_available(),
+                                "hosting retry: the identity draw starts over — nothing was hosted last time"
+                            );
+                        }
                         let summary = supervisor
                             .spawn_all(&mut provider, Some(tool_executor.clone()))
                             .await;

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -398,6 +398,19 @@ async fn board_state_of(
 /// child not tracked here, join every local resident by name (idempotent on the daemon),
 /// then read the child's OWN standing — a paused or done round is left again at once, so
 /// a stale announcement never seats anyone into finished work.
+/// Announced children this process has already seen ARCHIVED. Standing is read
+/// through a member's subscription, so once every resident has left a finished
+/// round nobody can read that it is finished: on 749d91ce6 the pass joined all five
+/// to find out, read "archived", parted all five, and the next pass began again —
+/// 733 seats and 256 departures of the same room in sixteen minutes, each one a
+/// membership epoch bump and a stream re-open. A finished child stays finished for
+/// the life of the process; a reboot re-learns it once.
+fn finished_children() -> &'static std::sync::Mutex<std::collections::HashSet<uuid::Uuid>> {
+    static FINISHED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<uuid::Uuid>>> =
+        std::sync::OnceLock::new();
+    FINISHED.get_or_init(Default::default)
+}
+
 async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegistry) {
     use crate::experience::children::{project_children, CHILD_WALL_CATEGORY};
     let local: std::collections::HashSet<String> = crate::cognition::bench_round::live_rounds()
@@ -428,6 +441,13 @@ async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
     use crate::persona::airc_citizen::AircCitizen as _;
     for child in project_children(&posts) {
         if !child.is_citizen_benchmark() || local.contains(&child.name) {
+            continue;
+        }
+        if finished_children()
+            .lock()
+            .map(|set| set.contains(&child.room_id))
+            .unwrap_or(false) // unwrap_or: a poisoned set forgets, which costs one join+part, never a loop
+        {
             continue;
         }
         // Standing FIRST, membership SECOND, and a join or a part only on a real change.
@@ -482,6 +502,9 @@ async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
             }
         }
         if finished {
+            if let Ok(mut set) = finished_children().lock() {
+                set.insert(child.room_id);
+            }
             if left > 0 {
                 crate::probe!(
                     class = "bench.round.announced_finished",

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -425,21 +425,19 @@ async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
             return;
         }
     };
+    use crate::persona::airc_citizen::AircCitizen as _;
     for child in project_children(&posts) {
         if !child.is_citizen_benchmark() || local.contains(&child.name) {
             continue;
         }
-        let mut joined = 0u64;
-        let mut already = 0u64;
-        let mut failed = 0u64;
-        for rt in registry.iter() {
-            // join is idempotent on the daemon: an already-seated resident costs one call.
-            match rt.join_room(&child.name).await {
-                Ok(()) => joined += 1,
-                Err(_) => failed += 1,
-            }
-        }
-        // Standing lives on the child's own wall; read it now that we are inside.
+        // Standing FIRST, membership SECOND, and a join or a part only on a real change.
+        // Measured 2026-09-12 00:57–01:13Z on 48fbbfd44: this pass joined every resident
+        // into every announced child and parted the finished ones again, every 10 s. A
+        // join is idempotent on the daemon but NOT free for the citizen: each one bumps
+        // her membership epoch, every bump re-opens her command pump's daemon stream,
+        // and the old stream's per-channel sockets stayed open — 1,961 re-opens, 19,589
+        // sockets, the fd table full, every spawn EBADF: no serving lane, no web/fetch,
+        // no `--list-devices`. The board was "busy" and the node was dead.
         let standing = match reader
             .airc()
             .subscription_set()
@@ -461,28 +459,50 @@ async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
             .as_ref()
             .map(|s| s.archived)
             .unwrap_or(false); // unwrap_or: no standing yet = a fresh round, seat it
-        if finished {
-            for rt in registry.iter() {
-                if rt.airc().part_channel(Some(child.name.as_str())).await.is_ok() {
-                    already += 1;
+        let (mut joined, mut already, mut left, mut failed) = (0u64, 0u64, 0u64, 0u64);
+        for rt in registry.iter() {
+            let member = rt
+                .subscribed_rooms()
+                .await
+                .map(|rooms| rooms.contains(&child.room_id))
+                .unwrap_or(false); // unwrap_or: an unreadable room list reads as "not seated"; the join is idempotent on the daemon
+            if finished {
+                if member && rt.leave_room(Some(child.name.as_str())).await.is_ok() {
+                    left += 1;
                 }
+                continue;
             }
-            crate::probe!(
-                class = "bench.round.announced_finished",
-                room = %child.name,
-                left = already,
-                "an announced round is paused or done on its own wall — residents left again"
-            );
+            if member {
+                already += 1;
+                continue;
+            }
+            match rt.join_room(&child.name).await {
+                Ok(()) => joined += 1,
+                Err(_) => failed += 1,
+            }
+        }
+        if finished {
+            if left > 0 {
+                crate::probe!(
+                    class = "bench.round.announced_finished",
+                    room = %child.name,
+                    left,
+                    "an announced round is paused or done on its own wall — residents left again"
+                );
+            }
             continue;
         }
-        crate::probe!(
-            class = "bench.round.seated_remote",
-            room = %child.name,
-            suite = %child.suite.clone().unwrap_or_default(), // unwrap_or: is_citizen_benchmark guarantees a suite
-            joined,
-            failed,
-            "residents seated into a round another node spawned — the board is shared, now the room is too"
-        );
+        if joined > 0 || failed > 0 {
+            crate::probe!(
+                class = "bench.round.seated_remote",
+                room = %child.name,
+                suite = %child.suite.clone().unwrap_or_default(), // unwrap_or: is_citizen_benchmark guarantees a suite
+                joined,
+                already,
+                failed,
+                "residents seated into a round another node spawned — the board is shared, now the room is too"
+            );
+        }
     }
 }
 

--- a/core/continuum-core/src/persona/command_inbound_pump.rs
+++ b/core/continuum-core/src/persona/command_inbound_pump.rs
@@ -239,6 +239,18 @@ impl PersonaCommandInboundPump {
 /// Delay before the n-th consecutive re-open attempt: 1 s doubling to a
 /// 30 s cap. A daemon that is down stays down for a while; a stream that
 /// ended on a membership change is back in one hop.
+/// The channel set a subscribe would open on right now — the daemon's subscription
+/// set, as room ids. `None` when the daemon could not be asked (then a bump re-opens,
+/// the safe side).
+async fn subscribed_set(airc: &Airc) -> Option<std::collections::BTreeSet<Uuid>> {
+    let set = airc.subscription_set().await.ok()?;
+    Some(
+        set.all()
+            .map(|sub| sub.as_room().channel.as_uuid())
+            .collect(),
+    )
+}
+
 fn reopen_delay(attempt: u32) -> Duration {
     Duration::from_secs(1u64 << attempt.min(5)).min(Duration::from_secs(30))
 }
@@ -327,6 +339,11 @@ async fn run(
     // hours with nothing on any probe. The pump now re-opens on end AND on a
     // membership move, with a bounded backoff, and says so each time.
     let mut attempt: u32 = 0;
+    // The room set the live stream was opened on. A membership epoch bump whose set is
+    // unchanged (an idempotent join, a part of a room she never held) is NOT a reason
+    // to re-open: every re-open costs a daemon connection per channel, and the
+    // 2026-09-12 reseat storm turned 1,961 no-op bumps into 19,589 open sockets.
+    let mut opened_with = subscribed_set(&airc).await;
     loop {
         let reason = loop {
             tokio::select! {
@@ -378,6 +395,18 @@ async fn run(
                 },
             }
         };
+        if reason == Reopen::MembershipChanged {
+            let now = subscribed_set(&airc).await;
+            if now.is_some() && now == opened_with {
+                crate::probe!(
+                    class = "persona.command_pump.membership_unchanged",
+                    persona_id = %persona_id,
+                    rooms = opened_with.as_ref().map_or(0, |s| s.len()),
+                    "membership epoch moved but the room set did not — the stream stays open"
+                );
+                continue;
+            }
+        }
         crate::probe!(
             class = "persona.command_pump.ended",
             persona_id = %persona_id,
@@ -393,6 +422,7 @@ async fn run(
             match crate::persona::airc_citizen::subscribe_every_room(&airc).await {
                 Ok(next) => {
                     stream = next;
+                    opened_with = subscribed_set(&airc).await;
                     crate::probe!(
                         class = "persona.command_pump.reopened",
                         persona_id = %persona_id,

--- a/core/continuum-core/src/persona/resume_or_mint_provider.rs
+++ b/core/continuum-core/src/persona/resume_or_mint_provider.rs
@@ -122,6 +122,17 @@ impl ResumeOrMintProvider {
     pub fn identities_available(&self) -> usize {
         self.resumed.len().max(self.min_personas)
     }
+
+    /// Start the draw over. The provider is built ONCE at boot and every hosting
+    /// attempt draws from it; an attempt that walks the whole list and then fails
+    /// (2026-09-12 02:42Z: the daemon was mid-restart, five spawns failed after the
+    /// draw) left the cursor at the end, and the next 700 attempts read "identity
+    /// provider exhausted at slot 0" from a directory holding twelve citizens. A retry
+    /// that cannot succeed is not a retry. Nothing was hosted, so nothing is double-drawn.
+    pub fn rewind(&mut self) {
+        self.resumed_cursor = 0;
+        self.minted_count = 0;
+    }
 }
 
 #[async_trait]
@@ -262,6 +273,36 @@ async fn scan_personas_dir(
 
 #[cfg(test)]
 mod tests {
+    // what this catches: a hosting retry drawing from a cursor a failed attempt left
+    // at the end — the 2026-09-12 boot that read "exhausted at slot 0" 700 times with
+    // twelve citizens on disk. After a rewind the provider yields the same identities
+    // again, resumed first, then the mint floor.
+    #[tokio::test]
+    async fn a_rewound_provider_yields_its_identities_again() {
+        let mut p = ResumeOrMintProvider {
+            resumed: vec![mint_fresh_intent(), mint_fresh_intent()],
+            resumed_cursor: 0,
+            min_personas: 3,
+            minted_count: 0,
+        };
+        let mut first = Vec::new();
+        while let Some(i) = p.next_persona().await.expect("draw") {
+            first.push(i.agent_name.clone());
+        }
+        assert_eq!(first.len(), 3, "two resumed + one minted to the floor");
+        assert!(p.next_persona().await.expect("draw").is_none(), "exhausted after a full draw");
+        p.rewind();
+        let again: Vec<String> = {
+            let mut v = Vec::new();
+            while let Some(i) = p.next_persona().await.expect("draw") {
+                v.push(i.agent_name.clone());
+            }
+            v
+        };
+        assert_eq!(again.len(), 3);
+        assert_eq!(&again[..2], &first[..2], "resumed identities come back in order");
+    }
+
     use super::*;
     use tempfile::TempDir;
 

--- a/core/continuum-core/src/system_resources/fd_gauge.rs
+++ b/core/continuum-core/src/system_resources/fd_gauge.rs
@@ -1,0 +1,87 @@
+//! The process's own file-descriptor table, as a gauge with a named alert.
+//!
+//! 2026-09-12 00:57–01:13Z on 48fbbfd44: the core reached 19,866 open descriptors
+//! (19,589 of them unix sockets to the airc daemon) sixteen minutes after boot.
+//! Every spawn then failed with EBADF — the serving lane's `--list-devices`
+//! probe, `web/fetch`'s browser, the lane relaunch itself — and every reader
+//! saw a different symptom (a placement violation, a Chrome error, a silent
+//! roster). Nothing named the table. This does: a count on every memory tick,
+//! and a `process.open_fds.high` probe once it passes half the soft limit,
+//! before the node goes dark instead of after.
+
+/// Open descriptors right now, counted from `/dev/fd` (macOS and Linux both
+/// expose the calling process's table there). `None` when it cannot be listed.
+pub fn open_fds() -> Option<usize> {
+    let n = std::fs::read_dir("/dev/fd").ok()?.count();
+    // the directory handle used for the listing is itself one entry
+    Some(n.saturating_sub(1))
+}
+
+/// The soft `RLIMIT_NOFILE` — the ceiling at which the next pipe or socket
+/// fails. `None` when the limit is unlimited or cannot be read.
+pub fn fd_soft_limit() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        let mut lim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        // SAFETY: getrlimit writes into the struct we own and reads nothing else.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) };
+        if rc != 0 || lim.rlim_cur == libc::RLIM_INFINITY {
+            return None;
+        }
+        Some(lim.rlim_cur as u64)
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+/// Above this share of the soft limit the gauge raises `process.open_fds.high`.
+pub const HIGH_WATER_PCT: u64 = 50;
+
+/// One reading, as the tick emits it. Pure over its inputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FdReading {
+    pub open: usize,
+    pub soft_limit: Option<u64>,
+}
+
+impl FdReading {
+    pub fn take() -> Option<Self> {
+        Some(Self { open: open_fds()?, soft_limit: fd_soft_limit() })
+    }
+
+    /// Percent of the soft limit in use; `None` without a limit.
+    pub fn pct(&self) -> Option<u64> {
+        let lim = self.soft_limit?;
+        if lim == 0 {
+            return None;
+        }
+        Some(self.open as u64 * 100 / lim)
+    }
+
+    pub fn is_high(&self) -> bool {
+        self.pct().is_some_and(|p| p >= HIGH_WATER_PCT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the gauge reading nothing on the platforms it exists
+    // for (a `/dev/fd` that lists nothing, a limit read that always fails) and the
+    // high-water arithmetic drifting — the alert must fire at exactly the share
+    // the constant names.
+    #[test]
+    fn the_gauge_reads_this_process_and_names_the_high_water_mark() {
+        let r = FdReading::take().expect("this process can count its own descriptors");
+        assert!(r.open >= 3, "stdin/stdout/stderr at least: {r:?}");
+        let half = FdReading { open: 50, soft_limit: Some(100) };
+        assert_eq!(half.pct(), Some(50));
+        assert!(half.is_high());
+        let low = FdReading { open: 49, soft_limit: Some(100) };
+        assert!(!low.is_high());
+        assert_eq!(FdReading { open: 5, soft_limit: None }.pct(), None);
+    }
+}

--- a/core/continuum-core/src/system_resources/memory_pressure.rs
+++ b/core/continuum-core/src/system_resources/memory_pressure.rs
@@ -1151,6 +1151,24 @@ impl Daemon for MemoryPressureMonitor {
     }
 
     async fn tick(&self) {
+        if let Some(fds) = crate::system_resources::fd_gauge::FdReading::take() {
+            if fds.is_high() {
+                crate::probe!(
+                    class = "process.open_fds.high",
+                    open = fds.open,
+                    soft_limit = fds.soft_limit.unwrap_or(0), // unwrap_or: is_high needs a limit; 0 never reaches here
+                    pct = fds.pct().unwrap_or(0), // unwrap_or: same — the gauge has a limit when it is high
+                    "the core's descriptor table is past half its limit — the next pipe or socket fails with EBADF; find the leak before the node goes dark"
+                );
+            } else {
+                crate::probe!(
+                    class = "process.open_fds",
+                    open = fds.open,
+                    soft_limit = fds.soft_limit.unwrap_or(0), // unwrap_or: 0 = unlimited or unreadable
+                    "open descriptors this tick"
+                );
+            }
+        }
         self.poll().await;
     }
 }

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -19,6 +19,7 @@ pub mod bounded_command;
 pub mod concurrency;
 pub mod disk_eviction;
 pub mod disk_pressure;
+pub mod fd_gauge;
 pub mod disk_reporters;
 pub mod memory_pressure;
 pub mod monitor;


### PR DESCRIPTION
Measured 2026-09-12 00:57–01:13Z on 48fbbfd44, sixteen minutes after boot: the core
held 19,866 open descriptors, 19,589 of them unix sockets to the airc daemon (which
itself held 23). Every spawn then failed with EBADF and every reader saw a different
symptom — the serving lane's `--list-devices` probe "could not run", the backend
receipt fell back to CPU, the Metal lane came up on CPU and #3759's gate refused it
every 5 s (zero lanes), `web/fetch` could not start Chrome. The board read busy; the
node was dead.

The chain: `seat_announced_rounds` joined every resident into every announced child
round on every 10 s pass ("a join is idempotent on the daemon") and, for finished
children, parted them again — each join/part bumps her membership epoch; every bump
re-opens the command pump's daemon stream (1,961 `command_pump.reopened`, all
MembershipChanged, attempt 0); the old stream's per-channel sockets stayed open.
Recipe-spawned rounds the tracker does not own are exactly the "not local" children
that re-joined forever.

Three fixes, three layers:
- the reseat pass reads standing FIRST and joins or parts only on a real membership
  change (per resident, by the child's room id; its `already` counter now counts);
- the command pump ignores an epoch bump whose room set did not change
  (`persona.command_pump.membership_unchanged`) — idempotent joins anywhere in the
  substrate can no longer re-open streams;
- a process fd gauge (`system_resources/fd_gauge.rs`) on the memory tick:
  `process.open_fds` every tick, `process.open_fds.high` past half the soft limit —
  this class is named before the node goes dark, never after.

Still owed to airc-lib: the per-channel attach tasks must release their sockets when
the stream drops (the guard aborts them; the sockets stayed), and the SDK must handle
AttachCursorAdvanced instead of logging it 6,391 times a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo