### PR TITLE
fix(system): descriptors have an owner — the process-fds tier restarts the daemon this core spawned

### DIFF
--- a/core/continuum-core/src/airc/daemon_supervisor.rs
+++ b/core/continuum-core/src/airc/daemon_supervisor.rs
@@ -1,0 +1,139 @@
+//! The airc daemon this core spawned — owned, probed in-process, restartable.
+//!
+//! Before 2026-09-12 the boot asked `airc ipc-endpoint` (a CLI fork that prints a
+//! path and proves nothing about liveness), spawned `airc daemon`, dropped the child
+//! handle, and never looked again. When the descriptor table filled that night the
+//! only recovery was a human killing and restarting the daemon by hand. Now the core
+//! records the pid it spawned, answers "is it answering" by connecting to the socket
+//! it resolves itself, and can restart the daemon it owns — the action the
+//! [`FdPressurePool`](crate::system_resources::fd_pressure::FdPressurePool) takes.
+//! A daemon someone else started is never killed: [`Restart::NotOurs`] is a named
+//! outcome, not a silent no-op.
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+/// The pid of the daemon THIS process spawned; 0 = none (adopted or absent).
+static OWNED_PID: AtomicU32 = AtomicU32::new(0);
+
+/// The machine-account scope the daemon serves: `<home>/.airc`, the scope
+/// `airc daemon` run from `<home>` binds (the CLI's own default resolution).
+pub fn scope_home() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(|h| PathBuf::from(h).join(".airc"))
+}
+
+/// Is a daemon accepting connections on the scope's socket? In-process, no fork:
+/// the path comes from [`crate::airc::daemon_endpoint::default_socket_path_in`] and
+/// the answer from a connect. `false` when the scope is unresolvable.
+pub fn answering() -> bool {
+    let Some(scope) = scope_home() else { return false };
+    let path = crate::airc::daemon_endpoint::default_socket_path_in(&scope);
+    #[cfg(unix)]
+    {
+        std::os::unix::net::UnixStream::connect(&path).is_ok()
+    }
+    #[cfg(not(unix))]
+    {
+        path.exists()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Spawned {
+    /// A daemon was already answering; nothing spawned.
+    Answering,
+    /// Spawned and answering within the bound.
+    Started { pid: u32 },
+    /// The `airc` binary is not on PATH — a transportless box (CI, a fresh clone).
+    BinaryAbsent,
+    /// Neither USERPROFILE nor HOME is set: the machine-account scope is unresolvable.
+    NoHome,
+    /// Spawned (or failed to) and never answered within the bound.
+    Failed(String),
+}
+
+/// How long a freshly spawned daemon gets to answer. Cold stores take seconds
+/// (a 5 s sqlite pool acquire was measured on the busy M5 store).
+pub const ANSWER_BOUND: Duration = Duration::from_secs(15);
+
+/// Spawn the daemon from the scope's home (never the repo cwd — the ownership
+/// guard refuses a socket served under the wrong identity) and wait for it to
+/// answer. Idempotent: an answering daemon is left alone.
+pub fn spawn() -> Spawned {
+    if answering() {
+        return Spawned::Answering;
+    }
+    let Some(scope) = scope_home() else { return Spawned::NoHome };
+    let Some(home) = scope.parent().map(|p| p.to_path_buf()) else { return Spawned::NoHome };
+    let child = std::process::Command::new("airc")
+        .arg("daemon")
+        .current_dir(&home)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+    let child = match child {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Spawned::BinaryAbsent,
+        Err(e) => return Spawned::Failed(format!("airc daemon spawn: {e}")),
+    };
+    let pid = child.id();
+    OWNED_PID.store(pid, Ordering::SeqCst);
+    let deadline = std::time::Instant::now() + ANSWER_BOUND;
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(250));
+        if answering() {
+            return Spawned::Started { pid };
+        }
+    }
+    Spawned::Failed(format!(
+        "airc daemon (pid {pid}) spawned but never answered within {}s",
+        ANSWER_BOUND.as_secs()
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Restart {
+    /// The daemon we own was killed and a new one answers.
+    Restarted { old: u32, new: u32 },
+    /// No daemon of ours to restart (adopted at boot, or absent) — left alone.
+    NotOurs,
+    /// Killed ours; the replacement did not come up.
+    Failed(String),
+}
+
+/// Kill the daemon this process spawned and spawn another. Only ours: a daemon we
+/// adopted belongs to whoever started it.
+pub fn restart_if_owned() -> Restart {
+    let old = OWNED_PID.load(Ordering::SeqCst);
+    if old == 0 {
+        return Restart::NotOurs;
+    }
+    crate::inference::lane_process::kill9(old);
+    OWNED_PID.store(0, Ordering::SeqCst);
+    std::thread::sleep(Duration::from_millis(500));
+    match spawn() {
+        Spawned::Started { pid } => Restart::Restarted { old, new: pid },
+        Spawned::Answering => Restart::Restarted { old, new: 0 },
+        other => Restart::Failed(format!("{other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: a restart killing a daemon we did not spawn (the adopted
+    // case must be a named NotOurs), and the scope resolving to something other
+    // than the CLI's machine-account home.
+    #[test]
+    fn a_daemon_we_did_not_spawn_is_never_restarted() {
+        OWNED_PID.store(0, Ordering::SeqCst);
+        assert_eq!(restart_if_owned(), Restart::NotOurs);
+        if let Some(scope) = scope_home() {
+            assert!(scope.ends_with(".airc"), "{}", scope.display());
+        }
+    }
+}

--- a/core/continuum-core/src/airc/mod.rs
+++ b/core/continuum-core/src/airc/mod.rs
@@ -7,6 +7,7 @@
 pub mod bridge_protocol;
 pub mod client;
 pub mod daemon_endpoint;
+pub mod daemon_supervisor;
 pub mod daemon_transport;
 pub mod discovery;
 pub mod reresolving_client;

--- a/core/continuum-core/src/boot_plan.rs
+++ b/core/continuum-core/src/boot_plan.rs
@@ -99,68 +99,19 @@ fn step_adopt_lanes() -> Outcome {
 /// The airc transport daemon — the one service whose absence makes the whole
 /// system inert (no rooms → no residency → nothing to resume into).
 fn step_airc_daemon() -> Outcome {
-    let probe = std::process::Command::new("airc")
-        .arg("ipc-endpoint")
-        .output();
-    match probe {
-        Ok(out) if out.status.success() => Outcome::Ok("daemon answering".into()),
-        Ok(_) => {
-            // Present but not answering: start it detached, bounded wait.
-            //
-            // CWD = the OS home dir, NEVER the repo. `airc daemon` derives its
-            // scope from the working directory; spawned from a continuum
-            // checkout it derives the REPO scope, and airc's ownership guard
-            // (their #1347/#1352/#1353 family) then rightly refuses to serve
-            // the machine-account socket under a foreign identity:
-            //
-            //   airc: refusing to serve a socket this scope does not own.
-            //
-            // Measured on the 5090 node 2026-09-04: `continuum reboot` died
-            // exactly here — core built, then "no transport: no rooms, no
-            // resident citizens". This is the THIRD spawn-site instance of
-            // that bug class; airc made it a compile error internally with a
-            // newtype, but this call site lives outside airc where the type
-            // cannot reach, so the rule is enforced the only way available
-            // here: spawn from the home that owns the socket. Refusing to
-            // spawn at all when no home dir is resolvable is deliberate — a
-            // daemon under the wrong identity gives every caller the wrong
-            // peer_id, which is strictly worse than no daemon.
-            let Some(home) =
-                std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))
-            else {
-                return Outcome::Failed(
-                    "cannot spawn airc daemon: neither USERPROFILE nor HOME is set, \
-                     so the machine-account scope is unresolvable — a daemon spawned \
-                     from the repo CWD would serve the socket under the WRONG identity \
-                     and airc's ownership guard refuses it"
-                        .into(),
-                );
-            };
-            let spawned = std::process::Command::new("airc")
-                .arg("daemon")
-                .current_dir(&home)
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn();
-            match spawned {
-                Ok(_) => {
-                    for _ in 0..20 {
-                        std::thread::sleep(std::time::Duration::from_millis(250));
-                        if std::process::Command::new("airc")
-                            .arg("ipc-endpoint")
-                            .output()
-                            .map(|o| o.status.success())
-                            .unwrap_or(false) // safe: a probe error reads as not-ready; the loop retries
-                        {
-                            return Outcome::Ok("daemon started".into());
-                        }
-                    }
-                    Outcome::Failed("airc daemon spawned but never answered (5s)".into())
-                }
-                Err(e) => Outcome::Failed(format!("airc daemon spawn: {e}")),
-            }
-        }
-        Err(_) => Outcome::Skipped("airc binary absent — transportless box (CI/fresh)".into()),
+    use crate::airc::daemon_supervisor::{spawn, Spawned};
+    match spawn() {
+        Spawned::Answering => Outcome::Ok("daemon answering".into()),
+        Spawned::Started { pid } => Outcome::Ok(format!("daemon started (pid {pid}, owned)")),
+        Spawned::BinaryAbsent => Outcome::Skipped("airc binary absent — transportless box (CI/fresh)".into()),
+        Spawned::NoHome => Outcome::Failed(
+            "cannot spawn airc daemon: neither USERPROFILE nor HOME is set, so the \
+             machine-account scope is unresolvable — a daemon spawned from the repo CWD \
+             would serve the socket under the WRONG identity and airc's ownership guard \
+             refuses it"
+                .into(),
+        ),
+        Spawned::Failed(e) => Outcome::Failed(e),
     }
 }
 

--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -1414,9 +1414,14 @@ pub fn start_server(
     // construction sites. Observer-only in PR-1: no commands routed
     // here yet. PR-2 of #1299 adds `system/pressure-broker-state` IPC;
     // PR-3 wires the chat-substrate alert sink.
-    runtime.register(Arc::new(
-        crate::modules::pressure_broker_module::PressureBrokerModule::new(),
+    let pressure_broker = Arc::new(crate::modules::pressure_broker_module::PressureBrokerModule::new());
+    // The descriptor table has an owner: the `process-fds` tier restarts the daemon
+    // this core spawned when the broker turns to it (2026-09-12: the gauge fired,
+    // nothing followed, a human ran lsof).
+    pressure_broker.broker().register(Arc::new(
+        crate::system_resources::fd_pressure::FdPressurePool::with_daemon_relief(),
     ));
+    runtime.register(pressure_broker);
     // InferenceCoordinatorModule — stands up the multi-persona-one-model
     // lane coordinator. Registered before the broker block below so its
     // CoordinatorResourcePool can be attached to the broker in the same

--- a/core/continuum-core/src/system_resources/fd_pressure.rs
+++ b/core/continuum-core/src/system_resources/fd_pressure.rs
@@ -1,0 +1,165 @@
+//! The process descriptor table as a pressure tier with an OWNER that acts.
+//!
+//! 2026-09-12: `process.open_fds.high` fired and nothing followed. The gauge is
+//! [`fd_gauge`](super::fd_gauge); this is the actor. It sits on the broker as the
+//! `process-fds` tier beside `sys-memory` and `disk-root`, and when the broker
+//! turns to it, it restarts the airc daemon this core spawned — the one action
+//! measured that night to bring a poisoned client/daemon pair back to a flat
+//! count — then names the outcome. Once per cooldown: a relief that fires every
+//! tick is a new storm.
+//!
+//! The pool's "bytes" are descriptors: the broker's arithmetic is unit-agnostic
+//! (usage/capacity), and a descriptor freed is the quantity this tier owns.
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::paging::pool::{ResourcePool, ResourcePoolEntry};
+use crate::system_resources::fd_gauge::{fd_soft_limit, open_fds};
+
+/// The budget when the soft limit is unlimited or unreadable: the ceiling this
+/// class hits in practice (the 2026-09-12 core plateaued at ~20.4k twice).
+pub const DEFAULT_FD_BUDGET: u64 = 20_480;
+/// Minimum spacing between two actions.
+pub const RELIEF_COOLDOWN_MS: u64 = 10 * 60 * 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReliefOutcome {
+    pub action: &'static str,
+    pub freed: u64,
+}
+
+/// What the tier does when the broker turns to it. Behind a trait so the pool's
+/// gating is testable without a daemon.
+pub trait FdRelief: Send + Sync {
+    fn relieve(&self) -> ReliefOutcome;
+}
+
+/// Restart the airc daemon this core spawned; the freed count is measured, not
+/// assumed.
+pub struct DaemonRestartRelief;
+
+impl FdRelief for DaemonRestartRelief {
+    fn relieve(&self) -> ReliefOutcome {
+        let before = open_fds().unwrap_or(0); // unwrap_or: an unreadable table reads as 0 freed, never as a gain
+        match crate::airc::daemon_supervisor::restart_if_owned() {
+            crate::airc::daemon_supervisor::Restart::Restarted { old, new } => {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                let after = open_fds().unwrap_or(before); // unwrap_or: unreadable after = nothing freed
+                let freed = before.saturating_sub(after) as u64;
+                crate::probe!(
+                    class = "process.fds.owner_acted",
+                    action = "daemon_restart",
+                    old_pid = old,
+                    new_pid = new,
+                    before,
+                    after,
+                    freed,
+                    "descriptor pressure: the daemon this core spawned was restarted"
+                );
+                ReliefOutcome { action: "daemon_restart", freed }
+            }
+            crate::airc::daemon_supervisor::Restart::NotOurs => {
+                crate::probe!(
+                    class = "process.fds.owner_exhausted",
+                    reason = "daemon not ours",
+                    open = before,
+                    "descriptor pressure with no action left: the daemon was adopted, not spawned — an operator restart is owed"
+                );
+                ReliefOutcome { action: "none", freed: 0 }
+            }
+            crate::airc::daemon_supervisor::Restart::Failed(e) => {
+                crate::probe!(
+                    class = "process.fds.owner_exhausted",
+                    reason = %e,
+                    open = before,
+                    "descriptor pressure: the daemon restart did not come back"
+                );
+                ReliefOutcome { action: "daemon_restart_failed", freed: 0 }
+            }
+        }
+    }
+}
+
+pub struct FdPressurePool {
+    relief: Box<dyn FdRelief>,
+    capacity: u64,
+    cooldown_ms: u64,
+    last_acted_ms: AtomicU64,
+}
+
+impl FdPressurePool {
+    /// The production pool: the soft limit (or the default budget) and the daemon restart.
+    pub fn with_daemon_relief() -> Self {
+        Self::new(Box::new(DaemonRestartRelief), fd_soft_limit().unwrap_or(DEFAULT_FD_BUDGET), RELIEF_COOLDOWN_MS) // unwrap_or: unlimited/unreadable = the measured practical ceiling
+    }
+
+    pub fn new(relief: Box<dyn FdRelief>, capacity: u64, cooldown_ms: u64) -> Self {
+        Self { relief, capacity: capacity.max(1), cooldown_ms, last_acted_ms: AtomicU64::new(0) }
+    }
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0) // unwrap_or: a pre-epoch clock reads as 0 — the cooldown then always allows, the safe side
+    }
+}
+
+impl ResourcePool for FdPressurePool {
+    fn tier_name(&self) -> &str {
+        "process-fds"
+    }
+    fn capacity_bytes(&self) -> u64 {
+        self.capacity
+    }
+    fn usage_bytes(&self) -> u64 {
+        open_fds().map_or(0, |n| n as u64)
+    }
+    fn evict_at_least(&self, _want: u64) -> u64 {
+        let now = Self::now_ms();
+        let last = self.last_acted_ms.load(Ordering::SeqCst);
+        if last != 0 && now.saturating_sub(last) < self.cooldown_ms {
+            crate::probe!(
+                class = "process.fds.owner_cooling",
+                since_ms = now.saturating_sub(last),
+                cooldown_ms = self.cooldown_ms,
+                "descriptor pressure persists inside the cooldown — the last action has not had its effect yet"
+            );
+            return 0;
+        }
+        self.last_acted_ms.store(now, Ordering::SeqCst);
+        self.relief.relieve().freed
+    }
+    fn snapshot(&self) -> Vec<ResourcePoolEntry> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    struct Counting(AtomicUsize);
+    impl FdRelief for Counting {
+        fn relieve(&self) -> ReliefOutcome {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            ReliefOutcome { action: "counted", freed: 7 }
+        }
+    }
+
+    // what this catches: the actor firing on every broker tick (a relief storm on
+    // top of the pressure it exists to end) or never (the cooldown never expiring),
+    // and the tier's arithmetic drifting from usage/capacity.
+    #[test]
+    fn the_owner_acts_once_per_cooldown_and_reads_its_table() {
+        let pool = FdPressurePool::new(Box::new(Counting(AtomicUsize::new(0))), 100, 60_000);
+        assert_eq!(pool.evict_at_least(1), 7, "first call acts");
+        assert_eq!(pool.evict_at_least(1), 0, "second call inside the cooldown does not");
+        let hot = FdPressurePool::new(Box::new(Counting(AtomicUsize::new(0))), 100, 0);
+        assert_eq!(hot.evict_at_least(1), 7);
+        assert_eq!(hot.evict_at_least(1), 7, "a zero cooldown acts every time");
+        assert!(pool.usage_bytes() >= 3, "this process holds at least stdio");
+        assert_eq!(pool.tier_name(), "process-fds");
+        assert_eq!(FdPressurePool::new(Box::new(Counting(AtomicUsize::new(0))), 0, 0).capacity_bytes(), 1, "capacity never zero");
+    }
+}

--- a/core/continuum-core/src/system_resources/mod.rs
+++ b/core/continuum-core/src/system_resources/mod.rs
@@ -20,6 +20,7 @@ pub mod concurrency;
 pub mod disk_eviction;
 pub mod disk_pressure;
 pub mod fd_gauge;
+pub mod fd_pressure;
 pub mod disk_reporters;
 pub mod memory_pressure;
 pub mod monitor;


### PR DESCRIPTION
2026-09-12: process.open_fds.high fired and nothing followed; a human read lsof, killed
the daemon, and rolled a binary back by hand. That is the diagnosis story, not
reliability (Joel: "reliable out of the box, recover itself, and not just for our
machine"). This is the last-resort ACTOR for the descriptor table — not the fix for
the design flaw (one daemon connection per channel per subscriber; the multiplexed
session is carded in airc) — and it is written so it can never be mistaken for one.

- airc/daemon_supervisor.rs: the core records the pid of the daemon it spawns,
  answers "is it answering" by connecting to the socket it resolves in-process
  (retiring the two `airc ipc-endpoint` forks in boot_plan — a path printed by a CLI
  proved nothing about liveness), and restart_if_owned() with NotOurs as a named
  outcome: a daemon someone else started is never killed.
- system_resources/fd_pressure.rs: FdPressurePool, the `process-fds` tier on the
  PressureBroker beside sys-memory and disk-root (capacity = the soft limit or the
  measured practical ceiling, usage = the table); evict_at_least = restart the owned
  daemon, once per 10-min cooldown, freed count measured not assumed; probes
  process.fds.owner_acted | owner_exhausted | owner_cooling. FdRelief is a trait so
  the gating is tested without a daemon.
- boot_plan::step_airc_daemon uses the supervisor (Answering / Started{pid, owned} /
  BinaryAbsent / NoHome / Failed).

Tests: the owner acts once per cooldown and reads its own table; a daemon we did not
spawn is never restarted; every boot step still leaves a receipt row.

**This is the last-resort actor, not the fix.** The design flaw (one daemon connection per channel per subscriber, one per request; the storm that multiplies it) is carded in airc and written up in #3972. Joel: *"the storm shouldn't even happen — don't mitigate a flaw in design or order."* This PR exists so that when the table fills anyway, the node names it and acts instead of a human reading `lsof`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo