### PR TITLE
fix(persona): no card in hand means the deck before ANY turn; the pull names every silent return

### DIFF
--- a/core/continuum-core/src/persona/service_loop.rs
+++ b/core/continuum-core/src/persona/service_loop.rs
@@ -2517,7 +2517,14 @@ async fn run_self_cycle(
                 );
                 return true;
             }
-            PullOutcome::DeferredWip | PullOutcome::Nothing => {}
+            outcome @ (PullOutcome::DeferredWip | PullOutcome::Nothing) => {
+                crate::probe!(
+                    class = "persona.selftick.deck_first",
+                    persona = %ctx.identity.agent_name,
+                    outcome = ?outcome,
+                    "idle citizen asked the deck first — nothing taken; on to the act question"
+                );
+            }
         }
     }
     let work_room = focus_room.unwrap_or(ctx.identity.default_room); // unwrap_or: no held claim = home room

--- a/core/continuum-core/src/persona/work_pull.rs
+++ b/core/continuum-core/src/persona/work_pull.rs
@@ -94,6 +94,14 @@ fn pull_probe_due(peer: Uuid) -> bool {
 
 pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn PersonaConversation) -> PullOutcome {
     let Some(citizen) = conversation.stream_citizen() else {
+        if pull_probe_due(ctx.identity.peer_id.as_uuid()) {
+            crate::probe!(
+                class = "bench.round.pull_none",
+                persona = %ctx.identity.agent_name,
+                reason = "no_citizen_stream",
+                "no pull: this conversation has no airc citizen to pull through"
+            );
+        }
         return PullOutcome::Nothing;
     };
     // WIP = 1, enforced HERE and not by call order: a citizen who already holds a
@@ -122,6 +130,7 @@ pub(crate) async fn try_pull_next_card(ctx: &HostedPersona, conversation: &dyn P
         let me = ctx.identity.peer_id.as_uuid();
         let last = LAST_PULL_MS.lock().unwrap_or_else(|e| e.into_inner()).get(&me).copied().unwrap_or(0); // unwrap_or: never pulled = 0
         if crate::modules::chat::now_ms().saturating_sub(last) < PULL_SETTLE_MS {
+            // Not probed: a pull two minutes ago is the normal case, not an absence.
             return PullOutcome::Nothing;
         }
     }


### PR DESCRIPTION
Two idle coders sat beside an open card for 35 min with no pull row of any kind: the pull's early returns and the deck-first arm's empty outcome were silent. Probes only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoTjvf5j3Ez13g6k8mRkFo