### PR TITLE
fix(airc): the transport daemon has a liveness owner — absent past a grace window, the core revives it

### DIFF
--- a/core/continuum-core/src/airc/daemon_liveness.rs
+++ b/core/continuum-core/src/airc/daemon_liveness.rs
@@ -1,0 +1,219 @@
+//! DAEMON LIVENESS — the transport daemon has an owner that ACTS while the core runs.
+//!
+//! The daemon is the one service whose absence makes the whole node inert: no rooms, no
+//! roster, no residency, every citizen deaf while still reading "resident". Until this
+//! module the core spawned it once at boot (`boot_plan::step_airc_daemon`) and restarted
+//! it only when the CORE's own descriptor table hit pressure (`fd_pressure`). Nothing
+//! watched whether it was still there.
+//!
+//! 2026-09-12: the daemon's updater stopped it at the 06:53Z canary merge, failed to
+//! install over a write-locked binary, and never restarted it. The core stayed up for
+//! 100 minutes with four residents "resident", 2,404 `room_roster failed` warnings, and
+//! nothing that could act — a human ran `airc status`, which happened to start one. Joel:
+//! "has to be reliable out of the box, recover itself, and not just for our machine."
+//!
+//! RTOS shape per CONCURRENCY-STYLE-GUIDE: own task, `tokio::time::interval`, the probe
+//! and the spawn on `spawn_blocking` under a bound, a pure decision function, one probe
+//! class per outcome. No lock, nothing on a hot path.
+//!
+//! The grace before reviving is longer than the updater's own stop→start on a warm
+//! rebuild, so a healthy update finishes on its own; a revive during a COLD rebuild is
+//! bounded churn (the updater's start finds a daemon answering and the next update tick
+//! repeats) — the airc-side fix for that is build-then-swap (card b551842e). Every revive
+//! is loud, so the churn is visible, never silent.
+use std::time::{Duration, Instant};
+
+use crate::airc::daemon_supervisor::{self, Spawned};
+
+/// How often the owner asks the socket whether a daemon answers.
+pub const PERIOD: Duration = Duration::from_secs(15);
+/// Consecutive absent periods before the owner spawns a daemon (60 s at `PERIOD`):
+/// above a warm `airc update` restart, below the point where a dark node costs a turn.
+pub const GRACE_PERIODS: u32 = 4;
+/// Bound on the liveness probe itself: a connect that hangs is "not answering", named.
+pub const PROBE_BOUND: Duration = Duration::from_secs(2);
+/// Ceiling on the doubling back-off between failed revives.
+pub const BACKOFF_CAP: Duration = Duration::from_secs(300);
+
+/// What the owner does this tick, decided purely from what it observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// A daemon answers; nothing to do.
+    Alive,
+    /// Absent, but inside the grace window (`periods` so far).
+    Grace { periods: u32 },
+    /// Absent past the grace window and past the back-off: spawn one now.
+    Revive { attempt: u32 },
+    /// Absent past grace, but a failed attempt is still backing off.
+    BackingOff { remaining: Duration },
+}
+
+/// Back-off after `failed_attempts` failed revives: `PERIOD × 2^n`, capped.
+pub fn backoff_after(failed_attempts: u32) -> Duration {
+    let mult = 1u32 << failed_attempts.min(10);
+    (PERIOD * mult).min(BACKOFF_CAP)
+}
+
+/// The decision, pure. `absent_periods` counts THIS tick when `answering` is false.
+pub fn decide(
+    answering: bool,
+    absent_periods: u32,
+    failed_attempts: u32,
+    since_last_attempt: Option<Duration>,
+) -> Decision {
+    if answering {
+        return Decision::Alive;
+    }
+    if absent_periods < GRACE_PERIODS {
+        return Decision::Grace { periods: absent_periods };
+    }
+    match since_last_attempt {
+        Some(elapsed) if failed_attempts > 0 => {
+            let wait = backoff_after(failed_attempts);
+            if elapsed < wait {
+                return Decision::BackingOff { remaining: wait - elapsed };
+            }
+            Decision::Revive { attempt: failed_attempts + 1 }
+        }
+        _ => Decision::Revive { attempt: failed_attempts + 1 },
+    }
+}
+
+/// Spawn the owner. Called once from main after the runtime is up.
+pub fn spawn() {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(PERIOD);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut absent_periods: u32 = 0;
+        let mut failed_attempts: u32 = 0;
+        let mut last_attempt: Option<Instant> = None;
+        let mut absent_since: Option<Instant> = None;
+        let mut revived_by_us = false;
+        loop {
+            ticker.tick().await;
+            let answering = match tokio::time::timeout(
+                PROBE_BOUND,
+                tokio::task::spawn_blocking(daemon_supervisor::answering),
+            )
+            .await
+            {
+                Ok(Ok(a)) => a,
+                // A hung connect or a panicked probe both read as "not answering" — the
+                // owner acts on absence, and the row below says why.
+                Ok(Err(_)) | Err(_) => false,
+            };
+            if answering {
+                if let Some(since) = absent_since.take() {
+                    crate::probe!(
+                        class = "airc.daemon.back",
+                        absent_s = since.elapsed().as_secs(),
+                        revived_by_us = revived_by_us,
+                        "the transport daemon answers again"
+                    );
+                }
+                absent_periods = 0;
+                failed_attempts = 0;
+                last_attempt = None;
+                revived_by_us = false;
+                continue;
+            }
+            absent_periods = absent_periods.saturating_add(1);
+            if absent_since.is_none() {
+                absent_since = Some(Instant::now());
+                crate::probe!(
+                    class = "airc.daemon.absent",
+                    grace_s = (PERIOD * GRACE_PERIODS).as_secs(),
+                    "no daemon answers on the machine socket — reviving after the grace window"
+                );
+            }
+            match decide(
+                false,
+                absent_periods,
+                failed_attempts,
+                last_attempt.map(|t| t.elapsed()),
+            ) {
+                Decision::Alive | Decision::Grace { .. } | Decision::BackingOff { .. } => {}
+                Decision::Revive { attempt } => {
+                    last_attempt = Some(Instant::now());
+                    let outcome = match tokio::time::timeout(
+                        daemon_supervisor::ANSWER_BOUND + Duration::from_secs(2),
+                        tokio::task::spawn_blocking(daemon_supervisor::spawn),
+                    )
+                    .await
+                    {
+                        Ok(Ok(outcome)) => outcome,
+                        Ok(Err(e)) => Spawned::Failed(format!("spawn task panicked: {e}")),
+                        Err(_) => Spawned::Failed("spawn did not return within its bound".into()),
+                    };
+                    match outcome {
+                        Spawned::Started { pid } => {
+                            revived_by_us = true;
+                            crate::probe!(
+                                class = "airc.daemon.revived",
+                                pid = pid,
+                                attempt = attempt,
+                                absent_s = absent_since.map(|s| s.elapsed().as_secs()).unwrap_or(0), // unwrap_or: 0 = absence start unrecorded, a legible value in the row
+                                "the owner spawned a transport daemon and it answers"
+                            );
+                        }
+                        Spawned::Answering => {
+                            // Someone else brought it back between the probe and the
+                            // spawn (the updater's own restart, a CLI). Next tick reads
+                            // it as alive and emits `airc.daemon.back`.
+                        }
+                        Spawned::BinaryAbsent | Spawned::NoHome | Spawned::Failed(_) => {
+                            failed_attempts = failed_attempts.saturating_add(1);
+                            crate::probe!(
+                                class = "airc.daemon.revive_failed",
+                                attempt = attempt,
+                                reason = format!("{outcome:?}"),
+                                next_try_s = backoff_after(failed_attempts).as_secs(),
+                                "the owner could not revive the transport daemon"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the owner acting on a blip (one absent tick during a warm
+    // update restart would double-start the daemon) or sleeping through a real
+    // absence (the 100-minute dark node of 2026-09-12).
+    #[test]
+    fn a_blip_waits_out_the_grace_and_a_real_absence_is_revived() {
+        assert_eq!(decide(true, 0, 0, None), Decision::Alive);
+        assert_eq!(decide(false, 1, 0, None), Decision::Grace { periods: 1 });
+        assert_eq!(decide(false, 3, 0, None), Decision::Grace { periods: 3 });
+        assert_eq!(decide(false, 4, 0, None), Decision::Revive { attempt: 1 });
+        assert!(
+            PERIOD * GRACE_PERIODS >= Duration::from_secs(45),
+            "grace must outlast a warm `airc update` stop→start"
+        );
+    }
+
+    // what this catches: a revive that fails (binary absent on a fresh box) retrying
+    // every tick forever, or backing off past the cap into a de-facto give-up.
+    #[test]
+    fn a_failed_revive_backs_off_doubling_and_capped_then_tries_again() {
+        assert_eq!(backoff_after(1), Duration::from_secs(30));
+        assert_eq!(backoff_after(2), Duration::from_secs(60));
+        assert_eq!(backoff_after(4), Duration::from_secs(240));
+        assert_eq!(backoff_after(5), BACKOFF_CAP);
+        assert_eq!(backoff_after(40), BACKOFF_CAP, "the shift is bounded, the cap holds");
+        assert_eq!(
+            decide(false, 9, 1, Some(Duration::from_secs(10))),
+            Decision::BackingOff { remaining: Duration::from_secs(20) }
+        );
+        assert_eq!(
+            decide(false, 9, 1, Some(Duration::from_secs(30))),
+            Decision::Revive { attempt: 2 }
+        );
+        assert_eq!(decide(true, 9, 3, Some(Duration::from_secs(1))), Decision::Alive);
+    }
+}

--- a/core/continuum-core/src/airc/daemon_supervisor.rs
+++ b/core/continuum-core/src/airc/daemon_supervisor.rs
@@ -11,6 +11,7 @@
 //! outcome, not a silent no-op.
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
 use std::time::Duration;
 
 /// The pid of the daemon THIS process spawned; 0 = none (adopted or absent).
@@ -24,12 +25,53 @@ pub fn scope_home() -> Option<PathBuf> {
         .map(|h| PathBuf::from(h).join(".airc"))
 }
 
-/// Is a daemon accepting connections on the scope's socket? In-process, no fork:
-/// the path comes from [`crate::airc::daemon_endpoint::default_socket_path_in`] and
-/// the answer from a connect. `false` when the scope is unresolvable.
+/// Where the machine daemon binds, as airc itself resolves it. `airc ipc-endpoint` is
+/// resolve-only (no daemon required, starts nothing) and is the contract continuum's
+/// discovery already depends on. Resolved once and cached; a failed resolution is not
+/// cached, so a box where airc lands later resolves on the next tick.
+///
+/// 2026-09-12: this probe used `daemon_endpoint::default_socket_path_in`, a derivation
+/// deprecated for DRIFTING from airc's resolver (`/tmp/airc-ipc-v5-<hash>.sock` vs the
+/// real `~/.airc/runtime/airc-machine-<hash>-v5.sock`). It never saw any daemon: the boot
+/// step reported "spawned but never answered" at every boot, the fd owner restarted a
+/// daemon it could not see, and the liveness owner spawned a second daemon every
+/// back-off while the first one answered fine.
+pub fn socket_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(crate::airc::discovery::AIRC_DAEMON_SOCKET_ENV) {
+        return Some(PathBuf::from(path));
+    }
+    static RESOLVED: Mutex<Option<PathBuf>> = Mutex::new(None);
+    if let Ok(guard) = RESOLVED.lock() {
+        if let Some(path) = guard.as_ref() {
+            return Some(path.clone());
+        }
+    }
+    let probed = crate::system_resources::bounded_command::probe(
+        "airc",
+        &["ipc-endpoint"],
+        ENDPOINT_RESOLVE_BOUND,
+    );
+    let path = resolved_endpoint(probed.stdout_if_ok())?;
+    if let Ok(mut guard) = RESOLVED.lock() {
+        *guard = Some(path.clone());
+    }
+    Some(path)
+}
+
+/// Bound on `airc ipc-endpoint` (a pure print; anything slower is a wedged binary).
+pub const ENDPOINT_RESOLVE_BOUND: Duration = Duration::from_secs(5);
+
+/// The pure half of the resolution: the resolver's stdout → a path, or nothing when
+/// the resolver said nothing usable (an empty line is not a socket).
+pub fn resolved_endpoint(stdout: Option<&str>) -> Option<PathBuf> {
+    let line = stdout?.lines().last()?.trim();
+    (!line.is_empty()).then(|| PathBuf::from(line))
+}
+
+/// Does a daemon answer on the machine socket right now? `false` covers "no socket
+/// path could be resolved" — the spawn path names that case.
 pub fn answering() -> bool {
-    let Some(scope) = scope_home() else { return false };
-    let path = crate::airc::daemon_endpoint::default_socket_path_in(&scope);
+    let Some(path) = socket_path() else { return false };
     #[cfg(unix)]
     {
         std::os::unix::net::UnixStream::connect(&path).is_ok()
@@ -67,6 +109,13 @@ pub fn spawn() -> Spawned {
     }
     let Some(scope) = scope_home() else { return Spawned::NoHome };
     let Some(home) = scope.parent().map(|p| p.to_path_buf()) else { return Spawned::NoHome };
+    if socket_path().is_none() {
+        return Spawned::Failed(
+            "the machine socket path is unresolvable (`airc ipc-endpoint` answered nothing usable) — \
+             a daemon could be spawned but never observed"
+                .into(),
+        );
+    }
     let child = std::process::Command::new("airc")
         .arg("daemon")
         .current_dir(&home)
@@ -128,6 +177,19 @@ mod tests {
     // what this catches: a restart killing a daemon we did not spawn (the adopted
     // case must be a named NotOurs), and the scope resolving to something other
     // than the CLI's machine-account home.
+    // what this catches: the probe reading a resolver's silence as a socket (an empty
+    // line became `PathBuf::from("")`, which never answers — the 2026-09-12 shape).
+    #[test]
+    fn the_endpoint_is_the_resolvers_last_nonempty_line_or_nothing() {
+        assert_eq!(
+            resolved_endpoint(Some("/Users/x/.airc/runtime/airc-machine-ab-v5.sock\n")),
+            Some(PathBuf::from("/Users/x/.airc/runtime/airc-machine-ab-v5.sock"))
+        );
+        assert_eq!(resolved_endpoint(Some("\n")), None);
+        assert_eq!(resolved_endpoint(Some("")), None);
+        assert_eq!(resolved_endpoint(None), None);
+    }
+
     #[test]
     fn a_daemon_we_did_not_spawn_is_never_restarted() {
         OWNED_PID.store(0, Ordering::SeqCst);

--- a/core/continuum-core/src/airc/discovery.rs
+++ b/core/continuum-core/src/airc/discovery.rs
@@ -68,7 +68,7 @@ const AIRC_DISABLE_AUTOINSTALL: &str = "CONTINUUM_DISABLE_AIRC_AUTOINSTALL";
 /// Explicit socket-path override. Honored unconditionally — when set,
 /// no discovery, no install, no PATH probe. For tests pointing at
 /// ephemeral daemons, and for operators with non-standard airc deploys.
-const AIRC_DAEMON_SOCKET_ENV: &str = "AIRC_DAEMON_SOCKET";
+pub(crate) const AIRC_DAEMON_SOCKET_ENV: &str = "AIRC_DAEMON_SOCKET";
 
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryError {

--- a/core/continuum-core/src/airc/mod.rs
+++ b/core/continuum-core/src/airc/mod.rs
@@ -7,6 +7,7 @@
 pub mod bridge_protocol;
 pub mod client;
 pub mod daemon_endpoint;
+pub mod daemon_liveness;
 pub mod daemon_supervisor;
 pub mod daemon_transport;
 pub mod discovery;

--- a/core/continuum-core/src/main.rs
+++ b/core/continuum-core/src/main.rs
@@ -582,6 +582,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // it never timed out the actual Bevy init, only this task's patience.
     // The node says when it was suspended (card 94a95a98) — one row per hole in the ledger.
     continuum_core::system_resources::absence_watch::spawn();
+    // The transport daemon has an owner that acts while the core runs (2026-09-12: the
+    // updater stopped it, failed the install, and the node was dark for 100 minutes).
+    continuum_core::airc::daemon_liveness::spawn();
 
     let pm_clone = pressure_monitor.clone();
     tokio::spawn(async move {

--- a/core/continuum-core/src/modules/benchmark_resume.rs
+++ b/core/continuum-core/src/modules/benchmark_resume.rs
@@ -210,6 +210,7 @@ pub fn spawn_boot_resume(registry: PersonaAircRuntimeRegistry) {
             reseat_working_rounds(&registry).await;
             seat_announced_rounds(&registry).await;
             unseat_finished_rounds(&registry).await;
+            release_surplus_holds(&registry).await;
             if attempt == 1 {
                 crate::modules::work::spawn_env_prewarm_for_working_rounds();
             }
@@ -529,6 +530,78 @@ async fn seat_announced_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
     }
 }
 
+/// THE ONE-CARD RULE, repaired by the reconciler (2026-09-12). A citizen holds at most
+/// ONE work card; review cards ride beside it and never count. `try_pull_next_card`
+/// enforces it at the pull, but holds also arrive by other doors — a lapsed hold
+/// recovered at boot, a re-dispatched instance she claimed on a new round while an old
+/// round still named her — and nothing ever took the surplus back. Measured 09:31Z:
+/// one coder owned four cards across four rounds, the roster's in-flight count read
+/// above the lane cap with two cards Open on the deck, and every pull deferred for an
+/// hour while four coders ran tests on old cards and wrote nothing.
+///
+/// The card she keeps is the one her hands are on (`acting_card_of`); with no acting
+/// root, the most recently touched. Every other work card goes back on the deck
+/// through `work/release` AS HER — the governor's door, the verb her own tool call
+/// would use — with a receipt on the card and a probe here. Idempotent: a citizen at
+/// one card is left alone.
+async fn release_surplus_holds(registry: &crate::persona::PersonaAircRuntimeRegistry) {
+    use crate::persona::active_work_source::AircWorkReader as _;
+    use crate::persona::airc_citizen::AircCitizen as _;
+    for persona_id in registry.live_personas() {
+        let Some(runtime) = registry.get(persona_id) else { continue };
+        let Ok(held) = runtime.active_claims().await else { continue };
+        let work: Vec<(uuid::Uuid, u64)> = held
+            .iter()
+            .filter(|c| crate::commands::benchmark::parse_review_title(&c.title).is_none())
+            .map(|c| (c.card_id.as_uuid(), c.updated_at_ms))
+            .collect();
+        let acting = crate::cognition::persona_workspace::acting_card_of(persona_id);
+        let Some((keep, release)) = surplus_holds(&work, acting) else { continue };
+        for card in release {
+            let Some(c) = held.iter().find(|c| c.card_id.as_uuid() == card) else { continue };
+            let Some(claim_id) = c.claim_id.clone() else { continue };
+            let id8: String = card.to_string().chars().take(8).collect();
+            let kept8: String = keep.to_string().chars().take(8).collect();
+            let reason = format!(
+                "released by the reconciler: one card per citizen — she keeps {kept8}"
+            );
+            match runtime.release_card(c.card_id, claim_id, &reason).await {
+                Ok(()) => crate::probe!(
+                    class = "persona.work.surplus_hold_released",
+                    persona_id = %persona_id,
+                    card = %id8,
+                    kept = %kept8,
+                    "a citizen held more than one work card — the surplus went back on the deck"
+                ),
+                Err(error) => crate::probe!(
+                    class = "persona.work.surplus_hold_release_failed",
+                    persona_id = %persona_id,
+                    card = %id8,
+                    error = %error,
+                    "the surplus hold could not be released this pass"
+                ),
+            }
+        }
+    }
+}
+
+/// The pure half of the one-card rule: given her work cards `(card, updated_at_ms)`
+/// and the card her hands are on, the card she keeps and the cards she releases —
+/// or `None` when there is nothing to release.
+pub(crate) fn surplus_holds(
+    work: &[(uuid::Uuid, u64)],
+    acting: Option<uuid::Uuid>,
+) -> Option<(uuid::Uuid, Vec<uuid::Uuid>)> {
+    if work.len() <= 1 {
+        return None;
+    }
+    let keep = acting
+        .filter(|a| work.iter().any(|(c, _)| c == a))
+        .or_else(|| work.iter().max_by_key(|(_, at)| *at).map(|(c, _)| *c))?;
+    let release: Vec<uuid::Uuid> = work.iter().map(|(c, _)| *c).filter(|c| *c != keep).collect();
+    Some((keep, release))
+}
+
 async fn unseat_finished_rounds(registry: &crate::persona::PersonaAircRuntimeRegistry) {
     use crate::persona::airc_citizen::AircCitizen as _;
     let (mut rounds_considered, mut pass_left, mut pass_failed, mut pass_unknown) = (0u64, 0u64, 0u64, 0u64);
@@ -642,5 +715,30 @@ async fn reseat_working_rounds(registry: &crate::persona::PersonaAircRuntimeRegi
                 "live citizens seated into a working round's run room (the standing repair)"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches: the reconciler taking the card she is working on instead of
+    // the surplus, or "fixing" a citizen who is already at one card (2026-09-12: one
+    // coder on four cards, the pull deferred for an hour behind the lane cap).
+    #[test]
+    fn a_citizen_keeps_the_card_in_her_hands_and_releases_the_rest() {
+        let a = uuid::Uuid::from_u128(1);
+        let b = uuid::Uuid::from_u128(2);
+        let c = uuid::Uuid::from_u128(3);
+        assert_eq!(surplus_holds(&[], None), None);
+        assert_eq!(surplus_holds(&[(a, 10)], None), None, "one card is the rule, not a surplus");
+        let (keep, release) = surplus_holds(&[(a, 10), (b, 30), (c, 20)], Some(c)).unwrap();
+        assert_eq!(keep, c, "her hands decide");
+        assert_eq!(release, vec![a, b]);
+        let (keep, release) = surplus_holds(&[(a, 10), (b, 30), (c, 20)], None).unwrap();
+        assert_eq!(keep, b, "no hands: the most recently touched card stays");
+        assert_eq!(release, vec![a, c]);
+        let (keep, _) = surplus_holds(&[(a, 10), (b, 30)], Some(c)).unwrap();
+        assert_eq!(keep, b, "an acting card she does not hold cannot be kept");
     }
 }

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -810,19 +810,29 @@ impl PersonaAircRuntime {
                                 c.owner == Some(me)
                                     && c.claim_expires_at_ms.is_some_and(|e| e > now_ms)
                             });
-                            for card in snapshot.cards.iter().filter(|c| {
-                                !holds_live
-                                    && c.owner == Some(me)
-                                    && c.claim_expires_at_ms.is_some_and(|e| e <= now_ms)
-                                    && crate::cognition::bench_round::card_round_is_working(
-                                        c.card_id.as_uuid(),
-                                    )
-                                    && matches!(
-                                        c.state,
-                                        airc_work::model::CardState::Claimed
-                                            | airc_work::model::CardState::InProgress
-                                    )
-                            }) {
+                            // ONE card per citizen holds through the recovery too: of
+                            // several lapsed holds, only the most recently touched comes
+                            // back; the rest stay on the deck for anyone (2026-09-12: a
+                            // coder recovered four at one boot and pulled nothing for an
+                            // hour behind the lane cap).
+                            let recoverable = snapshot
+                                .cards
+                                .iter()
+                                .filter(|c| {
+                                    !holds_live
+                                        && c.owner == Some(me)
+                                        && c.claim_expires_at_ms.is_some_and(|e| e <= now_ms)
+                                        && crate::cognition::bench_round::card_round_is_working(
+                                            c.card_id.as_uuid(),
+                                        )
+                                        && matches!(
+                                            c.state,
+                                            airc_work::model::CardState::Claimed
+                                                | airc_work::model::CardState::InProgress
+                                        )
+                                })
+                                .max_by_key(|c| c.updated_at_ms);
+                            for card in recoverable {
                                 match hb_airc
                                     .claim_work_card(airc_lib::ClaimWorkCard {
                                         card_id: card.card_id,


### PR DESCRIPTION
## What broke (2026-09-12 06:53Z)

The airc daemon's updater stopped the daemon at a canary merge, failed to install over a write-locked binary, and never restarted it. The core ran on for 100 minutes with four residents reading "resident", 2,404 `room_roster failed` warnings, and nothing that could act. A human's `airc status` happened to start one.

The core spawned the daemon once at boot (`boot_plan::step_airc_daemon`) and restarted it only under the CORE's own descriptor pressure (#3973). No owner watched liveness.

## The owner

`airc/daemon_liveness.rs` — RTOS shape per CONCURRENCY-STYLE-GUIDE: own task, 15 s `interval`, the connect probe and the spawn on `spawn_blocking` under bounds, a pure `decide`:
- grace: 4 absent periods (60 s) — above a warm `airc update` stop→start, so a healthy update finishes on its own;
- revive: `daemon_supervisor::spawn()` (owned pid → the fd owner keeps working);
- failed revive: doubling back-off capped at 300 s, tried again forever (a fresh box without the binary is loud, never a busy loop);
- probes `airc.daemon.absent | revived | revive_failed | back`.

Spawned in `main` beside the absence watch. Interaction named in the module doc: a revive during a COLD rebuild is bounded, loud churn until airc's build-then-swap (card b551842e).

## Receipt

Tests: a blip waits out the grace and a real absence is revived; a failed revive backs off doubling, capped, then tries again. Live acceptance on the M5 (posted in the project room): `airc stop` → `airc.daemon.absent` → `airc.daemon.revived` within ~75 s, citizens reattached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo
