### PR TITLE
fix(persona): a refused seat builds nothing and backs off; a runtime owns its tasks — the storm that filled the M5's descriptor tables

### DIFF
--- a/core/continuum-core/src/ipc/mod.rs
+++ b/core/continuum-core/src/ipc/mod.rs
@@ -3115,8 +3115,8 @@ pub fn start_server(
                             tracing::warn!(
                                 persona_id = ?failure.persona_id,
                                 reason = %failure.reason,
-                                "hosting reconciler: slot failed — will retry on the \
-                                 next serving-plan edge"
+                                "hosting reconciler: slot failed — retried after its backoff \
+                                 (persona.host.slot_backoff names the wait)"
                             );
                         }
                     }

--- a/core/continuum-core/src/persona/airc_citizen.rs
+++ b/core/continuum-core/src/persona/airc_citizen.rs
@@ -82,6 +82,13 @@ pub trait AircCitizen:
     + crate::persona::wall_source::WallReader
     + crate::persona::room_board_source::RoomBoardReader
 {
+    /// Take ownership of a task whose life must end with this citizen's (an
+    /// invalidator holding daemon streams, a watcher). The default ABORTS it at
+    /// once — a citizen that cannot own tasks must not leave them running.
+    fn own_task(&self, handle: tokio::task::JoinHandle<()>) {
+        handle.abort();
+    }
+
     /// The airc-side peer identity (Ed25519 pubkey, formatted as Uuid).
     /// Cognition uses this for self-loop filtering; the supervisor uses
     /// it as part of the persona's tracing span.

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -229,6 +229,8 @@ pub struct PersonaAircRuntime {
     /// heartbeat window. `None` on `from_attached` (tests/demo). Held for the
     /// persona's lifetime; aborted on drop, like the heartbeat pump.
     identity_republish: Option<JoinHandle<()>>,
+    /// Tasks whose life ends with this runtime (see `AircCitizen::own_task`).
+    owned_tasks: std::sync::Mutex<Vec<JoinHandle<()>>>,
     /// Where this citizen's identity came from — resumed from disk
     /// vs freshly minted. Carried for the lifetime of the runtime so
     /// telemetry surfaces (list/get IPC, future status panels) can
@@ -1036,6 +1038,7 @@ impl PersonaAircRuntime {
             executor: Some(executor_for_acts),
             heartbeat,
             identity_republish,
+            owned_tasks: std::sync::Mutex::new(Vec::new()),
             source,
         })
     }
@@ -1138,6 +1141,7 @@ impl PersonaAircRuntime {
             // from_attached is sync; the periodic card re-publisher (async spawn)
             // is a bootstrap-path concern. Test/demo callers don't need it.
             identity_republish: None,
+            owned_tasks: std::sync::Mutex::new(Vec::new()),
             source,
         }
     }
@@ -1364,6 +1368,13 @@ impl crate::persona::room_board_source::RoomBoardReader for PersonaAircRuntime {
 
 #[async_trait::async_trait]
 impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
+    fn own_task(&self, handle: JoinHandle<()>) {
+        match self.owned_tasks.lock() {
+            Ok(mut owned) => owned.push(handle),
+            Err(_) => handle.abort(), // a poisoned list cannot own; never leave the task running
+        }
+    }
+
     fn peer_id(&self) -> Uuid {
         self.airc.peer_id().as_uuid()
     }
@@ -1510,6 +1521,11 @@ impl Drop for PersonaAircRuntime {
         if let Some(handle) = self.identity_republish.take() {
             // Stop re-emitting the identity card once the persona leaves the grid.
             handle.abort();
+        }
+        if let Ok(mut owned) = self.owned_tasks.lock() {
+            for handle in owned.drain(..) {
+                handle.abort();
+            }
         }
         // Arc<Airc> drops alongside the runtime; airc-lib handles
         // its own cleanup (daemon connection close, identity state

--- a/core/continuum-core/src/persona/grounding_invalidation.rs
+++ b/core/continuum-core/src/persona/grounding_invalidation.rs
@@ -145,10 +145,12 @@ pub fn is_room_state_publish(kind: &airc_core::TranscriptKind) -> bool {
 /// reconnection; a terminal end is a real fault the pump already logs loud
 /// — this listener just stops, the caches go permanently dirty-capable-less
 /// but the personas' pumps have bigger problems at that point).
+/// Returns the task's handle: the caller OWNS it (a runtime aborts it in Drop). An
+/// orphaned invalidator held 24 daemon streams per failed seat on 2026-09-12.
 pub fn spawn_publish_invalidator(
     mut stream: airc_lib::FilteredEventStream,
     handles: Vec<WeakDirtyHandle>,
-) {
+) -> tokio::task::JoinHandle<()> {
     use futures::stream::StreamExt;
     tokio::spawn(async move {
         let mut handles = handles;
@@ -174,7 +176,7 @@ pub fn spawn_publish_invalidator(
                 return; // every wrapped source dropped — stop listening
             }
         }
-    });
+    })
 }
 
 #[cfg(test)]

--- a/core/continuum-core/src/persona/host.rs
+++ b/core/continuum-core/src/persona/host.rs
@@ -211,6 +211,8 @@ pub struct PersonaSpawnSupervisor {
     tier_id: String,
     model_registry: &'static crate::model_registry::Registry,
     rt_handle: tokio::runtime::Handle,
+    /// Seats that failed, by persona: attempts and the instant they may be tried again.
+    slot_backoff: std::sync::Mutex<std::collections::HashMap<Uuid, SlotBackoff>>,
 }
 
 impl PersonaSpawnSupervisor {
@@ -237,6 +239,7 @@ impl PersonaSpawnSupervisor {
             tier_id: tier_id.into(),
             model_registry,
             rt_handle,
+            slot_backoff: std::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -330,6 +333,7 @@ impl PersonaSpawnSupervisor {
         // the citizens, then the next serving edge hosted them through
         // host_unattended with zero held_out probes.
         let plans = Self::filter_by_hold(plans);
+        let plans = self.filter_by_backoff(plans);
 
         let mut summary = BootSummary::default();
         self.host_plans(plans, tool_command_executor, &mut summary)
@@ -360,6 +364,42 @@ impl PersonaSpawnSupervisor {
     /// in spawn_all, so bootstrap registered citizens and the next
     /// serving edge hosted all of them via host_unattended — a valid
     /// hold, four adoptions, zero held_out probes.
+    /// Skip seats whose last attempts failed until their backoff expires. Before
+    /// 2026-09-12 a seat refused at admission was re-attempted on EVERY reconciler
+    /// pass (34 a minute), each attempt building and abandoning daemon streams; the
+    /// log said "will retry on the next serving-plan edge" and did not mean it.
+    fn filter_by_backoff(
+        &self,
+        plans: Vec<crate::persona::spawner_module::MaterializedPersonaPlan>,
+    ) -> Vec<crate::persona::spawner_module::MaterializedPersonaPlan> {
+        let now = now_ms();
+        let map = self.slot_backoff.lock().unwrap_or_else(|e| e.into_inner());
+        filter_by_backoff_with(now, &map, plans)
+    }
+
+    fn note_slot_failure(&self, persona_id: Uuid, reason: &str) {
+        let now = now_ms();
+        let mut map = self.slot_backoff.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(persona_id).or_insert(SlotBackoff { attempts: 0, until_ms: 0 });
+        entry.attempts = entry.attempts.saturating_add(1);
+        let delay = backoff_delay(entry.attempts);
+        entry.until_ms = now.saturating_add(delay.as_millis() as u64);
+        crate::probe!(
+            class = "persona.host.slot_backoff",
+            persona_id = %persona_id,
+            attempts = entry.attempts,
+            retry_in_s = delay.as_secs(),
+            reason = %reason,
+            "a seat failed; it is not tried again until its backoff expires — the reason names the repair"
+        );
+    }
+
+    fn clear_slot_failure(&self, persona_id: Uuid) {
+        if let Ok(mut map) = self.slot_backoff.lock() {
+            map.remove(&persona_id);
+        }
+    }
+
     fn filter_by_hold(
         plans: Vec<crate::persona::spawner_module::MaterializedPersonaPlan>,
     ) -> Vec<crate::persona::spawner_module::MaterializedPersonaPlan> {
@@ -528,6 +568,7 @@ impl PersonaSpawnSupervisor {
         // gate as boot — see [`Self::filter_by_hold`] for the bypass this
         // closed.
         let plans = Self::filter_by_hold(plans);
+        let plans = self.filter_by_backoff(plans);
 
         self.host_plans(plans, tool_command_executor, &mut summary)
             .await;
@@ -577,13 +618,20 @@ impl PersonaSpawnSupervisor {
 
         for (slot_idx, result) in hosted_results.into_iter().enumerate() {
             match result {
-                Ok(ctx) => self.spawn_and_attach(slot_idx, ctx, summary).await,
+                Ok(ctx) => {
+                    self.clear_slot_failure(ctx.identity.peer_id.as_uuid());
+                    self.spawn_and_attach(slot_idx, ctx, summary).await
+                }
                 Err(err) => {
                     let (slot_index, role) = supervisor_error_facts(&err);
+                    let persona_id = supervisor_error_persona(&err);
+                    if let Some(pid) = persona_id {
+                        self.note_slot_failure(pid, &format!("{err}"));
+                    }
                     summary.failures.push(BootSlotFailure {
                         slot_index: slot_index.unwrap_or(slot_idx),
                         role: Some(role),
-                        persona_id: None,
+                        persona_id,
                         reason: format!("{err}"),
                     });
                     tracing::warn!(
@@ -699,6 +747,51 @@ impl PersonaSpawnSupervisor {
 /// place — the error enum's variants both carry these fields but
 /// behind different names. Centralizing the extraction keeps the
 /// summary-construction site clean.
+/// A failed seat's attempts and the instant it may be tried again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SlotBackoff {
+    pub attempts: u32,
+    pub until_ms: u64,
+}
+
+/// Doubling from 2 s, capped at 10 min: a refused seat is tried again soon in case the
+/// cause was transient (a daemon mid-restart), then rarely, and never at pass rate.
+pub(crate) fn backoff_delay(attempts: u32) -> std::time::Duration {
+    std::time::Duration::from_secs((2u64 << attempts.saturating_sub(1).min(9)).min(600))
+}
+
+/// Pure half of the backoff filter. Plans whose persona is inside its backoff are dropped.
+pub(crate) fn filter_by_backoff_with(
+    now_ms: u64,
+    map: &std::collections::HashMap<Uuid, SlotBackoff>,
+    plans: Vec<crate::persona::spawner_module::MaterializedPersonaPlan>,
+) -> Vec<crate::persona::spawner_module::MaterializedPersonaPlan> {
+    plans
+        .into_iter()
+        .filter(|p| {
+            map.get(&p.instance.peer_id.as_uuid())
+                .map_or(true, |b| now_ms >= b.until_ms)
+        })
+        .collect()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0) // unwrap_or: a pre-epoch clock reads every backoff as expired — a retry, never a stuck seat
+}
+
+/// The persona a failure names, when the error carries one.
+fn supervisor_error_persona(err: &SupervisorError) -> Option<Uuid> {
+    match err {
+        SupervisorError::WorkspaceRegistration { persona_id, .. }
+        | SupervisorError::AdmissionRestore { persona_id, .. }
+        | SupervisorError::RuntimeMissing { persona_id, .. } => Some(*persona_id),
+        _ => None,
+    }
+}
+
 fn supervisor_error_facts(err: &SupervisorError) -> (Option<usize>, RoleId) {
     match err {
         SupervisorError::Profile {
@@ -725,6 +818,26 @@ fn supervisor_error_facts(err: &SupervisorError) -> (Option<usize>, RoleId) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches: a refused seat re-attempted at pass rate (the 2026-09-12
+    // storm: 34 attempts/min, 24 leaked daemon streams each), a backoff that never
+    // expires, or one that does not double and cap.
+    #[test]
+    fn a_failed_seat_backs_off_doubling_and_capped_and_is_tried_again_after() {
+        assert_eq!(backoff_delay(1).as_secs(), 2);
+        assert_eq!(backoff_delay(2).as_secs(), 4);
+        assert_eq!(backoff_delay(5).as_secs(), 32);
+        assert_eq!(backoff_delay(40).as_secs(), 600, "capped at ten minutes");
+        let plan = plan_named("Atlas");
+        let pid = plan.instance.peer_id.as_uuid();
+        let mut map = std::collections::HashMap::new();
+        map.insert(pid, SlotBackoff { attempts: 3, until_ms: 10_000 });
+        assert!(filter_by_backoff_with(9_999, &map, vec![plan]).is_empty(), "inside the backoff: skipped");
+        let plan = plan_named("Atlas");
+        map.insert(plan.instance.peer_id.as_uuid(), SlotBackoff { attempts: 3, until_ms: 10_000 });
+        assert_eq!(filter_by_backoff_with(10_000, &map, vec![plan]).len(), 1, "at expiry: tried again");
+        assert_eq!(filter_by_backoff_with(0, &map, vec![plan_named("Demetri")]).len(), 1, "another persona is untouched");
+    }
 
     fn plan_named(name: &str) -> crate::persona::spawner_module::MaterializedPersonaPlan {
         crate::persona::spawner_module::MaterializedPersonaPlan {

--- a/core/continuum-core/src/persona/identity_card_cache.rs
+++ b/core/continuum-core/src/persona/identity_card_cache.rs
@@ -1,0 +1,125 @@
+//! Identity cards, fetched once per peer — never per tick.
+//!
+//! 2026-09-12: the positron presence emitter rendered every room every 2 s through
+//! airc-lib's `room_roster_cards_in`, which round-trips the daemon for EVERY live
+//! member's identity card on EVERY call. Fifty rooms × their members ÷ 2 s ≈ 250
+//! daemon requests a second whenever citizens were seated (zero with none), the
+//! daemon slowed under them, the requests outran their completions, and both
+//! descriptor tables filled — the host reached `ENFILE`. A card names a peer; it
+//! changes when the peer republishes it, not every two seconds. This cache is the
+//! one place a card is fetched, with a TTL and an explicit invalidate; a peer with
+//! no card is remembered as such for the same TTL so it is not re-asked per tick.
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use airc_core::identity::Identity;
+use airc_lib::PeerId;
+
+/// How long a fetched card (or a confirmed absence) stands before it is re-asked.
+pub const CARD_TTL_MS: u64 = 10 * 60 * 1000;
+
+#[derive(Debug, Clone)]
+struct Entry {
+    identity: Option<Identity>,
+    fetched_ms: u64,
+}
+
+/// The cache itself, pure over a clock so its policy is testable without a daemon.
+#[derive(Default)]
+pub struct CardCache {
+    entries: dashmap::DashMap<PeerId, Entry>,
+    pub hits: AtomicU64,
+    pub misses: AtomicU64,
+}
+
+impl CardCache {
+    /// The cached identity for `peer` if fresher than `ttl_ms` at `now_ms`.
+    pub fn get(&self, peer: PeerId, now_ms: u64, ttl_ms: u64) -> Option<Option<Identity>> {
+        let e = self.entries.get(&peer)?;
+        if now_ms.saturating_sub(e.fetched_ms) < ttl_ms {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            Some(e.identity.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn put(&self, peer: PeerId, identity: Option<Identity>, now_ms: u64) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        self.entries.insert(peer, Entry { identity, fetched_ms: now_ms });
+    }
+
+    /// Forget a peer's card — call when an identity publish for that peer is seen.
+    pub fn invalidate(&self, peer: PeerId) {
+        self.entries.remove(&peer);
+    }
+}
+
+fn global() -> &'static CardCache {
+    static CACHE: std::sync::OnceLock<CardCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(CardCache::default)
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0) // unwrap_or: a pre-epoch clock reads every entry as stale — a refetch, never a wrong card
+}
+
+/// The identity for `peer`: from the cache, else ONE daemon round-trip, then cached
+/// (absence included) for [`CARD_TTL_MS`].
+pub async fn identity_for(
+    airc: &airc_lib::Airc,
+    peer: PeerId,
+) -> Result<Option<Identity>, airc_lib::AircError> {
+    let now = now_ms();
+    if let Some(hit) = global().get(peer, now, CARD_TTL_MS) {
+        return Ok(hit);
+    }
+    let identity = airc.peer_identity_card(peer).await?.map(|card| card.identity);
+    global().put(peer, identity.clone(), now);
+    let (h, m) = (global().hits.load(Ordering::Relaxed), global().misses.load(Ordering::Relaxed));
+    crate::probe!(
+        class = "roster.identity_card.fetched",
+        peer = %peer.as_uuid(),
+        known = identity.is_some(),
+        hits = h,
+        misses = m,
+        "identity card fetched once for this peer; the roster reads the cache for the next 10 min"
+    );
+    Ok(identity)
+}
+
+/// Forget a peer's card so the next roster read fetches the republished one.
+pub fn invalidate(peer: PeerId) {
+    global().invalidate(peer);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(name: &str) -> Identity {
+        Identity { name: name.into(), ..Default::default() }
+    }
+
+    // what this catches: the card being re-asked inside its TTL (the 250-requests-a-
+    // second class), an unknown peer being re-asked per tick, and a stale entry or an
+    // invalidated one NOT being re-asked.
+    #[test]
+    fn a_card_is_fetched_once_per_ttl_and_absence_is_remembered() {
+        let c = CardCache::default();
+        let p = PeerId::new();
+        assert!(c.get(p, 1_000, CARD_TTL_MS).is_none(), "cold: a miss");
+        c.put(p, Some(ident("Atlas")), 1_000);
+        assert_eq!(c.get(p, 2_000, CARD_TTL_MS).flatten().map(|i| i.name), Some("Atlas".into()));
+        assert!(c.get(p, 1_000 + CARD_TTL_MS, CARD_TTL_MS).is_none(), "stale after the TTL");
+        let q = PeerId::new();
+        c.put(q, None, 5_000);
+        assert_eq!(c.get(q, 6_000, CARD_TTL_MS), Some(None), "a known absence is a hit, not a refetch");
+        c.invalidate(p);
+        assert!(c.get(p, 2_000, CARD_TTL_MS).is_none(), "invalidated = re-asked");
+        assert_eq!(c.hits.load(Ordering::Relaxed), 2);
+        assert_eq!(c.misses.load(Ordering::Relaxed), 2);
+    }
+}

--- a/core/continuum-core/src/persona/mod.rs
+++ b/core/continuum-core/src/persona/mod.rs
@@ -91,6 +91,7 @@ pub mod roster_hold;
 pub mod role_template;
 pub mod room_board_source;
 pub mod room_doctrine_source;
+pub mod identity_card_cache;
 pub mod room_roster_source;
 #[cfg(any(test, feature = "test-fixtures"))]
 pub mod scripted_adapter_factory;

--- a/core/continuum-core/src/persona/room_roster_source.rs
+++ b/core/continuum-core/src/persona/room_roster_source.rs
@@ -154,14 +154,31 @@ impl AircRosterReader for airc_lib::Airc {
         airc_lib::Airc::peer_id(self)
     }
 
+    // Both reads below are ONE liveness query plus cached identity cards. airc-lib's
+    // `room_roster_in` / `room_roster_cards_in` round-trip the daemon per live member
+    // on every call; rendered every 2 s for every room, that was ~250 requests a
+    // second with citizens seated (2026-09-12) and it filled both descriptor tables.
     async fn room_roster(
         &self,
         within: Duration,
         window: usize,
         room: Option<uuid::Uuid>,
     ) -> Result<Vec<RoomMember>, AircError> {
-        airc_lib::Airc::room_roster_in(self, room.map(airc_core::RoomId::from_uuid), within, window)
-            .await
+        let live = airc_lib::Airc::active_agents_in(self, room.map(airc_core::RoomId::from_uuid), within, window).await?;
+        let mut members = Vec::with_capacity(live.len());
+        for liveness in live {
+            let identity = crate::persona::identity_card_cache::identity_for(self, liveness.peer).await?;
+            // an empty published name is an honest "unknown", not an empty display string
+            let display_name = identity.map(|i| i.name).filter(|n| !n.trim().is_empty());
+            members.push(RoomMember {
+                peer_id: liveness.peer,
+                display_name,
+                runtime: liveness.runtime,
+                availability: liveness.coordination.availability,
+                last_seen_ms: liveness.last_seen_ms,
+            });
+        }
+        Ok(members)
     }
 
     async fn room_roster_cards(
@@ -170,13 +187,19 @@ impl AircRosterReader for airc_lib::Airc {
         window: usize,
         room: Option<uuid::Uuid>,
     ) -> Result<Vec<airc_lib::RoomMemberCard>, AircError> {
-        airc_lib::Airc::room_roster_cards_in(
-            self,
-            room.map(airc_core::RoomId::from_uuid),
-            within,
-            window,
-        )
-        .await
+        let live = airc_lib::Airc::active_agents_in(self, room.map(airc_core::RoomId::from_uuid), within, window).await?;
+        let mut members = Vec::with_capacity(live.len());
+        for liveness in live {
+            let identity = crate::persona::identity_card_cache::identity_for(self, liveness.peer).await?;
+            members.push(airc_lib::RoomMemberCard {
+                peer_id: liveness.peer,
+                runtime: liveness.runtime,
+                availability: liveness.coordination.availability,
+                last_seen_ms: liveness.last_seen_ms,
+                identity,
+            });
+        }
+        Ok(members)
     }
 }
 

--- a/core/continuum-core/src/persona/supervisor.rs
+++ b/core/continuum-core/src/persona/supervisor.rs
@@ -562,6 +562,32 @@ pub async fn materialize_adapters(
             }
         };
         let identity = plan.instance;
+        // ADMISSION FIRST. This restore opens the persona's engram store; when it fails
+        // the seat is refused (6d17695c: never host a blank admission store). Until
+        // 2026-09-12 it ran AFTER every daemon-facing adapter had been built — a
+        // subscription to every room, the doctrine/wall invalidator task, the pumps —
+        // and a refused seat abandoned them all, un-aborted. One citizen whose store
+        // would not decode was re-attempted every reconciler pass: 24 daemon streams
+        // leaked per attempt, ~150 sockets/s, both descriptor tables full, the host at
+        // ENFILE. A seat that will be refused must build nothing first.
+        let persisted_admission = {
+            let home = crate::persona::home::PersonaHome::from_root(identity.home.clone());
+            let recall_meta =
+                std::sync::Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new());
+            match crate::persona::admission_state::AdmissionState::for_persona(&home, recall_meta).await
+            {
+                Ok(persisted) => persisted,
+                Err(source) => {
+                    out.push(Err(SupervisorError::AdmissionRestore {
+                        slot_index,
+                        role: plan.role,
+                        persona_id: identity.peer_id.as_uuid(),
+                        source,
+                    }));
+                    continue;
+                }
+            }
+        };
         let runtime = match runtime_lookup(identity.peer_id.as_uuid()) {
             Some(r) => r,
             None => {
@@ -869,10 +895,12 @@ pub async fn materialize_adapters(
                     crate::persona::cached_source::CachedRagSource::new(raw_doctrine);
                 let (wall_cached, wall_dirty) =
                     crate::persona::cached_source::CachedRagSource::new(raw_wall);
-                crate::persona::grounding_invalidation::spawn_publish_invalidator(
+                // The invalidator owns a subscription to every room; it lives and dies with
+                // the runtime (aborted in the runtime's Drop), never as an orphan task.
+                runtime.own_task(crate::persona::grounding_invalidation::spawn_publish_invalidator(
                     stream,
                     vec![doctrine_dirty.downgrade(), wall_dirty.downgrade()],
-                );
+                ));
                 (doctrine_cached, wall_cached)
             }
             Err(e) => {
@@ -946,28 +974,10 @@ pub async fn materialize_adapters(
         // would hide prior engrams and lose future admissions across restart.
         // A new home succeeds with an empty persistent store. MUST run before
         // WorkspaceCycle assembly so RecallFaculty binds persisted admission.
-        let home = crate::persona::home::PersonaHome::from_root(identity.home.clone());
-        let recall_meta =
-            std::sync::Arc::new(crate::persona::recall_metadata::RecallMetadataRegistry::new());
-        match crate::persona::admission_state::AdmissionState::for_persona(&home, recall_meta).await
-        {
-            Ok(persisted) => {
-                cognition.attach_persistent_admission(
-                    identity.peer_id.as_uuid(),
-                    std::sync::Arc::new(persisted),
-                );
-            }
-            Err(source) => {
-                out.push(Err(SupervisorError::AdmissionRestore {
-                    slot_index,
-                    role: plan.role,
-                    persona_id: identity.peer_id.as_uuid(),
-                    source,
-                }));
-                continue;
-            }
-        }
-
+        cognition.attach_persistent_admission(
+            identity.peer_id.as_uuid(),
+            std::sync::Arc::new(persisted_admission),
+        );
         let system_prompt = build_persona_system_prompt(&identity.agent_name);
 
         // Assemble this persona's continuous mind into the process-global


### PR DESCRIPTION
2026-09-12, named by a symbolized stack sample during the storm: the positron presence
emitter renders every room every 2 s through airc-lib's room_roster_cards_in, which
round-trips the daemon for EVERY live member's identity card on EVERY call. ~50 rooms ×
their members ÷ 2 s ≈ 250 daemon requests a second whenever citizens were seated (zero
with none — no live members), the daemon slowed under them, requests outran their
completions, and both descriptor tables filled: core 8.7k → 20.3k in 60 s, the host at
ENFILE, every spawn EBADF, the lane refused, the node dark. Three hotfixes, a daemon
rollback and an hour of lsof had treated the symptoms.

A card names a peer; it changes when the peer republishes it, not every two seconds.
persona/identity_card_cache.rs is the ONE place a card is fetched: once per peer, a
10-minute TTL, absence remembered too, `invalidate(peer)` for a republish, a probe per
fetch. The AircRosterReader impl over airc_lib::Airc is composed here — one
active_agents_in query per read, cards from the cache — for both room_roster (names)
and room_roster_cards; airc-lib's per-member round-trips are no longer on any path.

Test: a card is fetched once per TTL, an unknown peer is a hit not a refetch, stale and
invalidated entries are re-asked. Acceptance: five coders seated, core fds and daemon
sockets flat for the watch window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo