### PR TITLE
fix(work): a held claim is board-true, a reopen releases the claim, every no-pull exit is named

### DIFF
--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1968,6 +1968,14 @@ async fn raw_advance(
             .await;
     }
     attempt.map_err(|e| e.to_string())?;
+    // A REOPEN MEANS NOBODY HOLDS IT. The column moved to Open but the claim ledger
+    // kept the holder's lease alive: her roster row still listed the card, her
+    // work turns kept acting on it, and the deck offered a card with a live claim
+    // to everyone else (2026-09-12, three coders on a paused round for 2.5 h).
+    // The reopen releases the claim through the same verb the holder would use.
+    if state == CardState::Open {
+        release_live_claim_on_reopen(airc, card_id, via).await;
+    }
     // The CARD's room, never `current_room()` — boards are per-room and the grade
     // subscriber refuses an event with no room.
     let room_id = room_holding_card(airc, card_id)
@@ -1984,6 +1992,43 @@ async fn raw_advance(
     )
     .await;
     Ok(())
+}
+
+
+/// The claim half of a reopen: a card returned to Open carries no hold. Best effort
+/// with a named outcome — a release the ledger refuses (a claim already gone) is a
+/// row, never an error on the verb, and `active_claims` no longer counts a claim
+/// the board does not honour either way.
+async fn release_live_claim_on_reopen(airc: &Arc<Airc>, card_id: WorkCardId, via: &'static str) {
+    let Ok(board) = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await
+        .map(|b| b.snapshot())
+    else {
+        return;
+    };
+    let Some(card) = board.cards.iter().find(|c| c.card_id == card_id) else { return };
+    let (Some(owner), Some(claim_id)) = (card.owner, card.claim_id) else { return };
+    let reason = Some(format!("reopened via {via}: a card returned to Open carries no hold"));
+    match airc
+        .release_work_claim(ReleaseWorkClaim { card_id, claim_id, reason })
+        .await
+    {
+        Ok(_) => crate::probe!(
+            class = "work.reopen.claim_released",
+            card = %card_id.as_uuid(),
+            owner = %owner.as_uuid(),
+            "reopen released the holder's live claim — the card is nobody's"
+        ),
+        Err(error) => crate::probe!(
+            class = "work.reopen.claim_release_refused",
+            card = %card_id.as_uuid(),
+            owner = %owner.as_uuid(),
+            error = %error.to_string(),
+            "reopen could not release the holder's claim — the board-true read in \
+             active_claims stops her counting it as held"
+        ),
+    }
 }
 
 // ─────────────────────────── work/heartbeat ──────────────────────

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1335,18 +1335,55 @@ impl crate::persona::wall_source::WallReader for PersonaAircRuntime {
 impl crate::persona::active_work_source::AircWorkReader for PersonaAircRuntime {
     /// This persona's claimed cards, read from airc's work roster and filtered to
     /// its own peer — grounding reflects what IT owns, board-wide (all rooms).
+    /// Her live claims, BOARD-TRUE. The roster projection lists every claim whose
+    /// lease has not expired — including one on a card an operator moved back to
+    /// Open, or that a pause returned to the deck. 2026-09-12 09:58–12:24Z: three
+    /// coders kept working cards that read Open/no-owner on the board for two and a
+    /// half hours (78 acts) because this read still called them held. A claim is a
+    /// hold only while the board's own card says so (`hold_of` = Held); the rest are
+    /// history, not work.
     async fn active_claims(&self) -> Result<Vec<airc_lib::WorkCard>, AircError> {
         let status = self
             .airc
             .work_roster_status(airc_lib::WorkRosterQuery::default())
             .await?;
         let me = self.airc.peer_id();
-        Ok(status
+        let claims = status
             .rows
             .into_iter()
             .find(|r| r.peer == me)
             .map(|r| r.active_claims)
-            .unwrap_or_default())
+            .unwrap_or_default();
+        if claims.is_empty() {
+            return Ok(claims);
+        }
+        let board = self
+            .airc
+            .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+            .await?
+            .snapshot();
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0 — every lease then reads live, the conservative side
+        let (held, stale): (Vec<_>, Vec<_>) = claims.into_iter().partition(|claim| {
+            board.cards.iter().any(|card| {
+                card.card_id == claim.card_id
+                    && card.owner == Some(me)
+                    && crate::persona::card_holder::hold_of(card, now_ms)
+                        == crate::persona::card_holder::Hold::Held
+                    && !crate::persona::card_holder::claimable_now(card, now_ms)
+            })
+        });
+        for claim in &stale {
+            crate::probe!(
+                class = "persona.claim.not_held_on_board",
+                card = %claim.card_id.as_uuid(),
+                "the roster lists a live claim the board does not honour (Open, lapsed, or \
+                 another owner) — not counted as held work"
+            );
+        }
+        Ok(held)
     }
 }
 

--- a/core/continuum-core/src/persona/work_pull.rs
+++ b/core/continuum-core/src/persona/work_pull.rs
@@ -65,6 +65,22 @@ impl HasCard for crate::cognition::bench_round::NextCard {
     }
 }
 
+
+/// One row per citizen per minute on a no-pull exit: enough to name the reason
+/// every time it changes, never a storm from a 3 s self-tick.
+fn pull_probe_due(peer: Uuid) -> bool {
+    static LAST: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<Uuid, u64>>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    const EVERY_MS: u64 = 60_000;
+    let now = crate::modules::chat::now_ms();
+    let mut last = LAST.lock().unwrap_or_else(|e| e.into_inner()); // unwrap_or_else: a poisoned throttle map still throttles — a probe cadence is never worth a panic
+    let due = last.get(&peer).map_or(true, |t| now.saturating_sub(*t) >= EVERY_MS);
+    if due {
+        last.insert(peer, now);
+    }
+    due
+}
+
 pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConversation) -> PullOutcome {
     let Some(citizen) = conversation.stream_citizen() else {
         return PullOutcome::Nothing;
@@ -139,14 +155,15 @@ pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn P
             in_flight += round.dispatched.saturating_sub(round.settled).saturating_sub(open);
         }
         if lanes > 0 && in_flight >= lanes {
-            static DEFERRED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-            if DEFERRED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % 50 == 0 {
+            // Once a minute per citizen, never sampled: a 1/50 sample on a four-coder
+            // node hid every deferral for an hour (2026-09-12).
+            if pull_probe_due(ctx.identity.peer_id.as_uuid()) {
                 crate::probe!(
                     class = "bench.round.pull_deferred_wip",
                     persona = %ctx.identity.agent_name,
                     in_flight = in_flight as u64,
                     lanes = lanes as u64,
-                    "no pull: the roster already holds as many cards as there are lanes (sampled 1/50)"
+                    "no pull: the roster already holds as many cards as there are lanes"
                 );
             }
             return PullOutcome::DeferredWip;
@@ -160,8 +177,18 @@ pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn P
         candidates
     };
     if candidates.is_empty() {
+        if pull_probe_due(ctx.identity.peer_id.as_uuid()) {
+            crate::probe!(
+                class = "bench.round.pull_none",
+                persona = %ctx.identity.agent_name,
+                reason = if reviews_only { "no_review_cards" } else { "no_candidates" },
+                resident_rooms = resident.len() as u64,
+                "no pull: the decks in the rooms she stands in offer nothing"
+            );
+        }
         return PullOutcome::Nothing;
     }
+    let candidate_count = candidates.len();
     // BOARD TRUTH decides what is takeable: the round tracker knows the deck, the
     // board knows who holds what. One board read per run room per self-tick.
     let now_ms = crate::persona::trace::now_ms();
@@ -191,6 +218,20 @@ pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn P
         }
     }
     let Some(next) = next else {
+        if pull_probe_due(ctx.identity.peer_id.as_uuid()) {
+            let rooms: Vec<String> = claimable_by_room
+                .iter()
+                .map(|(room, open)| format!("{}:{}", &room.to_string()[..8], open.len()))
+                .collect();
+            crate::probe!(
+                class = "bench.round.pull_none",
+                persona = %ctx.identity.agent_name,
+                reason = "none_claimable",
+                candidates = candidate_count as u64,
+                rooms = rooms.join(","),
+                "no pull: every candidate reads unclaimable on its room's board"
+            );
+        }
         return PullOutcome::Nothing;
     };
     let card_id = airc_work::WorkCardId::from_uuid(next.card);


### PR DESCRIPTION
See the commit message. Measured 09:58–12:24Z: three coders acted 78 times on cards that read Open/no-owner; a free coder's pull returned Nothing four times with no row. Receipt after deploy: `bench.round.pull_none` / `pull_deferred_wip` name the reason for every idle tick; a reopened card reads unheld on the holder's next gate; the first pull into multilingual-rust-0536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo