### PR TITLE
fix(persona): no card in hand means the deck first — the pull runs before the act question

### DIFF
--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1343,20 +1343,15 @@ impl crate::persona::active_work_source::AircWorkReader for PersonaAircRuntime {
     /// hold only while the board's own card says so (`hold_of` = Held); the rest are
     /// history, not work.
     async fn active_claims(&self) -> Result<Vec<airc_lib::WorkCard>, AircError> {
-        let status = self
-            .airc
-            .work_roster_status(airc_lib::WorkRosterQuery::default())
-            .await?;
+        // THE BOARD IS THE TRUTH ABOUT WHO HOLDS WHAT. This read used to start from the
+        // work ROSTER (the scope's claim ledger) and intersect it with the board. The
+        // roster is rebuilt after a boot, so for the first seconds of a fresh runtime it
+        // listed nothing — 2026-09-13 08:40:50Z, 13 s after the core answered: Atlas's
+        // `persona.work.gate held=0` while the board showed her live claim on
+        // django-15467, so the pull took her a SECOND card (matplotlib-21568) while a
+        // teammate sat with none. The board carries owner, lease and claim id; nothing
+        // the roster adds is needed to know her held work.
         let me = self.airc.peer_id();
-        let claims = status
-            .rows
-            .into_iter()
-            .find(|r| r.peer == me)
-            .map(|r| r.active_claims)
-            .unwrap_or_default();
-        if claims.is_empty() {
-            return Ok(claims);
-        }
         let board = self
             .airc
             .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
@@ -1366,24 +1361,16 @@ impl crate::persona::active_work_source::AircWorkReader for PersonaAircRuntime {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0 — every lease then reads live, the conservative side
-        let (held, stale): (Vec<_>, Vec<_>) = claims.into_iter().partition(|claim| {
-            board.cards.iter().any(|card| {
-                card.card_id == claim.card_id
-                    && card.owner == Some(me)
+        Ok(board
+            .cards
+            .into_iter()
+            .filter(|card| {
+                card.owner == Some(me)
                     && crate::persona::card_holder::hold_of(card, now_ms)
                         == crate::persona::card_holder::Hold::Held
                     && !crate::persona::card_holder::claimable_now(card, now_ms)
             })
-        });
-        for claim in &stale {
-            crate::probe!(
-                class = "persona.claim.not_held_on_board",
-                card = %claim.card_id.as_uuid(),
-                "the roster lists a live claim the board does not honour (Open, lapsed, or \
-                 another owner) — not counted as held work"
-            );
-        }
-        Ok(held)
+            .collect())
     }
 }
 

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -857,18 +857,11 @@ impl PersonaAircRuntime {
                             }
                         }
                     }
-                    match hb_airc
-                        .work_roster_status(airc_lib::WorkRosterQuery::default())
-                        .await
-                    {
-                        Ok(status) => {
-                            let me = hb_airc.peer_id();
-                            let mine = status
-                                .rows
-                                .into_iter()
-                                .find(|r| r.peer == me)
-                                .map(|r| r.active_claims)
-                                .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0, as every other now_ms here
+                    // Renew what the BOARD says she holds (board_held_by) — the roster
+                    // reads empty right after a boot, and a lease not renewed in that
+                    // window lapses out from under her.
+                    match board_held_by(hb_airc.as_ref()).await {
+                        Ok(mine) => {
                             let mut renewed = 0usize;
                             let mut failed = 0usize;
                             for card in &mine {
@@ -1351,26 +1344,7 @@ impl crate::persona::active_work_source::AircWorkReader for PersonaAircRuntime {
         // django-15467, so the pull took her a SECOND card (matplotlib-21568) while a
         // teammate sat with none. The board carries owner, lease and claim id; nothing
         // the roster adds is needed to know her held work.
-        let me = self.airc.peer_id();
-        let board = self
-            .airc
-            .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
-            .await?
-            .snapshot();
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0 — every lease then reads live, the conservative side
-        Ok(board
-            .cards
-            .into_iter()
-            .filter(|card| {
-                card.owner == Some(me)
-                    && crate::persona::card_holder::hold_of(card, now_ms)
-                        == crate::persona::card_holder::Hold::Held
-                    && !crate::persona::card_holder::claimable_now(card, now_ms)
-            })
-            .collect())
+        board_held_by(self.airc.as_ref()).await
     }
 }
 
@@ -1551,6 +1525,32 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
             .filter(|c| crate::persona::card_holder::in_flight_now(c, now_ms))
             .count())
     }
+}
+
+/// The cards `airc`'s peer HOLDS right now, by the board alone: owner = her, lease live,
+/// not claimable. The one source for "her held work" — the pull's WIP=1 guard, the
+/// renewal loop, anything that asks. Never the work roster: it is rebuilt after a boot
+/// and reads empty for its first seconds (2026-09-13 08:40:50Z, a second pull).
+pub(crate) async fn board_held_by(airc: &Airc) -> Result<Vec<airc_lib::WorkCard>, AircError> {
+    let me = airc.peer_id();
+    let board = airc
+        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
+        .await?
+        .snapshot();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0 — every lease then reads live, the conservative side
+    Ok(board
+        .cards
+        .into_iter()
+        .filter(|card| {
+            card.owner == Some(me)
+                && crate::persona::card_holder::hold_of(card, now_ms)
+                    == crate::persona::card_holder::Hold::Held
+                && !crate::persona::card_holder::claimable_now(card, now_ms)
+        })
+        .collect())
 }
 
 impl Drop for PersonaAircRuntime {

--- a/core/continuum-core/src/persona/airc_runtime.rs
+++ b/core/continuum-core/src/persona/airc_runtime.rs
@@ -1532,25 +1532,35 @@ impl crate::persona::airc_citizen::AircCitizen for PersonaAircRuntime {
 /// renewal loop, anything that asks. Never the work roster: it is rebuilt after a boot
 /// and reads empty for its first seconds (2026-09-13 08:40:50Z, a second pull).
 pub(crate) async fn board_held_by(airc: &Airc) -> Result<Vec<airc_lib::WorkCard>, AircError> {
+    // EVERY ROOM SHE STANDS IN, never "the board". airc's `work_board_complete` folds
+    // the scope's CURRENT room only — right after a boot that is her home room, so a
+    // card held in a run room read as not held: 2026-09-13 09:29:01Z, 13 s after the
+    // core answered, Atlas's gate read held=0 against her live django claim and the
+    // pull took her matplotlib as a second card (the same shape the roster read had).
+    // The per-room projection is what the pull itself reads; held work folds the same.
     let me = airc.peer_id();
-    let board = airc
-        .work_board_complete(airc_lib::WORK_BOARD_PROJECTION_PAGE_SIZE)
-        .await?
-        .snapshot();
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or_default(); // unwrap_or: a pre-epoch clock reads 0 — every lease then reads live, the conservative side
-    Ok(board
-        .cards
-        .into_iter()
-        .filter(|card| {
+    let rooms: Vec<Uuid> = airc
+        .subscription_set()
+        .await?
+        .all()
+        .map(|sub| sub.as_room().channel.as_uuid())
+        .collect();
+    let mut held = Vec::new();
+    for room in rooms {
+        let board =
+            crate::persona::room_board_source::RoomBoardReader::work_board(airc, Some(room)).await?;
+        held.extend(board.cards.into_iter().filter(|card| {
             card.owner == Some(me)
                 && crate::persona::card_holder::hold_of(card, now_ms)
                     == crate::persona::card_holder::Hold::Held
                 && !crate::persona::card_holder::claimable_now(card, now_ms)
-        })
-        .collect())
+        }));
+    }
+    Ok(held)
 }
 
 impl Drop for PersonaAircRuntime {

--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2500,6 +2500,26 @@ async fn run_self_cycle(
     // concludes it (`PASS: done`) — the autonomous loop the architecture always
     // promised ("the heartbeat advances my thread, not just reacts to pokes").
     // Returns early so she never ALSO spends a musing turn the same tick.
+    // NO CARD IN HAND → THE DECK FIRST. The act question below lets an idle citizen
+    // muse (read, run, look around) and, when she does, this tick returns before the
+    // pull — so a citizen who always finds something to look at never takes a card.
+    // Measured 2026-09-13 08:41–09:20Z: Joaquin, holding nothing, acted in her home
+    // room every tick (code/shell, code/read) while a seed-4 card sat open for 40
+    // minutes; not one pull attempt. Held work keeps its order (a holder's tick is
+    // her work turn; she pulls review cards after it, below).
+    if focus_room.is_none() {
+        match try_pull_next_card(ctx, conversation).await {
+            PullOutcome::Pulled => {
+                crate::probe!(
+                    class = "persona.selftick.pulled_before_musing",
+                    persona = %ctx.identity.agent_name,
+                    "idle citizen took a card from the deck before the act question"
+                );
+                return true;
+            }
+            PullOutcome::DeferredWip | PullOutcome::Nothing => {}
+        }
+    }
     let work_room = focus_room.unwrap_or(ctx.identity.default_room); // unwrap_or: no held claim = home room
     if crate::persona::act_question::ask_the_act_question(
         ctx,


### PR DESCRIPTION
An idle citizen who always finds something to muse on never reached the pull (the act question ran first and ended the tick): Joaquin acted every tick for 40 min while a seed-4 card sat open. Now: no held card → try the deck first, then the act question. Stacked on #3991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo