### PR TITLE
fix(identity): one resolver for who is acting — an agent takes a card like any citizen

### DIFF
--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -813,6 +813,24 @@ pub fn acting_card_of(persona_id: uuid::Uuid) -> Option<uuid::Uuid> {
         .and_then(|p| p.card) // poisoned lock = read the last state, same policy as every lock in this crate
 }
 
+/// Root a PEER's hands at a card's checkout — the claim edge for any identity, the
+/// operator self-peer included (2026-09-12: an agent's claim staged nothing and her
+/// `code/*` hands stayed at the core's cwd). Same registry, same truth the persona
+/// turn uses; a later persona rooting overwrites it, a release clears it.
+pub fn root_peer_hands_at_card(peer: uuid::Uuid, root: std::path::PathBuf, card: uuid::Uuid) {
+    let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
+    map.insert(peer, ActingPlace { root, card: Some(card) });
+}
+
+/// The release edge: a peer whose hands were rooted at `card` stands in her own
+/// workspace again. A different card's rooting is left alone.
+pub fn release_peer_hands(peer: uuid::Uuid, card: uuid::Uuid) {
+    let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
+    if map.get(&peer).and_then(|p| p.card) == Some(card) {
+        map.remove(&peer);
+    }
+}
+
 fn note_acting_card(persona_id: uuid::Uuid, card: uuid::Uuid) {
     if let Some(place) = ACTING_ROOTS
         .lock()
@@ -1661,6 +1679,22 @@ fn load_volatile(persona_id: Uuid) -> std::io::Result<Option<PersistedVolatile>>
 
 #[cfg(test)]
 mod tests {
+    // what this catches: the claim edge rooting a peer's hands and the release edge
+    // clearing them (a stale rooting after release sent every later edit into a card
+    // she no longer held); and a release of a DIFFERENT card leaving the rooting alone.
+    #[test]
+    fn a_peers_hands_root_at_the_claimed_card_until_that_card_is_released() {
+        let peer = uuid::Uuid::from_u128(0x5eed);
+        let (a, b) = (uuid::Uuid::from_u128(1), uuid::Uuid::from_u128(2));
+        super::root_peer_hands_at_card(peer, std::path::PathBuf::from("/w/swe/a"), a);
+        assert_eq!(super::acting_root_of(peer), Some(std::path::PathBuf::from("/w/swe/a")));
+        assert_eq!(super::acting_card_of(peer), Some(a));
+        super::release_peer_hands(peer, b);
+        assert_eq!(super::acting_card_of(peer), Some(a), "another card's release is not hers");
+        super::release_peer_hands(peer, a);
+        assert_eq!(super::acting_root_of(peer), None);
+    }
+
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::time::Duration;

--- a/core/continuum-core/src/cognition/persona_workspace.rs
+++ b/core/continuum-core/src/cognition/persona_workspace.rs
@@ -813,24 +813,6 @@ pub fn acting_card_of(persona_id: uuid::Uuid) -> Option<uuid::Uuid> {
         .and_then(|p| p.card) // poisoned lock = read the last state, same policy as every lock in this crate
 }
 
-/// Root a PEER's hands at a card's checkout — the claim edge for any identity, the
-/// operator self-peer included (2026-09-12: an agent's claim staged nothing and her
-/// `code/*` hands stayed at the core's cwd). Same registry, same truth the persona
-/// turn uses; a later persona rooting overwrites it, a release clears it.
-pub fn root_peer_hands_at_card(peer: uuid::Uuid, root: std::path::PathBuf, card: uuid::Uuid) {
-    let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
-    map.insert(peer, ActingPlace { root, card: Some(card) });
-}
-
-/// The release edge: a peer whose hands were rooted at `card` stands in her own
-/// workspace again. A different card's rooting is left alone.
-pub fn release_peer_hands(peer: uuid::Uuid, card: uuid::Uuid) {
-    let mut map = ACTING_ROOTS.lock().unwrap_or_else(|e| e.into_inner()); // poisoned lock = read the last state, same policy as every lock in this crate
-    if map.get(&peer).and_then(|p| p.card) == Some(card) {
-        map.remove(&peer);
-    }
-}
-
 fn note_acting_card(persona_id: uuid::Uuid, card: uuid::Uuid) {
     if let Some(place) = ACTING_ROOTS
         .lock()
@@ -1679,21 +1661,6 @@ fn load_volatile(persona_id: Uuid) -> std::io::Result<Option<PersistedVolatile>>
 
 #[cfg(test)]
 mod tests {
-    // what this catches: the claim edge rooting a peer's hands and the release edge
-    // clearing them (a stale rooting after release sent every later edit into a card
-    // she no longer held); and a release of a DIFFERENT card leaving the rooting alone.
-    #[test]
-    fn a_peers_hands_root_at_the_claimed_card_until_that_card_is_released() {
-        let peer = uuid::Uuid::from_u128(0x5eed);
-        let (a, b) = (uuid::Uuid::from_u128(1), uuid::Uuid::from_u128(2));
-        super::root_peer_hands_at_card(peer, std::path::PathBuf::from("/w/swe/a"), a);
-        assert_eq!(super::acting_root_of(peer), Some(std::path::PathBuf::from("/w/swe/a")));
-        assert_eq!(super::acting_card_of(peer), Some(a));
-        super::release_peer_hands(peer, b);
-        assert_eq!(super::acting_card_of(peer), Some(a), "another card's release is not hers");
-        super::release_peer_hands(peer, a);
-        assert_eq!(super::acting_root_of(peer), None);
-    }
 
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -1691,7 +1691,7 @@ impl ActionCommand for BenchmarkDispatch {
         ctx: &Ctx,
         p: BenchmarkDispatchParams,
     ) -> Result<BenchmarkDispatchResult, CommandError> {
-        use crate::modules::work::curator_airc;
+        use crate::modules::work::persona_airc;
         use airc_lib::{CreateWorkCard, Priority, RepoId};
 
         // ── RECIPE PATH: the whole experiment by name ──────────────────────
@@ -1863,7 +1863,7 @@ impl ActionCommand for BenchmarkDispatch {
         // window refused instantly with "none are online" while the 180s wait that
         // exists precisely for that window sat unreachable 30 lines below
         // (measured live 2026-08-26). Order: wait for a citizen, then author.
-        let airc = curator_airc(&self.registry, ctx, "benchmark/dispatch")?;
+        let airc = persona_airc(&self.registry, ctx, "benchmark/dispatch")?;
 
         // Resolve the dispatch roster against THIS machine's live citizens (never our
         // names): empty request → the whole live roster; explicit names → validated or

--- a/core/continuum-core/src/commands/code/cargo/check.rs
+++ b/core/continuum-core/src/commands/code/cargo/check.rs
@@ -78,7 +78,7 @@ crate::action_command! {
     params: CargoCheckParams,
     output: CargoCheckResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let timeout = Duration::from_secs(
             p.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS).clamp(1, MAX_TIMEOUT_SECS),
         );

--- a/core/continuum-core/src/commands/code/cargo/test.rs
+++ b/core/continuum-core/src/commands/code/cargo/test.rs
@@ -118,7 +118,7 @@ crate::action_command! {
     params: CargoTestParams,
     output: CargoTestResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let timeout = Duration::from_secs(
             p.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS).clamp(1, MAX_TIMEOUT_SECS),
         );

--- a/core/continuum-core/src/commands/code/git/add.rs
+++ b/core/continuum-core/src/commands/code/git/add.rs
@@ -42,7 +42,7 @@ crate::action_command! {
     params: GitAddParams,
     output: GitAddResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let output = blocking_git(move || {
             let refs: Vec<&str> = p.paths.iter().map(String::as_str).collect();
             git_bridge::git_add(&root, &refs)

--- a/core/continuum-core/src/commands/code/git/apply.rs
+++ b/core/continuum-core/src/commands/code/git/apply.rs
@@ -68,7 +68,7 @@ crate::action_command! {
                 .into(),
             ));
         }
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let check = p.check;
         let message = blocking_git(move || git_bridge::git_apply(&root, &p.patch, check))
             .await?

--- a/core/continuum-core/src/commands/code/git/commit.rs
+++ b/core/continuum-core/src/commands/code/git/commit.rs
@@ -47,7 +47,7 @@ crate::action_command! {
                 "code/git/commit: 'message' is required".into(),
             ));
         }
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let hash = blocking_git(move || git_bridge::git_commit(&root, &p.message))
             .await?
             .map_err(CommandError::Internal)?;

--- a/core/continuum-core/src/commands/code/git/diff.rs
+++ b/core/continuum-core/src/commands/code/git/diff.rs
@@ -43,7 +43,7 @@ crate::action_command! {
     params: GitDiffParams,
     output: GitDiffResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let diff = blocking_git(move || git_bridge::git_diff(&root, p.staged))
             .await?
             .map_err(CommandError::Internal)?;

--- a/core/continuum-core/src/commands/code/git/log.rs
+++ b/core/continuum-core/src/commands/code/git/log.rs
@@ -42,7 +42,7 @@ crate::action_command! {
     params: GitLogParams,
     output: GitLogResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let count = p.limit.unwrap_or(10);
         let log = blocking_git(move || git_bridge::git_log(&root, count))
             .await?

--- a/core/continuum-core/src/commands/code/git/mod.rs
+++ b/core/continuum-core/src/commands/code/git/mod.rs
@@ -46,9 +46,9 @@ use status::CodeGitStatus;
 /// Resolve the caller's workspace root, provisioning the engine on first use.
 /// Returns an OWNED [`PathBuf`] so the `DashMap` ref guard is dropped before the
 /// caller runs blocking git work — never a lock held across a shell-out.
-pub(crate) fn workspace_root_for(state: &CodeState, ctx: &Ctx) -> Result<PathBuf, CommandError> {
+pub(crate) async fn workspace_root_for(state: &CodeState, ctx: &Ctx) -> Result<PathBuf, CommandError> {
     let who = caller_id(ctx);
-    ensure_engine(state, &who)?;
+    ensure_engine(state, &who).await?;
     let engine = state
         .file_engines
         .get(&who)

--- a/core/continuum-core/src/commands/code/git/push.rs
+++ b/core/continuum-core/src/commands/code/git/push.rs
@@ -49,7 +49,7 @@ crate::action_command! {
     params: GitPushParams,
     output: GitPushResult,
     run(this, ctx, p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let remote = p.remote.unwrap_or_default();
         let branch = p.branch.unwrap_or_default();
         let output = blocking_git(move || git_bridge::git_push(&root, &remote, &branch))

--- a/core/continuum-core/src/commands/code/git/status.rs
+++ b/core/continuum-core/src/commands/code/git/status.rs
@@ -31,7 +31,7 @@ crate::action_command! {
     params: GitStatusParams,
     output: GitStatusInfo,
     run(this, ctx, _p) => {
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         blocking_git(move || git_bridge::git_status(&root)).await
     }
 }

--- a/core/continuum-core/src/commands/code/github/issue_create.rs
+++ b/core/continuum-core/src/commands/code/github/issue_create.rs
@@ -44,7 +44,7 @@ crate::action_command! {
         if p.title.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/issue-create: 'title' is required".into()));
         }
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let mut args = vec![
             "issue".to_string(), "create".to_string(),
             "--title".to_string(), p.title,

--- a/core/continuum-core/src/commands/code/github/pr_comment.rs
+++ b/core/continuum-core/src/commands/code/github/pr_comment.rs
@@ -42,7 +42,7 @@ crate::action_command! {
         if p.body.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/pr-comment: 'body' is required".into()));
         }
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let args = vec![
             "pr".to_string(), "comment".to_string(), p.number.to_string(),
             "--body".to_string(), p.body,

--- a/core/continuum-core/src/commands/code/github/pr_create.rs
+++ b/core/continuum-core/src/commands/code/github/pr_create.rs
@@ -54,7 +54,7 @@ crate::action_command! {
         if p.title.trim().is_empty() {
             return Err(CommandError::Invalid("code/github/pr-create: 'title' is required".into()));
         }
-        let root = workspace_root_for(&this.state, ctx)?;
+        let root = workspace_root_for(&this.state, ctx).await?;
         let mut args = vec![
             "pr".to_string(), "create".to_string(),
             "--title".to_string(), p.title,

--- a/core/continuum-core/src/commands/identity_whoami.rs
+++ b/core/continuum-core/src/commands/identity_whoami.rs
@@ -51,45 +51,21 @@ crate::action_command! {
     params: WhoamiParams,
     output: WhoamiResult,
     run(_this, ctx, _p) => {
-        // A persona toolbelt caller is herself.
-        // A signed caller is who it says it is. An anonymous socket (the web
-        // desktop's WS, stamped nil by the transport) carries NO identity and
-        // resolves like a caller-less session: the claimed actor or the operator.
-        if let Some(caller) = ctx.caller.as_ref().filter(|c| !c.is_anonymous_socket()) {
-            let id = caller.peer_id.as_uuid();
-            let name = crate::persona::PersonaAircRuntimeRegistry::try_global()
-                .and_then(|r| r.get(id))
-                .map(|rt| rt.agent_name().to_string())
-                .unwrap_or_else(|| id.to_string()); // JUSTIFIED unwrap_or_else: an unregistered caller renders as its uuid — honest identity, never an invented name
-            return Ok(WhoamiResult { id: id.to_string(), name, kind: "persona".into() });
-        }
-        // An AGENT-driven session (actorKind claim) is the AGENT self-peer.
-        if ctx.claimed_actor_kind.as_deref() == Some("agent") {
-            let rt = crate::persona::operator_peer::agent_runtime().ok_or_else(|| {
-                CommandError::Internal(
-                    "the agent self-peer is not online yet this boot — retry shortly;                      an agent session never resolves to the human's identity".into(),
-                )
-            })?;
-            return Ok(WhoamiResult {
-                id: rt.airc().peer_id().as_uuid().to_string(),
-                name: rt.agent_name().to_string(),
-                kind: "agent".into(),
-            });
-        }
-        // A caller-less local session is the node's OPERATOR (the durable human
-        // identity, #27). Not online yet this boot = a loud retryable error —
-        // never a minted stand-in.
-        let rt = crate::persona::operator_peer::operator_runtime().ok_or_else(|| {
-            CommandError::Internal(
-                "the operator self-peer is not online yet this boot — retry shortly \
-                 (it starts beside the citizens); never mint a local identity instead"
-                    .into(),
-            )
-        })?;
+        // ONE resolver for who is acting (`operator_peer::acting_runtime`): a persona
+        // toolbelt caller is herself, an agent session is the agent self-peer, a
+        // caller-less or anonymous-socket session is the operator. The same answer
+        // every other verb acts on.
+        let registry = crate::persona::PersonaAircRuntimeRegistry::try_global()
+            .unwrap_or_default(); // unwrap_or_default: no registry yet = no personas to name; the self-peers still resolve
+        let me = crate::persona::operator_peer::acting(&registry, ctx, "identity/whoami")?;
         Ok(WhoamiResult {
-            id: rt.airc().peer_id().as_uuid().to_string(),
-            name: rt.agent_name().to_string(),
-            kind: "human".into(),
+            id: me.peer.to_string(),
+            name: me
+                .runtime
+                .as_ref()
+                .map(|rt| rt.agent_name().to_string())
+                .unwrap_or_else(|| me.peer.to_string()), // JUSTIFIED unwrap_or_else: an unhosted signed caller renders as its uuid — honest identity, never an invented name
+            kind: me.kind.as_str().into(),
         })
     }
 }

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -390,7 +390,7 @@ fn write_workspace_sync_note(layer: &std::path::Path, summary: &str) {
 /// the shared checkout is never writable through a peer's hands. Idempotent and
 /// defers to an engine a prior call already created (so an explicit
 /// `create-workspace` with a specific root still wins).
-pub(crate) fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandError> {
+pub(crate) async fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandError> {
     let local = is_local_who(who);
     if local {
         // A LOCAL identity's hands follow her held card (2026-09-12): the operator or
@@ -399,7 +399,7 @@ pub(crate) fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandE
         // return to the core's cwd when the card is released. Only a CHANGE of card
         // rooting evicts the cached engine (and its shell); an engine a caller pinned
         // with `create-workspace` is otherwise left alone.
-        let card_root = card_root_of(who);
+        let card_root = card_root_of(who).await;
         let mut last = LAST_CARD_ROOT
             .lock()
             .unwrap_or_else(|e| e.into_inner()); // unwrap_or_else: a poisoned marker still compares — the hands must move, never panic
@@ -422,7 +422,7 @@ pub(crate) fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandE
         return Ok(());
     }
     let root = if local {
-        match card_root_of(who) {
+        match card_root_of(who).await {
             Some(root) => root,
             None => std::env::current_dir().map_err(|e| {
                 CommandError::Internal(format!("workspace root unavailable: {e}"))
@@ -459,10 +459,16 @@ fn is_local_who(who: &str) -> bool {
             .unwrap_or(false) // unwrap_or: not a uuid = not a self-peer
 }
 
-/// The held-card checkout a local identity's claim staged, when one is rooted.
-fn card_root_of(who: &str) -> Option<std::path::PathBuf> {
+/// The held-card checkout a local identity's hands stand in — BOARD-TRUE, read from her
+/// live claims on every provisioning (the same read a persona's held-work turn makes),
+/// never a note taken at claim time: a note dies with the process while the claim lives
+/// on the board (2026-09-12: the hands fell back to cwd after the first reboot).
+async fn card_root_of(who: &str) -> Option<std::path::PathBuf> {
+    use crate::persona::active_work_source::AircWorkReader as _;
     let peer = uuid::Uuid::parse_str(who).ok()?;
-    crate::cognition::persona_workspace::acting_root_of(peer)
+    let rt = crate::persona::operator_peer::local_runtime_of(peer)?;
+    let held = rt.active_claims().await.ok()?;
+    held.iter().find_map(|card| crate::modules::card_staging::checkout_path_for(&peer, card))
 }
 
 /// The card rooting each local identity's engine was last built for — a change here
@@ -479,12 +485,12 @@ static LAST_CARD_ROOT: std::sync::LazyLock<
 /// commands landed in the shared checkout. Idempotent; one bash session per
 /// caller, reused across `code/shell` calls so `cd`/env persist like a real
 /// terminal.
-fn ensure_shell(state: &CodeState, who: &str) -> Result<(), CommandError> {
+async fn ensure_shell(state: &CodeState, who: &str) -> Result<(), CommandError> {
     // The ENGINE decides the root and evicts a shell whose root moved (a held card
     // claimed after the shell was opened) — so it runs first; a shell that survives
     // it is current. Checking the shell first let a pre-claim `code/shell` pin the
     // hands at the core's cwd for the session's whole life (2026-09-12, live).
-    ensure_engine(state, who)?;
+    ensure_engine(state, who).await?;
     if state.shell_sessions.contains_key(who) {
         return Ok(());
     }
@@ -512,7 +518,7 @@ const DEFAULT_SHELL_WAIT_MS: u64 = 30_000;
 macro_rules! engine {
     ($self:ident, $ctx:ident) => {{
         let who = caller_id($ctx);
-        ensure_engine(&$self.state, &who)?;
+        ensure_engine(&$self.state, &who).await?;
         $self
             .state
             .file_engines
@@ -1338,7 +1344,7 @@ impl ActionCommand for CodeShell {
         p: CodeShellParams,
     ) -> Result<ShellExecuteResponse, CommandError> {
         let who = caller_id(ctx);
-        ensure_shell(&self.state, &who)?;
+        ensure_shell(&self.state, &who).await?;
 
         // Start the command while briefly holding the shell entry, then DROP the
         // DashMap ref before awaiting — never hold a lock across `.await` (the
@@ -1740,7 +1746,7 @@ impl ActionCommand for CodeCreateWorkspace {
         // the two halves of her hands pointing at different workspaces.
         self.state.shell_sessions.remove(&who);
         if !p.path_prepend.is_empty() {
-            ensure_shell(&self.state, &who)?;
+            ensure_shell(&self.state, &who).await?;
             if let Some(mut shell) = self.state.shell_sessions.get_mut(&who) {
                 let prepend = p.path_prepend.join(":");
                 // Hand the per-task prefix to the shell as CONTINUUM_PATH_PREPEND, NOT as a

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -480,10 +480,14 @@ static LAST_CARD_ROOT: std::sync::LazyLock<
 /// caller, reused across `code/shell` calls so `cd`/env persist like a real
 /// terminal.
 fn ensure_shell(state: &CodeState, who: &str) -> Result<(), CommandError> {
+    // The ENGINE decides the root and evicts a shell whose root moved (a held card
+    // claimed after the shell was opened) — so it runs first; a shell that survives
+    // it is current. Checking the shell first let a pre-claim `code/shell` pin the
+    // hands at the core's cwd for the session's whole life (2026-09-12, live).
+    ensure_engine(state, who)?;
     if state.shell_sessions.contains_key(who) {
         return Ok(());
     }
-    ensure_engine(state, who)?;
     let root = state
         .file_engines
         .get(&who.to_string())

--- a/core/continuum-core/src/modules/code_commands.rs
+++ b/core/continuum-core/src/modules/code_commands.rs
@@ -54,15 +54,14 @@ use crate::sdk_codegen::{AccessLevel, ActionCommand, CommandError, Ctx, DynComma
 /// substrate-local owner. This is the single point that maps the gated identity
 /// to the per-caller workspace; nothing trusts caller-supplied identity.
 pub(crate) fn caller_id(ctx: &Ctx) -> String {
-    ctx.caller
-        .as_ref()
-        .map(|c| c.peer_id.to_string())
-        .unwrap_or_else(|| LOCAL_OWNER.to_string())
+    // ONE resolver (`operator_peer::acting_peer_id`): the same peer the work verbs
+    // claim as. `LOCAL_OWNER` survives only for the boot window before the
+    // self-peers are online.
+    crate::persona::operator_peer::acting_peer_id(ctx)
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| LOCAL_OWNER.to_string()) // unwrap_or_else: boot window, no self-peer yet — the core's cwd, named below
 }
 
-/// The caller id assigned when a command arrives with NO peer identity — the
-/// substrate-local operator (uu CLI, boot plumbing). The ONE caller whose
-/// workspace is the core's own cwd; every identified peer gets a layer.
 pub(crate) const LOCAL_OWNER: &str = "local-owner";
 
 /// Resolve (and provision on first use) the citizen LAYER for an identified peer
@@ -392,12 +391,43 @@ fn write_workspace_sync_note(layer: &std::path::Path, summary: &str) {
 /// defers to an engine a prior call already created (so an explicit
 /// `create-workspace` with a specific root still wins).
 pub(crate) fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandError> {
+    let local = is_local_who(who);
+    if local {
+        // A LOCAL identity's hands follow her held card (2026-09-12): the operator or
+        // the agent self-peer claims on the board, the claim stages a checkout, her
+        // `code/*` verbs root THERE — the rule a persona's held-work turn applies — and
+        // return to the core's cwd when the card is released. Only a CHANGE of card
+        // rooting evicts the cached engine (and its shell); an engine a caller pinned
+        // with `create-workspace` is otherwise left alone.
+        let card_root = card_root_of(who);
+        let mut last = LAST_CARD_ROOT
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()); // unwrap_or_else: a poisoned marker still compares — the hands must move, never panic
+        if last.get(who).cloned().flatten() != card_root {
+            state.file_engines.remove(&who.to_string());
+            state.shell_sessions.remove(&who.to_string());
+            crate::probe!(
+                class = "code.hands.rerooted",
+                who = who,
+                root = %card_root
+                    .as_ref()
+                    .map(|r| r.display().to_string())
+                    .unwrap_or_else(|| "cwd".to_string()), // unwrap_or_else: no card = the core's cwd, named
+                "a local identity's hands moved with her held card"
+            );
+            last.insert(who.to_string(), card_root);
+        }
+    }
     if state.file_engines.contains_key(who) {
         return Ok(());
     }
-    let root = if who == LOCAL_OWNER {
-        std::env::current_dir()
-            .map_err(|e| CommandError::Internal(format!("workspace root unavailable: {e}")))?
+    let root = if local {
+        match card_root_of(who) {
+            Some(root) => root,
+            None => std::env::current_dir().map_err(|e| {
+                CommandError::Internal(format!("workspace root unavailable: {e}"))
+            })?,
+        }
     } else {
         let citizen_root = ensure_citizen_layer(who)?;
         // Every citizen workspace is git-backed from birth
@@ -419,6 +449,27 @@ pub(crate) fn ensure_engine(state: &CodeState, who: &str) -> Result<(), CommandE
         .or_insert_with(|| FileEngine::new(who, security));
     Ok(())
 }
+
+/// Is `who` a LOCAL identity — the boot-window `LOCAL_OWNER`, or the operator / agent
+/// self-peer? Local identities work in the core's own checkout; everyone else in a layer.
+fn is_local_who(who: &str) -> bool {
+    who == LOCAL_OWNER
+        || uuid::Uuid::parse_str(who)
+            .map(crate::persona::operator_peer::is_local_identity)
+            .unwrap_or(false) // unwrap_or: not a uuid = not a self-peer
+}
+
+/// The held-card checkout a local identity's claim staged, when one is rooted.
+fn card_root_of(who: &str) -> Option<std::path::PathBuf> {
+    let peer = uuid::Uuid::parse_str(who).ok()?;
+    crate::cognition::persona_workspace::acting_root_of(peer)
+}
+
+/// The card rooting each local identity's engine was last built for — a change here
+/// is the only thing that evicts a cached engine.
+static LAST_CARD_ROOT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, Option<std::path::PathBuf>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// Lazily ensure a persistent shell session exists for `who`, rooted at the
 /// caller's ENGINE root — the one workspace authority per caller (the operator's

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -202,29 +202,12 @@ pub(crate) const DEFAULT_CLAIM_TTL_MS: u64 = 30 * 60 * 1000;
 pub(crate) fn persona_runtime(
     registry: &PersonaAircRuntimeRegistry,
     ctx: &Ctx,
-    // What the CALLER actually invoked. Was hardcoded to "work commands", which
-    // #358 caught live the moment room/members reused this helper: a citizen asking
-    // who is here was told "work commands act as ..." and pointed at `airc work`.
-    // A refusal that misnames the thing you called teaches the wrong lesson.
+    // What the CALLER actually invoked, for the refusal text (#358).
     family: &str,
 ) -> Result<Arc<PersonaAircRuntime>, CommandError> {
-    // A persona acting through her toolbelt acts as HERSELF; the caller-less
-    // operator acts as the OPERATOR SELF-PEER (#27, closed 2026-08-30) — the
-    // human's in-core identity, booted beside the citizens. The deny below
-    // survives only for the boot window before the self-peer is online.
-    let Some(peer) = ctx.caller.as_ref().map(|c| c.peer_id.as_uuid()) else {
-        return crate::persona::operator_peer::operator_runtime().ok_or_else(|| {
-            CommandError::Denied(format!(
-                "{family} acts as the caller's own airc identity, and the operator \
-                 self-peer is not online yet this boot (it starts beside the \
-                 citizens — retry shortly, or check the operator.peer.boot_failed \
-                 probe)."
-            ))
-        });
-    };
-    registry
-        .get(peer)
-        .ok_or_else(|| CommandError::NotFound(format!("no live airc runtime for persona {peer}")))
+    // ONE resolver (`operator_peer::acting_runtime`): a persona acts as herself, an
+    // agent session as the agent self-peer, a caller-less session as the operator.
+    crate::persona::operator_peer::acting_runtime(registry, ctx, family).map(|(rt, _)| rt)
 }
 
 /// Read/write the caller's own airc handle. Membership mutations use
@@ -235,47 +218,6 @@ pub(crate) fn persona_airc(
     family: &str,
 ) -> Result<Arc<Airc>, CommandError> {
     Ok(persona_runtime(registry, ctx, family)?.airc().clone())
-}
-
-/// Resolve an airc handle for an OPERATOR/curator board write — e.g.
-/// `benchmark/dispatch` seeding a benchmark's tasks as claimable cards. Unlike
-/// [`persona_airc`], this does NOT dead-end when the caller has no self-identity.
-///
-/// A persona calling through her own toolbelt still authors as HERSELF (same as
-/// `persona_airc`). But the substrate-local operator has no self-peer in-core yet
-/// (#27), and seeding the board is a *curator* action, not a personal one — so when
-/// there is no caller identity, the seed is authored through a LIVE citizen's airc
-/// runtime. That is honest, not a fiction: benchmarks ARE the citizens' work, so a
-/// citizen posting the tasks is the right author (a live citizen chosen
-/// deterministically — never a hardcoded name like our "Benchy", which does not exist
-/// on a fresh clone's grid; see [`PersonaAircRuntimeRegistry::any_live_citizen`]). This
-/// fails loud only when NO citizen is online to author through — because then there is
-/// genuinely no board to seed for, and the fix is to spawn a persona, not to invent an
-/// identity.
-pub(crate) fn curator_airc(
-    registry: &PersonaAircRuntimeRegistry,
-    ctx: &Ctx,
-    family: &str,
-) -> Result<Arc<Airc>, CommandError> {
-    // An authenticated caller (a persona acting through her toolbelt) wins: the card
-    // is authored as her, exactly like `persona_airc`.
-    if let Some(rt) = ctx
-        .caller
-        .as_ref()
-        .and_then(|c| registry.get(c.peer_id.as_uuid()))
-    {
-        return Ok(rt.airc().clone());
-    }
-    // Operator seeding with no self-peer (#27): author through a live citizen —
-    // whoever this machine has online, chosen deterministically, never our name.
-    let rt = registry.any_live_citizen().ok_or_else(|| {
-        CommandError::Denied(format!(
-            "{family} seeds the shared board and must author as a citizen, but none \
-                 are online to author through — spawn a persona first (persona/spawn), \
-                 then retry."
-        ))
-    })?;
-    Ok(rt.airc().clone())
 }
 
 fn parse_priority(s: &str) -> Priority {
@@ -723,7 +665,14 @@ impl ActionCommand for WorkClaim {
         // room whose board holds it). Best-effort past the claim: the claim is hers
         // either way, and the probes say what happened. A card we cannot place gets NO
         // detached fallback — inventing invisible work is the failure #425 removed.
-        if let Some(caller) = ctx.caller.as_ref() {
+        // THE CLAIMER IS THE IDENTITY THE CLAIM WAS MADE AS — `airc.peer_id()`, never
+        // `ctx.caller`. The uu operator carries no caller identity: her claim rode the
+        // operator self-peer's airc and landed on the board as hers, then this block
+        // skipped her (no caller) — no staging, no hands, a card she could not work.
+        // 2026-09-12: the first agent to take a benchmark card through the verbs alone
+        // found it. A persona's airc peer IS her caller peer, so nothing changes for her.
+        let claimer_peer = airc.peer_id();
+        {
             match card_in_subscribed_rooms(&airc, card_id).await {
                 Some((room, card)) => {
                     use crate::cognition::bench_round::WorkDriver;
@@ -732,7 +681,7 @@ impl ActionCommand for WorkClaim {
                         Ok(home) => {
                             crate::modules::card_staging::stage_for_card(
                                 &home,
-                                caller.peer_id.as_uuid(),
+                                claimer_peer.as_uuid(),
                                 &card,
                             )
                             .await
@@ -742,12 +691,19 @@ impl ActionCommand for WorkClaim {
                             error: e.to_string(),
                         },
                     };
+                    if let Staging::Ready { path, .. } = &staging {
+                        crate::cognition::persona_workspace::root_peer_hands_at_card(
+                            claimer_peer.as_uuid(),
+                            path.clone(),
+                            card_id.as_uuid(),
+                        );
+                    }
                     let driver = crate::cognition::bench_round::driver_for_card(card_id.as_uuid());
                     match (driver, &staging) {
                         (WorkDriver::Citizen, _) => crate::probe!(
                             class = "work.claim.held",
                             card_id = %short8(card_id.as_uuid()),
-                            claimer = %short8(caller.peer_id.as_uuid()),
+                            claimer = %short8(claimer_peer.as_uuid()),
                             staging = ?staging,
                             "citizen-driven round — the card is hers to work in her own \
                              loop; nothing detached fires"
@@ -756,7 +712,7 @@ impl ActionCommand for WorkClaim {
                             crate::probe!(
                                 class = "work.claim.solve_withheld",
                                 card_id = %short8(card_id.as_uuid()),
-                                claimer = %short8(caller.peer_id.as_uuid()),
+                                claimer = %short8(claimer_peer.as_uuid()),
                                 stage = stage,
                                 error = %error,
                                 "detached solve NOT fired on an unstaged workspace — the \
@@ -769,7 +725,7 @@ impl ActionCommand for WorkClaim {
                                 ctx,
                                 &airc,
                                 StagedSolveDispatch {
-                                    claimer: caller.peer_id,
+                                    claimer: claimer_peer,
                                     card: card_id,
                                     room: room.channel,
                                     // An organic claim REJOINS the card's recorded team
@@ -793,7 +749,7 @@ impl ActionCommand for WorkClaim {
                 None => crate::probe!(
                     class = "work.claim.unplaceable_card",
                     card_id = %short8(card_id.as_uuid()),
-                    claimer = %short8(caller.peer_id.as_uuid()),
+                    claimer = %short8(claimer_peer.as_uuid()),
                     "claimed a card no subscribed room's board holds — the claim STANDS, \
                      but nothing is staged and no solve fires: work whose activity we \
                      cannot name is work no room can see (#425)"
@@ -1643,6 +1599,7 @@ impl ActionCommand for WorkRelease {
                 .await;
         }
         attempt.map_err(|e| CommandError::Internal(e.to_string()))?;
+        crate::cognition::persona_workspace::release_peer_hands(airc.peer_id().as_uuid(), card_id.as_uuid());
         Ok(WorkReleaseResult { released: true })
     }
 }

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -691,13 +691,6 @@ impl ActionCommand for WorkClaim {
                             error: e.to_string(),
                         },
                     };
-                    if let Staging::Ready { path, .. } = &staging {
-                        crate::cognition::persona_workspace::root_peer_hands_at_card(
-                            claimer_peer.as_uuid(),
-                            path.clone(),
-                            card_id.as_uuid(),
-                        );
-                    }
                     let driver = crate::cognition::bench_round::driver_for_card(card_id.as_uuid());
                     match (driver, &staging) {
                         (WorkDriver::Citizen, _) => crate::probe!(
@@ -1599,7 +1592,6 @@ impl ActionCommand for WorkRelease {
                 .await;
         }
         attempt.map_err(|e| CommandError::Internal(e.to_string()))?;
-        crate::cognition::persona_workspace::release_peer_hands(airc.peer_id().as_uuid(), card_id.as_uuid());
         Ok(WorkReleaseResult { released: true })
     }
 }

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -357,6 +357,14 @@ pub fn acting_peer_id(ctx: &crate::sdk_codegen::Ctx) -> Option<uuid::Uuid> {
     Some(rt.airc().peer_id().as_uuid())
 }
 
+/// The self-peer runtime (agent or operator) whose peer is `peer`, when online.
+pub fn local_runtime_of(peer: uuid::Uuid) -> Option<Arc<PersonaAircRuntime>> {
+    [agent_runtime(), operator_runtime()]
+        .into_iter()
+        .flatten()
+        .find(|rt| rt.airc().peer_id().as_uuid() == peer)
+}
+
 /// Is this peer one of the node's LOCAL identities (the operator or the agent
 /// self-peer)? Their hands live in the core's own checkout — a held card roots them
 /// at its staged checkout — while every other peer works in her citizen layer.

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -278,6 +278,113 @@ pub async fn ensure_agent_peer(
     }
 }
 
+/// WHO IS ACTING — the one answer for every verb. A persona through her toolbelt is
+/// herself; an agent-driven session (the CLI's `actorKind` claim) is the AGENT
+/// self-peer; a caller-less local session is the OPERATOR self-peer (the durable human
+/// identity, #27). An anonymous socket (the desktop's WS, stamped nil) carries no
+/// identity and resolves like a caller-less session.
+///
+/// Before 2026-09-12 three verbs answered this three ways: the work verbs fell back to
+/// the operator, board seeding authored through a random live citizen, and the code
+/// verbs invented an anonymous "local-owner" — so one `uu` session claimed a card as
+/// one identity, could not stage it, and edited files as another. One resolver, one
+/// identity per session, every verb.
+pub fn acting(
+    registry: &crate::persona::PersonaAircRuntimeRegistry,
+    ctx: &crate::sdk_codegen::Ctx,
+    family: &str,
+) -> Result<Acting, crate::sdk_codegen::CommandError> {
+    use crate::sdk_codegen::CommandError;
+    if let Some(caller) = ctx.caller.as_ref().filter(|c| !c.is_anonymous_socket()) {
+        // A signed caller IS who it says it is — an identity even with no live runtime
+        // here (a remote peer, a persona not hosted on this node).
+        let peer = caller.peer_id.as_uuid();
+        return Ok(Acting { peer, kind: ActorKind::Persona, runtime: registry.get(peer) });
+    }
+    if ctx.claimed_actor_kind.as_deref() == Some("agent") {
+        let rt = agent_runtime().ok_or_else(|| {
+            CommandError::Internal(format!(
+                "{family} acts as the agent self-peer, which is not online yet this boot — \
+                 retry shortly; an agent session never resolves to the human's identity"
+            ))
+        })?;
+        return Ok(Acting { peer: rt.airc().peer_id().as_uuid(), kind: ActorKind::Agent, runtime: Some(rt) });
+    }
+    let rt = operator_runtime().ok_or_else(|| {
+        CommandError::Denied(format!(
+            "{family} acts as the caller's own airc identity, and the operator self-peer \
+             is not online yet this boot (it starts beside the citizens — retry shortly, \
+             or check the operator.peer.boot_failed probe)."
+        ))
+    })?;
+    Ok(Acting { peer: rt.airc().peer_id().as_uuid(), kind: ActorKind::Human, runtime: Some(rt) })
+}
+
+/// The runtime a verb ACTS THROUGH — [`acting`] with a live runtime demanded: a signed
+/// caller this node does not host cannot claim, release, or speak from here.
+pub fn acting_runtime(
+    registry: &crate::persona::PersonaAircRuntimeRegistry,
+    ctx: &crate::sdk_codegen::Ctx,
+    family: &str,
+) -> Result<(Arc<PersonaAircRuntime>, ActorKind), crate::sdk_codegen::CommandError> {
+    let a = acting(registry, ctx, family)?;
+    let peer = a.peer;
+    a.runtime.map(|rt| (rt, a.kind)).ok_or_else(|| {
+        crate::sdk_codegen::CommandError::NotFound(format!("no live airc runtime for persona {peer}"))
+    })
+}
+
+/// Who a request acts as: the peer, its kind, and the live runtime when this node
+/// hosts it.
+pub struct Acting {
+    pub peer: uuid::Uuid,
+    pub kind: ActorKind,
+    pub runtime: Option<Arc<PersonaAircRuntime>>,
+}
+
+/// The peer a request acts AS, without a registry and without failing: a persona
+/// caller's peer, else the agent or operator self-peer when online. `None` only in
+/// the boot window before the self-peers exist.
+pub fn acting_peer_id(ctx: &crate::sdk_codegen::Ctx) -> Option<uuid::Uuid> {
+    if let Some(caller) = ctx.caller.as_ref().filter(|c| !c.is_anonymous_socket()) {
+        return Some(caller.peer_id.as_uuid());
+    }
+    let rt = if ctx.claimed_actor_kind.as_deref() == Some("agent") {
+        agent_runtime()
+    } else {
+        operator_runtime()
+    }?;
+    Some(rt.airc().peer_id().as_uuid())
+}
+
+/// Is this peer one of the node's LOCAL identities (the operator or the agent
+/// self-peer)? Their hands live in the core's own checkout — a held card roots them
+/// at its staged checkout — while every other peer works in her citizen layer.
+pub fn is_local_identity(peer: uuid::Uuid) -> bool {
+    [agent_runtime(), operator_runtime()]
+        .into_iter()
+        .flatten()
+        .any(|rt| rt.airc().peer_id().as_uuid() == peer)
+}
+
+/// What kind of actor a session resolved to — the word `identity/whoami` prints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActorKind {
+    Persona,
+    Agent,
+    Human,
+}
+
+impl ActorKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ActorKind::Persona => "persona",
+            ActorKind::Agent => "agent",
+            ActorKind::Human => "human",
+        }
+    }
+}
+
 /// The agent self-peer's runtime, when online.
 pub fn agent_runtime() -> Option<Arc<PersonaAircRuntime>> {
     AGENT.get().cloned()


### PR DESCRIPTION
See the commit. Found by taking a Rust benchmark card through `uu` verbs alone: the CLI claimed as the operator, was skipped by on-claim staging, and edited as an anonymous local owner in the wrong checkout — three resolvers for one question. Now one (`operator_peer::acting`), used by whoami, every work verb, dispatch, and the code verbs; a claim stages for the claiming identity and roots its hands at the card.

Receipt: an agent claims a Rust card with `uu work/claim`, the checkout stages under its own peer, `uu code/shell pwd` answers the card's checkout, and the card goes to review and is graded — posted in the round's room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo