### PR TITLE
fix(bench): an instance this box cannot grade is not offered as work again

### DIFF
--- a/core/continuum-core/src/cognition/swe_verdict_sweep.rs
+++ b/core/continuum-core/src/cognition/swe_verdict_sweep.rs
@@ -100,6 +100,25 @@ pub fn record_refusal(instance: &str, reason: &str, work_mtime_ms: Option<u64>) 
     }
 }
 
+/// Is this refusal about the ENVIRONMENT — the box cannot grade the instance at all
+/// (pristine-tree verdicts: PASS_TO_PASS 0/N, FAIL_TO_PASS passing or skipped before the
+/// patch; no runnable harness for the era; the repo will not install) — rather than about
+/// the WORK (no patch to grade)? An env refusal is deck hygiene: the instance is not
+/// offered on this box again until the env changes. A work refusal is the citizen's.
+pub fn refusal_is_env_fault(reason: &str) -> bool {
+    reason.starts_with("UNGRADEABLE — ")
+        || reason.contains("env has no runnable test harness")
+        || reason.contains("could not install")
+}
+
+/// The standing ENV refusal recorded for `instance` on this box, if any. Markers outlive
+/// the work-change TTL on purpose: an environment does not fix itself between rounds —
+/// clear the marker (or run `benchmark/validate`) when it does.
+pub fn standing_env_refusal(instance: &str) -> Option<String> {
+    let r = read_refusal(instance)?;
+    refusal_is_env_fault(&r.reason).then_some(r.reason)
+}
+
 pub fn clear_refusal(instance: &str) {
     let _ = std::fs::remove_file(refusal_path(instance));
 }
@@ -392,6 +411,19 @@ pub async fn sweep() -> SweepReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // what this catches (2026-09-13, seed-4): an instance this box cannot grade — pytest-7236
+    // (pristine PASS_TO_PASS 0/40), requests-1766 (era pytest cannot run here) — dispatched
+    // again the next round while its refusal marker stood; two of five cards burned hours
+    // on a wall. A WORK refusal (no patch) must not be mistaken for it.
+    #[test]
+    fn an_env_refusal_is_told_apart_from_a_work_refusal() {
+        assert!(refusal_is_env_fault("UNGRADEABLE — PASS_TO_PASS passes 0 of 40 on the PRISTINE tree: the suite does not run"));
+        assert!(refusal_is_env_fault("UNGRADEABLE — every FAIL_TO_PASS test already passes on the pristine tree ([\"a\"])"));
+        assert!(refusal_is_env_fault("psf__requests-1766's env has no runnable test harness: era-pinned pytest cannot execute"));
+        assert!(refusal_is_env_fault("could not install scikit-learn__scikit-learn-14983's repo into a venv — a cached broken env"));
+        assert!(!refusal_is_env_fault("no candidate patch to grade for matplotlib__matplotlib-21568 — the workspace holds no diff"));
+    }
 
     /// what this catches: the sweep manufacturing a score out of an absence or an ambiguity —
     /// the #384/#386 laundering class, which is why the grade tail existed at all. A worked

--- a/core/continuum-core/src/commands/benchmark_import.rs
+++ b/core/continuum-core/src/commands/benchmark_import.rs
@@ -103,6 +103,12 @@ pub struct BenchmarkImportResult {
     /// Instances drawn by the selection but NOT offered because a citizen already
     /// resolved them here — named, so the round's receipt can say why 3 drew and 1 posted.
     pub skipped_already_resolved: Vec<String>,
+    /// Instances drawn but NOT offered because THIS BOX cannot grade them: their env class
+    /// is proven red by `benchmark/validate`, or their own env refusal marker stands from
+    /// an earlier round. Each entry names the instance and the wall, so the round's
+    /// receipt says what the deck withheld and why (2026-09-13: two of five seed-4 cards
+    /// burned hours on pytest's pluggy and requests' 2013 pytest).
+    pub skipped_ungradeable: Vec<String>,
 }
 
 pub struct BenchmarkImport;
@@ -162,6 +168,7 @@ impl ActionCommand for BenchmarkImport {
         .await?;
         let mut cards = Vec::with_capacity(prepared.len());
         let mut skipped_already_resolved = Vec::new();
+        let mut skipped_ungradeable = Vec::new();
         for pc in &prepared {
             let row = imported_from(pc, p.repo.as_deref().unwrap_or(""))?;
             if p.skip_already_resolved
@@ -176,12 +183,30 @@ impl ActionCommand for BenchmarkImport {
                 skipped_already_resolved.push(row.task_id);
                 continue;
             }
+            // THE DECK NEVER OFFERS WHAT THIS BOX CANNOT GRADE — the same gate dispatch
+            // applies (known_red_wall), plus the instance's own standing env refusal.
+            if let CardWork::Swe { instance } = &pc.work {
+                let wall = crate::commands::benchmark::known_red_wall(spec.name, &instance.repo, instance.year())
+                    .map(|w| format!("env class {} {} proven red by benchmark/validate: {w}", instance.repo, instance.year()))
+                    .or_else(|| crate::cognition::swe_verdict_sweep::standing_env_refusal(&row.task_id)
+                        .map(|r| format!("env refusal stands from an earlier round: {r}")));
+                if let Some(wall) = wall {
+                    crate::probe!(
+                        class = "bench.round.ungradeable_withheld",
+                        instance = %row.task_id,
+                        wall = %wall,
+                        "an instance this box cannot grade is not offered as work"
+                    );
+                    skipped_ungradeable.push(format!("{}: {}", row.task_id, wall));
+                    continue;
+                }
+            }
             cards.push(row);
         }
         if let Some(n) = p.limit.filter(|n| *n > 0) {
             cards.truncate(n as usize);
         }
-        Ok(BenchmarkImportResult { suite: p.suite, cards, skipped_already_resolved })
+        Ok(BenchmarkImportResult { suite: p.suite, cards, skipped_already_resolved, skipped_ungradeable })
     }
 }
 

--- a/protocol/typescript/benchmark/BenchmarkImportResult.ts
+++ b/protocol/typescript/benchmark/BenchmarkImportResult.ts
@@ -6,4 +6,12 @@ export type BenchmarkImportResult = { suite: string, cards: Array<ImportedCard>,
  * Instances drawn by the selection but NOT offered because a citizen already
  * resolved them here — named, so the round's receipt can say why 3 drew and 1 posted.
  */
-skippedAlreadyResolved: Array<string>, };
+skippedAlreadyResolved: Array<string>, 
+/**
+ * Instances drawn but NOT offered because THIS BOX cannot grade them: their env class
+ * is proven red by `benchmark/validate`, or their own env refusal marker stands from
+ * an earlier round. Each entry names the instance and the wall, so the round's
+ * receipt says what the deck withheld and why (2026-09-13: two of five seed-4 cards
+ * burned hours on pytest's pluggy and requests' 2013 pytest).
+ */
+skippedUngradeable: Array<string>, };


### PR DESCRIPTION
Two of five seed-4 cards burned hours on env walls the box had already proven (pytest-7236 pluggy, requests-1766 era pytest). Import now withholds instances whose env class is proven red by benchmark/validate or whose own env refusal marker stands, naming each in `skipped_ungradeable`. Env vs work refusals are told apart (`refusal_is_env_fault`, tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo