### PR TITLE
fix(ext): ProcessCommand is crate-local machinery — canary's reachability ratchet back to baseline

### DIFF
--- a/core/continuum-core/src/sdk_codegen/ext.rs
+++ b/core/continuum-core/src/sdk_codegen/ext.rs
@@ -209,7 +209,7 @@ fn load_one(path: &Path, shipped: &[&str]) -> Result<ProcessCommand, ManifestErr
 /// A verb backed by a process. `name`/`description` are leaked ONCE at load — the
 /// registry keys on `&'static str`, and a manifest set is bounded and loaded once
 /// per process, so this is a boot-time allocation, not a leak per call.
-pub struct ProcessCommand {
+pub(crate) struct ProcessCommand {
     manifest: CommandManifest,
     name: &'static str,
     description: &'static str,


### PR DESCRIPTION
Canary is red at 48fbbfd44: `production_reachability` counts 108 unwired pub machinery types against a baseline of 107, and every open PR (#3968 #3969 #3970) inherits the failure.

The +1 is `ProcessCommand` from #3964: public, with its own `impl` and `new()`, constructed only by the loader in its file and reaching the kernel as `dyn DynCommand`; the only outside mention is a doc comment. `pub(crate)` says what it is. Once this merges the three PRs rebase and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo