### PR TITLE
fix(recipe): a round card carries its instance's own repo, and a failed birth archives its room

### DIFF
--- a/core/continuum-core/src/commands/agent/solve.rs
+++ b/core/continuum-core/src/commands/agent/solve.rs
@@ -1696,6 +1696,7 @@ impl AgentSolve {
                                 None,
                                 &std::collections::BTreeMap::new(),
                                 None,
+                                None, // no pipeline on this recipe
                             )
                             .await
                             .ok()

--- a/core/continuum-core/src/commands/benchmark.rs
+++ b/core/continuum-core/src/commands/benchmark.rs
@@ -2001,6 +2001,7 @@ impl ActionCommand for BenchmarkDispatch {
             None,
             &run_params,
             self.executor().ok(),
+            None, // hard-rs recipes declare no pipeline; nothing acts here
         )
         .await?;
         // The round's standing rules, published as the run room's operating doctrine

--- a/core/continuum-core/src/commands/benchmark_import.rs
+++ b/core/continuum-core/src/commands/benchmark_import.rs
@@ -53,6 +53,9 @@ pub struct BenchmarkImportParams {
     /// authored round must offer exactly what dispatch offers. Default true.
     #[serde(default = "default_true")]
     pub skip_already_resolved: bool,
+    /// Board key for GYM cards (a gym has no per-task repo); SWE cards carry their own.
+    #[serde(default)]
+    pub repo: Option<String>,
     /// Cap on cards offered, applied AFTER the gate. `None`/0 = every card the selection
     /// drew. The gym suites do not sample (a suite IS its task list), so this is how a
     /// round takes the first N of `hard-rs` — dispatch's `limit`, kept.
@@ -85,6 +88,10 @@ pub struct ImportedCard {
     pub task_id: String,
     /// `"swe"` (a real-project instance) or `"gym"` (an eval-set task).
     pub kind: String,
+    /// The board key the card is created under: the SWE instance's own repo (a seeded
+    /// Verified round mixes repos — a round-wide repo was wrong for every card but one);
+    /// a gym task's repo is the import's `repo` param.
+    pub repo: String,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -102,7 +109,7 @@ pub struct BenchmarkImport;
 
 /// The row an authored pipeline fans out over. Pure, so the projection is testable
 /// without a dataset: the title's key is the task id (one parser, one writer).
-pub(crate) fn imported_from(pc: &PreparedCard) -> Result<ImportedCard, CommandError> {
+pub(crate) fn imported_from(pc: &PreparedCard, gym_repo: &str) -> Result<ImportedCard, CommandError> {
     let (_, task_id) = parse_card_title(&pc.title).ok_or_else(|| {
         CommandError::Internal(format!(
             "prepared card title is not a benchmark title: {:?} — the ONE writer and the ONE \
@@ -117,6 +124,10 @@ pub(crate) fn imported_from(pc: &PreparedCard) -> Result<ImportedCard, CommandEr
         kind: match pc.work {
             CardWork::Swe { .. } => "swe".to_string(),
             CardWork::Gym { .. } => "gym".to_string(),
+        },
+        repo: match &pc.work {
+            CardWork::Swe { instance } => instance.repo.clone(),
+            CardWork::Gym { .. } => gym_repo.to_string(),
         },
     })
 }
@@ -152,7 +163,7 @@ impl ActionCommand for BenchmarkImport {
         let mut cards = Vec::with_capacity(prepared.len());
         let mut skipped_already_resolved = Vec::new();
         for pc in &prepared {
-            let row = imported_from(pc)?;
+            let row = imported_from(pc, p.repo.as_deref().unwrap_or(""))?;
             if p.skip_already_resolved
                 && row.kind == "swe"
                 && crate::cognition::swe_bench::read_verdict(&row.task_id).is_some_and(|v| v.resolved)

--- a/core/continuum-core/src/commands/benchmark_import.rs
+++ b/core/continuum-core/src/commands/benchmark_import.rs
@@ -345,7 +345,7 @@ mod tests {
             setup_shell: None,
             work: CardWork::Swe { instance: Box::new(inst) },
         };
-        let row = imported_from(&pc).expect("a writer's title parses");
+        let row = imported_from(&pc, "").expect("a writer's title parses");
         assert_eq!(row.task_id, "demo__repo-1");
         assert_eq!(row.kind, "swe");
         assert!(row.title.starts_with("[bench swe-bench-verified] demo__repo-1:"));

--- a/core/continuum-core/src/commands/benchmark_round.rs
+++ b/core/continuum-core/src/commands/benchmark_round.rs
@@ -388,6 +388,7 @@ impl ActionCommand for BenchmarkRound {
                     None,
                     &std::collections::BTreeMap::new(),
                     None,
+                    None, // no pipeline on this recipe
                 )
                 .await
                 {

--- a/core/continuum-core/src/experience/recipes/benchmark-round.json
+++ b/core/continuum-core/src/experience/recipes/benchmark-round.json
@@ -223,7 +223,8 @@
       "params": {
         "room": "$room.name",
         "members": "$args.team"
-      }
+      },
+      "condition": "$args.team"
     },
     {
       "command": "chat/send",

--- a/core/continuum-core/src/experience/recipes/benchmark-round.json
+++ b/core/continuum-core/src/experience/recipes/benchmark-round.json
@@ -203,7 +203,7 @@
       "command": "work/create",
       "each": "$imported.cards",
       "params": {
-        "repo": "$args.repo",
+        "repo": "$item.repo",
         "room": "$room.id",
         "title": "$item.title",
         "body": "$item.body"

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -886,16 +886,38 @@ pub async fn spawn_activity_room(
                             "recipe": recipe,
                         }),
                     )];
-                    let receipt = crate::recipe::PipelineExecutor::new(exec)
+                    let receipt = match crate::recipe::PipelineExecutor::new(exec)
                         .run_with(&recipe_def.purpose, &recipe_def.pipeline, pipeline_args, seed)
                         .await
-                        .map_err(|e| {
-                            CommandError::Internal(format!(
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            // A FAILED BIRTH IS ARCHIVED, never left as a bound, empty room the
+                            // rail lists and the reconciler reseats (2026-09-12: three Rust rounds
+                            // and a seed-4 round born with zero cards, card 5f36ce37).
+                            let note = format!("birth failed: {e}");
+                            let standing = RoomStanding { archived: true, protected: false, note: Some(note.clone()) };
+                            match serde_json::to_string(&standing) { // boundary: the standing wall record — airc's wire + store
+                                Ok(body) => {
+                                    let _ = airc
+                                        .publish_wall_post_in(&room, STANDING_WALL_CATEGORY.to_string(), body, None)
+                                        .await;
+                                }
+                                Err(_) => {}
+                            }
+                            crate::probe!(
+                                class = "activity.birth_failed_archived",
+                                room = %room.channel,
+                                error = %e,
+                                "the recipe's pipeline failed after the room was bound — archived, not left half-born"
+                            );
+                            return Err(CommandError::Internal(format!(
                                 "room {} was created and bound, but its recipe's pipeline \
-                                 failed: {e}",
+                                 failed: {e} — the room is archived",
                                 room.channel
-                            ))
-                        })?;
+                            )));
+                        }
+                    };
                     Some(ActivityPipelineReceipt {
                         steps_run: receipt.steps_run,
                         steps_skipped: receipt.steps_skipped,

--- a/core/continuum-core/src/modules/activity.rs
+++ b/core/continuum-core/src/modules/activity.rs
@@ -355,6 +355,8 @@ impl ActionCommand for ActivitySpawn {
         p: ActivitySpawnParams,
     ) -> Result<ActivitySpawnResult, CommandError> {
         let airc = caller_airc(&self.registry, ctx)?;
+        // The pipeline acts as the same identity that joins the room — one resolver.
+        let caller = crate::persona::operator_peer::acting_caller(&self.registry, ctx, "activity verbs")?;
         // A BENCHMARK ACTIVITY ROOTS ITSELF THROUGH ITS RUN.
         //
         // We work activities, period — so this verb does not get to hand back a
@@ -393,6 +395,7 @@ impl ActionCommand for ActivitySpawn {
             p.parent,
             &p.params,
             self.executor_slot.get().cloned(),
+            Some(caller),
         )
         .await
     }
@@ -683,6 +686,9 @@ pub async fn spawn_activity_room(
     parent: Option<RoomId>,
     params: &std::collections::BTreeMap<String, serde_json::Value>,
     executor: Option<std::sync::Arc<crate::runtime::command_executor::CommandExecutor>>,
+    // The identity the pipeline's steps act as — the spawner's (`acting_caller`);
+    // `None` only for a recipe with no pipeline or a substrate-internal birth.
+    caller: Option<crate::routing::CallerIdentity>,
 ) -> Result<ActivitySpawnResult, CommandError> {
     let recipe_def = resolve_recipe(
         recipe,
@@ -887,6 +893,7 @@ pub async fn spawn_activity_room(
                         }),
                     )];
                     let receipt = match crate::recipe::PipelineExecutor::new(exec)
+                        .with_caller(caller.clone())
                         .run_with(&recipe_def.purpose, &recipe_def.pipeline, pipeline_args, seed)
                         .await
                     {

--- a/core/continuum-core/src/modules/work.rs
+++ b/core/continuum-core/src/modules/work.rs
@@ -1208,6 +1208,7 @@ pub(crate) async fn dispatch_staged_swe_solve(
                 Some(room),
                 &std::collections::BTreeMap::new(),
                 None,
+                None, // no pipeline on this recipe
             )
             .await
             {

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -303,7 +303,7 @@ pub fn acting(
         // ([`acting_caller`]) — is still the agent or the human with its own runtime,
         // never a stranger persona with none.
         let runtime = registry.get(peer).or_else(|| local_runtime_of(peer));
-        let kind = self_peer_kind(peer).unwrap_or(ActorKind::Persona);
+        let kind = self_peer_kind(peer).unwrap_or(ActorKind::Persona); // unwrap_or: not a self-peer = a citizen, by definition of the two self-peers
         return Ok(Acting { peer, kind, runtime });
     }
     if ctx.claimed_actor_kind.as_deref() == Some("agent") {

--- a/core/continuum-core/src/persona/operator_peer.rs
+++ b/core/continuum-core/src/persona/operator_peer.rs
@@ -299,7 +299,12 @@ pub fn acting(
         // A signed caller IS who it says it is — an identity even with no live runtime
         // here (a remote peer, a persona not hosted on this node).
         let peer = caller.peer_id.as_uuid();
-        return Ok(Acting { peer, kind: ActorKind::Persona, runtime: registry.get(peer) });
+        // A self-peer presenting itself — a birth's pipeline acting AS its spawner
+        // ([`acting_caller`]) — is still the agent or the human with its own runtime,
+        // never a stranger persona with none.
+        let runtime = registry.get(peer).or_else(|| local_runtime_of(peer));
+        let kind = self_peer_kind(peer).unwrap_or(ActorKind::Persona);
+        return Ok(Acting { peer, kind, runtime });
     }
     if ctx.claimed_actor_kind.as_deref() == Some("agent") {
         let rt = agent_runtime().ok_or_else(|| {
@@ -318,6 +323,36 @@ pub fn acting(
         ))
     })?;
     Ok(Acting { peer: rt.airc().peer_id().as_uuid(), kind: ActorKind::Human, runtime: Some(rt) })
+}
+
+/// The identity a verb's SUB-DISPATCHES act as — what a recipe's birth pipeline threads
+/// into every step so `work/create` in step 3 is the same peer that joined the room in
+/// step 0. A signed caller passes through unchanged (its trust is its own); an agent or
+/// operator session becomes its self-peer as a local caller, which [`acting`] resolves
+/// back to the same runtime. Measured 2026-09-13: a seeded round born by the CLI joined
+/// its room as the agent peer and posted its cards as the operator — "room … is not
+/// among the rooms this caller is in" — zero cards, a room bound and empty.
+pub fn acting_caller(
+    registry: &crate::persona::PersonaAircRuntimeRegistry,
+    ctx: &crate::sdk_codegen::Ctx,
+    family: &str,
+) -> Result<crate::routing::CallerIdentity, crate::sdk_codegen::CommandError> {
+    if let Some(caller) = ctx.caller.as_ref().filter(|c| !c.is_anonymous_socket()) {
+        return Ok(caller.clone());
+    }
+    let peer = acting(registry, ctx, family)?.peer;
+    Ok(crate::routing::CallerIdentity::local(crate::identity::PeerId::from_uuid(peer)))
+}
+
+/// Which self-peer a peer id is, if either.
+fn self_peer_kind(peer: uuid::Uuid) -> Option<ActorKind> {
+    if agent_runtime().is_some_and(|rt| rt.airc().peer_id().as_uuid() == peer) {
+        return Some(ActorKind::Agent);
+    }
+    if operator_runtime().is_some_and(|rt| rt.airc().peer_id().as_uuid() == peer) {
+        return Some(ActorKind::Human);
+    }
+    None
 }
 
 /// The runtime a verb ACTS THROUGH — [`acting`] with a live runtime demanded: a signed
@@ -406,4 +441,37 @@ pub fn operator_airc() -> Option<Arc<airc_lib::Airc>> {
 /// The operator's runtime (transcript/roster readers), when online.
 pub fn operator_runtime() -> Option<Arc<PersonaAircRuntime>> {
     OPERATOR.get().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // what this catches (2026-09-13): a birth's pipeline steps acting as a DIFFERENT
+    // identity than the spawner — the spawner joins the room, the steps post as
+    // someone not in it. A signed caller must pass through `acting_caller` as itself,
+    // and `acting` must read that same identity back (peer + kind) with no runtime
+    // needed — the shape every pipeline step sees.
+    #[test]
+    fn a_signed_caller_is_the_identity_a_birth_acts_as() {
+        let peer = uuid::Uuid::new_v4();
+        let ctx = crate::sdk_codegen::Ctx {
+            handle: None,
+            session_id: None,
+            user_id: None,
+            context_id: None,
+            caller: Some(crate::routing::CallerIdentity::local_persona(
+                crate::identity::PeerId::from_uuid(peer),
+            )),
+            claimed_actor_kind: None,
+        };
+        let registry = crate::persona::PersonaAircRuntimeRegistry::new();
+        let threaded = acting_caller(&registry, &ctx, "test").expect("a signed caller resolves");
+        assert_eq!(threaded.peer_id.as_uuid(), peer);
+        assert!(matches!(threaded.source, crate::routing::CallerSource::LocalPersona));
+        let step_ctx = crate::sdk_codegen::Ctx { caller: Some(threaded), ..ctx };
+        let a = acting(&registry, &step_ctx, "test").expect("the step acts as the same peer");
+        assert_eq!(a.peer, peer);
+        assert_eq!(a.kind, ActorKind::Persona);
+    }
 }

--- a/core/continuum-core/src/recipe/executor.rs
+++ b/core/continuum-core/src/recipe/executor.rs
@@ -35,11 +35,22 @@ pub struct RecipeRunReceipt {
 
 pub struct PipelineExecutor {
     executor: Arc<CommandExecutor>,
+    /// The identity every step acts as (`operator_peer::acting_caller`). `None` =
+    /// the substrate's own code — right for a bare `recipe/run`, wrong for a birth,
+    /// whose steps must be the spawner (2026-09-13: cards posted as the operator
+    /// into a room only the agent peer had joined).
+    caller: Option<crate::routing::CallerIdentity>,
 }
 
 impl PipelineExecutor {
     pub fn new(executor: Arc<CommandExecutor>) -> Self {
-        Self { executor }
+        Self { executor, caller: None }
+    }
+
+    /// Act as `caller` in every step.
+    pub fn with_caller(mut self, caller: Option<crate::routing::CallerIdentity>) -> Self {
+        self.caller = caller;
+        self
     }
 
     /// Walk `pipeline` under `name` (the recipe's purpose, for receipts and probes).
@@ -245,7 +256,8 @@ impl PipelineExecutor {
     async fn dispatch_step(&self, name: &str, idx: usize, step: &RecipeStep, params: Value) -> Result<Value, String> {
         let mut outcome: Result<Value, String> = Err("unattempted".into());
         for attempt in 0..=step.retry_count {
-            let dispatch = self.executor.execute(step.command.as_str(), params.clone());
+            let dispatch =
+                self.executor.execute_with_caller(step.command.as_str(), params.clone(), self.caller.clone());
             let result = match step.timeout_ms {
                 Some(ms) => {
                     match tokio::time::timeout(std::time::Duration::from_millis(ms), dispatch)

--- a/protocol/typescript/benchmark/BenchmarkImportParams.ts
+++ b/protocol/typescript/benchmark/BenchmarkImportParams.ts
@@ -23,6 +23,10 @@ sample?: number, seed?: number,
  */
 skipAlreadyResolved: boolean, 
 /**
+ * Board key for GYM cards (a gym has no per-task repo); SWE cards carry their own.
+ */
+repo: string | null, 
+/**
  * Cap on cards offered, applied AFTER the gate. `None`/0 = every card the selection
  * drew. The gym suites do not sample (a suite IS its task list), so this is how a
  * round takes the first N of `hard-rs` — dispatch's `limit`, kept.

--- a/protocol/typescript/benchmark/ImportedCard.ts
+++ b/protocol/typescript/benchmark/ImportedCard.ts
@@ -14,4 +14,10 @@ taskId: string,
 /**
  * `"swe"` (a real-project instance) or `"gym"` (an eval-set task).
  */
-kind: string, };
+kind: string, 
+/**
+ * The board key the card is created under: the SWE instance's own repo (a seeded
+ * Verified round mixes repos — a round-wide repo was wrong for every card but one);
+ * a gym task's repo is the import's `repo` param.
+ */
+repo: string, };


### PR DESCRIPTION
See the commit (card 5f36ce37). A seeded Verified round was born with zero cards (round-wide repo into every card); now each card carries its instance's repo and a failed birth archives the room instead of leaving it bound and empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo